### PR TITLE
Add 'openqa-incompletes-stats' to readout recent incomplete jobs sorted by label

### DIFF
--- a/openqa-incompletes-stats
+++ b/openqa-incompletes-stats
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+host="${host:-"openqa.opensuse.org"}"
+ssh_host="${ssh_host:-"$host"}"
+scheme="${scheme:-"https"}"
+interval="${interval:-"24 hour"}"
+failed_since="${failed_since:-"(NOW() - interval '$interval')"}"
+width="${width:-80}"
+threshold="${threshold:-5}"
+query="${query:-"select left(text, $width), count(text) from jobs, comments where (result='incomplete' and t_finished >= $failed_since and jobs.id in (select job_id from comments where id is not null)) and jobs.id = job_id group by text having count(text) > $threshold order by count(text) desc;"}"
+ssh "$ssh_host" "cd /tmp; sudo -u geekotest psql --command=\"$query\" openqa"


### PR DESCRIPTION
Use like `env interval='96 hour' ./openqa-incompletes-stats`