### PR TITLE
Fix Factory submission against policy

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -25,6 +25,8 @@ update_package() {
     # ignore those updates
     rm -f _service:*-test.changes
     cp .osc/*-test.changes .
+    # Factory policies want only multiple spec files (for now)
+    rm -f _multibuild
     for file in _service:*; do 
       mv -v $file `echo $file | sed -e 's,.*:,,'`
     done


### PR DESCRIPTION
As Factory does not allow annotating multiple spec files in a multibuild file, we remove it

Validation: https://build.opensuse.org/request/show/739026 :)