### PR TITLE
Add openqa-investigate, helper for bisecting test/product/infra regressions

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -40,7 +40,7 @@ investigate() {
     # have more, ambiguous potential changes that we need to bisect on
 
     # for 1. current job/build + current test -> check if reproducible/sporadic
-    clone "$id" 'retry'
+    clone "$id" 'retry' "${@:2}"
 
     job_url="$host_url/tests/$id"
     investigation=$(curl -s "$job_url"/investigation)
@@ -65,7 +65,7 @@ investigate() {
         #refspec_arg="TEST_GIT_REFSPEC=$last_good_tests"
         repo="${repo:-"https://github.com/os-autoinst/os-autoinst-distri-opensuse.git"}"
         refspec_arg="CASEDIR=$repo#$last_good_tests"
-        clone "$id" "last_good_tests:$last_good_tests" "$refspec_arg"
+        clone "$id" "last_good_tests:$last_good_tests" "$refspec_arg" "${@:2}"
     fi
 
     # 3. last good job/build + current test -> check for product regression
@@ -78,7 +78,7 @@ investigate() {
         # here we clone with unspecified test refspec, i.e. this could be a
         # more recent tests version. As an alternative we could explicitly
         # checkout the git version from "first bad"
-        clone "$last_good" "last_good_build:$last_good_build"
+        clone "$last_good" "last_good_build:$last_good_build" "${@:2}"
     fi
 
     # 4. last good job/build + last good test -> check for other problem
@@ -88,7 +88,7 @@ investigate() {
     elif [[ -z $last_good_build ]]; then
         echo "No product regression expected. Not triggered 'good build+test' as it would be the same as 2., current build + good test"
     else
-        clone "$last_good" "last_good_tests_and_build:$last_good_tests+$last_good_build" "$refspec_arg"
+        clone "$last_good" "last_good_tests_and_build:$last_good_tests+$last_good_build" "$refspec_arg" "${@:2}"
     fi
 }
 
@@ -99,8 +99,8 @@ main() {
     clone_call="${clone_call:-"$client_prefix openqa-clone-job --skip-chained-deps --within-instance"}"
     # shellcheck disable=SC2013
     for i in $(cat - | sed 's/ .*$//'); do
-        investigate "$i"
+        investigate "$i" "$@"
     done
 }
 
-main
+main "$@"

--- a/openqa-investigate
+++ b/openqa-investigate
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+
+host="${host:-"openqa.opensuse.org"}"
+scheme="${scheme:-"https"}"
+host_url="$scheme://$host"
+dry_run="${dry_run:-"0"}"
+prio_add="${prio_add:-"100"}"
+client_args="--json-output --host $host_url"
+echoerr() { echo "$@" >&2; }
+
+
+clone() {
+    id="${1:?"Need 'job_id'"}"
+    name_suffix="${2+":$2"}"
+    # shellcheck disable=SC2086
+    job_data=$(openqa-client $client_args jobs/"$id")
+    name=$(echo "$job_data" | jq -r '.job.test')
+    base_prio=$(echo "$job_data" | jq -r '.job.priority')
+    out=$($clone_call "$host_url/tests/$id" TEST="$name:investigate$name_suffix" _GROUP_ID=0 BUILD= "${@:3}")
+    echo "$out"
+    clone_id=${out/:*/}; clone_id=${clone_id/*#/}
+    $client_call jobs/"$clone_id" put --json-data "{\"priority\": $((base_prio + prio_add))}"
+}
+
+# crosscheck
+# 1. current job/build + current test -> check if reproducible/sporadic
+# 2. current job/build + last good test (+ last good needles) -> check for
+#    test (+needles) regression
+# 3. last good job/build + current test -> check for product regression
+# 4. last good job/build + last good test -> check for other problem
+#    sources, e.g. infrastructure
+investigate() {
+    id="${1##*/}"
+
+    # Optionally we can find "first failed", could extend openQA investigation
+    # method instead for we are just working based on supplied job which can
+    # have more, ambiguous potential changes that we need to bisect on
+
+    # for 1. current job/build + current test -> check if reproducible/sporadic
+    clone "$id" 'retry'
+
+    job_url="$host_url/tests/$id"
+    investigation=$(curl -s "$job_url"/investigation)
+    last_good=$(echo "$investigation" | jq -r '.last_good')
+
+    # for 2. current job/build + last good test (+ last good needles) ->
+    #   check for test (+needles) regression
+    test_log=$(echo "$investigation" | jq -r '.test_log')
+    if echo "$test_log" | grep -q "No.*changes recorded"; then
+        echo "$test_log. Skipping test regression investigation job."
+        last_good_tests=''
+    else
+        vars_last_good=$(curl -s "$host_url/tests/$last_good"/file/vars.json)
+        last_good_tests=$(echo "$vars_last_good" | jq -r '.TEST_GIT_HASH')
+        # here we could apply the same approach for needles, not only tests
+        # With https://github.com/os-autoinst/os-autoinst/pull/1358 we could
+        # theoretically use TEST_GIT_REFSPEC but this would act on the shared
+        # test case dir within either the common openQA folder or the common
+        # worker cache and hence influence other tests.
+        # So better we use CASEDIR with a git refspec, only slightly less
+        # efficient and also needing to know which git repo to use
+        #refspec_arg="TEST_GIT_REFSPEC=$last_good_tests"
+        repo="${repo:-"https://github.com/os-autoinst/os-autoinst-distri-opensuse.git"}"
+        refspec_arg="CASEDIR=$repo#$last_good_tests"
+        clone "$id" "last_good_tests:$last_good_tests" "$refspec_arg"
+    fi
+
+    # 3. last good job/build + current test -> check for product regression
+    if ! echo "$investigation" | grep -q '\<BUILD\>'; then
+        echo "Current job has same build as last good, product regression unlikely. Skipping product regression investigation job."
+        last_good_build=''
+    else
+        vars_last_good=${vars_last_good:-$(curl -s "$host_url/tests/$last_good"/file/vars.json)}
+        last_good_build=$(echo "$vars_last_good" | jq -r '.BUILD')
+        # here we clone with unspecified test refspec, i.e. this could be a
+        # more recent tests version. As an alternative we could explicitly
+        # checkout the git version from "first bad"
+        clone "$last_good" "last_good_build:$last_good_build"
+    fi
+
+    # 4. last good job/build + last good test -> check for other problem
+    #    sources, e.g. infrastructure
+    if [[ -z $last_good_tests ]]; then
+        echo "No test regression expected. Not triggered 'good build+test' as it would be the same as 3., good build + current test"
+    elif [[ -z $last_good_build ]]; then
+        echo "No product regression expected. Not triggered 'good build+test' as it would be the same as 2., current build + good test"
+    else
+        clone "$last_good" "last_good_tests_and_build:$last_good_tests+$last_good_build" "$refspec_arg"
+    fi
+}
+
+main() {
+    client_prefix=''
+    [ "$dry_run" = "1" ] && client_prefix="echo"
+    client_call="${client_call:-"$client_prefix openqa-client $client_args"}"
+    clone_call="${clone_call:-"$client_prefix openqa-clone-job --skip-chained-deps --within-instance"}"
+    # shellcheck disable=SC2013
+    for i in $(cat - | sed 's/ .*$//'); do
+        investigate "$i"
+    done
+}
+
+main


### PR DESCRIPTION
Following
https://progress.opensuse.org/projects/openqav3/wiki#Further-decision-steps-working-on-test-issues
and
https://progress.opensuse.org/projects/openqatests/wiki#Structured-test-issue-investigation
the helper "openqa-investigate" triggers openQA tests for investigation
to allow the test reviewers to more easily bisect and find out most
likely failure reasons. If called openqa-investigate will trigger clones
outside the job groups with different name and build identifier to not
pollute any production validation tests. The output will be forwarded
output of openqa-clone-job with multiple jobs that can help to bisect
based on the combination of results.

The script has a dry-run mode for trying out commands without actually
triggering them.

Example run:

```
okurz@linux-28d6:~ 0 (master) $ echo https://openqa.opensuse.org/tests/1200993 | env dry_run=1 local/os-autoinst/scripts/openqa-investigate WORKER_CLASS=openqaworker4
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/1200993 TEST=docker_image:investigate:retry _GROUP_ID=0 BUILD= WORKER_CLASS=openqaworker4
openqa-client --json-output --host https://openqa.opensuse.org jobs/openqa-clone-job --skip-chained-deps --within-instance https put --json-data {"priority": 150}
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/1200993 TEST=docker_image:investigate:last_good_tests:f08b91c97dc831910c194cbbcea28d968303f576 _GROUP_ID=0 BUILD= TEST_GIT_REFSPEC=f08b91c97dc831910c194cbbcea28d968303f576
openqa-client --json-output --host https://openqa.opensuse.org jobs/openqa-clone-job --skip-chained-deps --within-instance https put --json-data {"priority": 150}
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/1190969 TEST=docker_image:investigate:last_good_build:112.2 _GROUP_ID=0 BUILD=
openqa-client --json-output --host https://openqa.opensuse.org jobs/openqa-clone-job --skip-chained-deps --within-instance https put --json-data {"priority": 150}
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/1190969 TEST=docker_image:investigate:last_good_tests_and_build:f08b91c97dc831910c194cbbcea28d968303f576+112.2 _GROUP_ID=0 BUILD= TEST_GIT_REFSPEC=f08b91c97dc831910c194cbbcea28d968303f576
openqa-client --json-output --host https://openqa.opensuse.org jobs/openqa-clone-job --skip-chained-deps --within-instance https put --json-data {"priority": 150}
okurz@linux-28d6:~ 0 (master) $ echo https://openqa.opensuse.org/tests/1200993 | local/os-autoinst/scripts/openqa-investigate
Created job #1201078: opensuse-15.2-DVD-aarch64-Build124.2-docker_image@aarch64 -> https://openqa.opensuse.org/t1201078
{
   "job_id" : 1201078
}
Created job #1201079: opensuse-15.2-DVD-aarch64-Build124.2-docker_image@aarch64 -> https://openqa.opensuse.org/t1201079
{
   "job_id" : 1201079
}
Created job #1201080: opensuse-15.2-DVD-aarch64-Build112.2-docker_image@aarch64 -> https://openqa.opensuse.org/t1201080
{
   "job_id" : 1201080
}
Created job #1201081: opensuse-15.2-DVD-aarch64-Build112.2-docker_image@aarch64 -> https://openqa.opensuse.org/t1201081
{
   "job_id" : 1201081
}
```

* https://openqa.opensuse.org/t1201078
* https://openqa.opensuse.org/t1201079
* https://openqa.opensuse.org/t1201080
* https://openqa.opensuse.org/t1201081

or, using CASEDIR instead of TEST_GIT_REFSPEC

```
okurz@linux-28d6:~ 0 (master) $ echo https://openqa.opensuse.org/tests/1200993 | env dry_run=1 local/os-autoinst/scripts/openqa-investigate WORKER_CLASS=openqaworker4
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/1200993 TEST=docker_image:investigate:retry _GROUP_ID=0 BUILD= WORKER_CLASS=openqaworker4
openqa-client --json-output --host https://openqa.opensuse.org jobs/openqa-clone-job --skip-chained-deps --within-instance https put --json-data {"priority": 150}
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/1200993 TEST=docker_image:investigate:last_good_tests:f08b91c97dc831910c194cbbcea28d968303f576 _GROUP_ID=0 BUILD= CASEDIR=https://github.com/os-autoinst/os-autoinst-distri-opensuse//tree/f08b91c97dc831910c194cbbcea28d968303f576
openqa-client --json-output --host https://openqa.opensuse.org jobs/openqa-clone-job --skip-chained-deps --within-instance https put --json-data {"priority": 150}
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/1190969 TEST=docker_image:investigate:last_good_build:112.2 _GROUP_ID=0 BUILD=
openqa-client --json-output --host https://openqa.opensuse.org jobs/openqa-clone-job --skip-chained-deps --within-instance https put --json-data {"priority": 150}
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/1190969 TEST=docker_image:investigate:last_good_tests_and_build:f08b91c97dc831910c194cbbcea28d968303f576+112.2 _GROUP_ID=0 BUILD= CASEDIR=https://github.com/os-autoinst/os-autoinst-distri-opensuse//tree/f08b91c97dc831910c194cbbcea28d968303f576
openqa-client --json-output --host https://openqa.opensuse.org jobs/openqa-clone-job --skip-chained-deps --within-instance https put --json-data {"priority": 150}
okurz@linux-28d6:~ 0 (master) $ echo https://openqa.opensuse.org/tests/1200993 | local/os-autoinst/scripts/openqa-investigate
Created job #1201073: opensuse-15.2-DVD-aarch64-Build124.2-docker_image@aarch64 -> https://openqa.opensuse.org/t1201073
{
   "job_id" : 1201073
}
Created job #1201074: opensuse-15.2-DVD-aarch64-Build124.2-docker_image@aarch64 -> https://openqa.opensuse.org/t1201074
{
   "job_id" : 1201074
}
Created job #1201075: opensuse-15.2-DVD-aarch64-Build112.2-docker_image@aarch64 -> https://openqa.opensuse.org/t1201075
{
   "job_id" : 1201075
}
Created job #1201076: opensuse-15.2-DVD-aarch64-Build112.2-docker_image@aarch64 -> https://openqa.opensuse.org/t1201076
{
   "job_id" : 1201076
}
```

* https://openqa.opensuse.org/t1201073
* https://openqa.opensuse.org/t1201074
* https://openqa.opensuse.org/t1201075
* https://openqa.opensuse.org/t1201076

Note: For …_GIT_REFSPEC to work the working copy of tests/needles needs to be writable for the worker, e.g. a worker with the openQA caching feature for tests enabled. For example https://openqa.opensuse.org/tests/1201079# failed to checkout the git refspec as assets are cached but not tests on aarch64.o.o

Related progress issue: https://progress.opensuse.org/issues/19720