### PR TITLE
openqa-label-known-issues: Match for tickets before non-ticket labels

### DIFF
--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -26,7 +26,7 @@ label_on_issue() {
 main() {
     [ "$dry_run" = "1" ] && client_prefix="echo"
     client_call="${client_call:-"$client_prefix openqa-client --host $host_url"}"
-    issues=$($client_prefix curl -s "$issue_query" | $client_prefix jq -r '.issues | .[] | (.id,.subject)')
+    issues=$(curl -s "$issue_query" | jq -r '.issues | .[] | (.id,.subject)')
     for i in $(cat - | sed 's/ .*$//'); do
         id="${i##*/}"
         out=$(mktemp)

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -70,32 +70,6 @@ main() {
             # triggering a restart on jobs that already have a clone does not have an effect
             $client_call jobs/"$id"/restart post
 
-        elif label_on_issue "$id" 'Migrate to file failed, it has been running for more than' 'poo#59858 migrate failed, took too long' 1; then :
-        elif label_on_issue "$id" 'Could not open backing file.*: No such file or directory' 'poo#46742 premature deletion of files from cache' 1; then :
-        elif label_on_issue "$id" 'Unexpected end of data 0' 'poo#59926 test incompletes just in the middle of execution with Unexpected end of data 0' 1; then :
-        elif label_on_issue "$id" 'Asset was already requested by another job' 'poo#60140 job incompletes failing on initial asset download with "Asset was already requested by another job"' 1; then :
-        elif label_on_issue "$id" 'needledir not found: .*null' 'poo#59330 openqa-clone-custom-git-refspec fails setting NEEDLES_DIR=null with new os-autoinst or openQA'; then :
-        elif label_on_issue "$id" 'The console .sut. is not responding (half-open socket?)' 'poo#60161 test incompletes in t20_teaming_ab_all_link'; then :
-        elif label_on_issue "$id" 'Download .* failed with: 521 - Connect timeout' 'poo#60167 jobs incomplete trying to download from cache, potentially worker specific' 1; then :
-        elif label_on_issue "$id" 'qemu-img: Could not open ..: The .file. block driver requires a file name' 'poo#60170 job incompletes trying to load empty value ISO_1'; then :
-        elif label_on_issue "$id" 'Result: done' 'poo#43631 Job ending up incomplete but everything else looks fine' 1; then :
-        elif label_on_issue "$id" 'svirt serial: unable to read: transport read (error code: -43)' 'poo#60416 The console .* is not responding (half-open socket?)", very big log files with repetition of "svirt serial: unable to read: transport read (error code: -43)"'; then :
-        # could create an issue automatically with
-        # $client_prefix curl -s -H "Content-Type: application/json" -X POST -H "X-Redmine-API-Key: $(sed -n 's/redmine-token = //p' ~/.query_redminerc)" --data '{"issue": {"project_id": 36, "category_id": 152, priority_id: 5, "subject": "test from command line"}}' https://progress.opensuse.org/issues.json
-        # but we should check if the issue already exists, e.g. same
-        # subject line
-        elif label_on_issue "$id" 'Download of .* failed with: 404' 'label:non_existing asset, candidate for removal'; then
-            echo "$i : Non-existing asset referenced, potential candidate for removal and/or ticket"
-        elif label_on_issue "$id" 'File .*\.yaml.* does not exist at .*scheduler.pm' 'label:missing_schedule_file'; then :
-        elif label_on_issue "$id" 'Compilation failed in require at .*isotovideo line 28.' 'label:schedule_compilation_error'; then :
-        elif label_on_issue "$id" 'qemu-img: Could not open .*: No such file or directory' 'label:missing_asset'; then :
-        elif label_on_issue "$id" 'Result: setup failure' 'label:setup_failure, probably wrong settings or missing asset'; then :
-        elif label_on_issue "$id" 'fatal: Remote branch .* not found' 'label:remote_branch_not_found, probably wrong custom git URL specified with branch'; then :
-        elif label_on_issue "$id" 'fatal: repository not found' 'label:remote_repo_not_found, probably wrong custom git URL specified'; then :
-        elif label_on_issue "$id" 'SOL payload already de-activated' 'poo#60437 Failed trying to deactivate ipmi SOL'; then :
-        elif label_on_issue "$id" 'Can.* undefined value as a symbol reference at .*serial_screen.pm' 'poo#60416 unable to read svirt serial'; then :
-        elif label_on_issue "$id" '(?s)Cloning git URL.*to use as test distribution.*(No scripts in|needledir not found)' 'label:remote_repo_invalid, probably wrong custom git URL specified'; then :
-        elif label_on_issue "$id" '(?s)Cloning git URL.*to use as test distribution.*(SCHEDULE.*not set)' 'label:remote_repo_schedule_not_found, probably wrong custom git URL + PRODUCTDIR specified'; then :
         # Idea: query progress.o.o for all subjects with '"' included as search terms and
         # crosscheck logfile with these issues
         # it is possible to search for issues with a subject search term, e.g.:
@@ -108,6 +82,34 @@ main() {
         elif echo "$issues" | (while read -r issue; do
             read -r subject
             after=${subject#*\"} && search=${after%\"*} && [[ ${#search} -ge $min_search_term ]] && label_on_issue "$id" "$search" "poo#$issue $subject" && break; done); then :
+        elif label_on_issue "$id" 'Migrate to file failed, it has been running for more than' 'poo#59858 migrate failed, took too long' 1; then :
+        elif label_on_issue "$id" 'Could not open backing file.*: No such file or directory' 'poo#46742 premature deletion of files from cache' 1; then :
+        elif label_on_issue "$id" 'Unexpected end of data 0' 'poo#59926 test incompletes just in the middle of execution with Unexpected end of data 0' 1; then :
+        elif label_on_issue "$id" 'Asset was already requested by another job' 'poo#60140 job incompletes failing on initial asset download with "Asset was already requested by another job"' 1; then :
+        elif label_on_issue "$id" 'needledir not found: .*null' 'poo#59330 openqa-clone-custom-git-refspec fails setting NEEDLES_DIR=null with new os-autoinst or openQA'; then :
+        elif label_on_issue "$id" 'The console .sut. is not responding (half-open socket?)' 'poo#60161 test incompletes in t20_teaming_ab_all_link'; then :
+        elif label_on_issue "$id" 'Download .* failed with: 521 - Connect timeout' 'poo#60167 jobs incomplete trying to download from cache, potentially worker specific' 1; then :
+        elif label_on_issue "$id" 'qemu-img: Could not open ..: The .file. block driver requires a file name' 'poo#60170 job incompletes trying to load empty value ISO_1'; then :
+        elif label_on_issue "$id" 'Result: done' 'poo#43631 Job ending up incomplete but everything else looks fine' 1; then :
+        elif label_on_issue "$id" 'svirt serial: unable to read: transport read (error code: -43)' 'poo#60416 The console .* is not responding (half-open socket?)", very big log files with repetition of "svirt serial: unable to read: transport read (error code: -43)"'; then :
+        elif label_on_issue "$id" 'SOL payload already de-activated' 'poo#60437 Failed trying to deactivate ipmi SOL'; then :
+        elif label_on_issue "$id" 'Can.* undefined value as a symbol reference at .*serial_screen.pm' 'poo#60416 unable to read svirt serial'; then :
+
+        ## Issues without tickets, e.g. potential singular, manual debug jobs,
+        # wrong user settings, etc.
+        # could create an issue automatically with
+        # $client_prefix curl -s -H "Content-Type: application/json" -X POST -H "X-Redmine-API-Key: $(sed -n 's/redmine-token = //p' ~/.query_redminerc)" --data '{"issue": {"project_id": 36, "category_id": 152, priority_id: 5, "subject": "test from command line"}}' https://progress.opensuse.org/issues.json
+        # but we should check if the issue already exists, e.g. same
+        # subject line
+        elif label_on_issue "$id" 'Download of .* failed with: 404' 'label:non_existing asset, candidate for removal'; then :
+        elif label_on_issue "$id" 'File .*\.yaml.* does not exist at .*scheduler.pm' 'label:missing_schedule_file'; then :
+        elif label_on_issue "$id" 'Compilation failed in require at .*isotovideo line 28.' 'label:schedule_compilation_error'; then :
+        elif label_on_issue "$id" 'qemu-img: Could not open .*: No such file or directory' 'label:missing_asset'; then :
+        elif label_on_issue "$id" 'Result: setup failure' 'label:setup_failure, probably wrong settings or missing asset'; then :
+        elif label_on_issue "$id" 'fatal: Remote branch .* not found' 'label:remote_branch_not_found, probably wrong custom git URL specified with branch'; then :
+        elif label_on_issue "$id" 'fatal: repository not found' 'label:remote_repo_not_found, probably wrong custom git URL specified'; then :
+        elif label_on_issue "$id" '(?s)Cloning git URL.*to use as test distribution.*(No scripts in|needledir not found)' 'label:remote_repo_invalid, probably wrong custom git URL specified'; then :
+        elif label_on_issue "$id" '(?s)Cloning git URL.*to use as test distribution.*(SCHEDULE.*not set)' 'label:remote_repo_schedule_not_found, probably wrong custom git URL + PRODUCTDIR specified'; then :
         else
             echoerr "$i : Unknown issue, to be reviewed -> $i/file/autoinst-log.txt"
             echoerr -e "Likely the error is within this log excerpt, last lines before shutdown:\n---"


### PR DESCRIPTION
Looking for issues from the redmine query first, then for all ticket references
and only then for non-ticket labels to be able to cover more in tickets where
followup is easier. The labels, e.g. "label:setup_failure" should then be used
as last-resort.