### PR TITLE
openqa-label-known-issues: Use combined reason+autoinst-log to detect more issues

### DIFF
--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -145,16 +145,23 @@ handle_unknown() {
 investigate_issue() {
     local id="${1##*/}"
     local out
+    local reason
+    local curl
     # reason specified with insufficient length
     # we could accept sufficient length of reason as explanation enough not
     # needing any comment but then we should distinguish between real
     # user-errors or infrastructure related ones that we need to care about
-    out="$(openqa-client --json-output --host "$host_url" jobs/"$id" | jq -r '.job.reason')"
-    if [ -n "$out" ] && [ ${#out} -lt "$reason_min_length" ]; then
+    reason="$(openqa-client --json-output --host "$host_url" jobs/"$id" | jq -r '.job.reason')"
+    if [ -n "$reason" ] && [ ${#reason} -lt "$reason_min_length" ]; then
         $client_call jobs/"$id"/comments post text="poo#63718 incomplete reason with just 'quit' could provide more information"
     fi
     out=$(mktemp)
-    if [[ "$(curl -s -w "%{http_code}" "$i/file/autoinst-log.txt" -o "$out")" != "200" ]]; then
+    curl=$(curl -s -w "%{http_code}" "$i/file/autoinst-log.txt" -o "$out")
+    # combine both the reason and autoinst-log.txt to check known issues
+    # against even in case when autoinst-log.txt is missing the details, e.g.
+    # see https://progress.opensuse.org/issues/69178
+    echo "$reason" >> "$out"
+    if [[ "$curl" != "200" ]]; then
         # if we can not even access the page it is something more critical
         handle_unreachable_or_no_log "$id" "$i" "$out"
     elif label_on_issues_from_issue_tracker "$id"; then return


### PR DESCRIPTION
There can be some search terms which are found only in reason and not in
autoinst-log.txt, sometimes in worker-log.txt which we do not parse so
far. Concatenating the reason into the downloaded log content allows us
to also look for search terms matching the reason string. This for
example is now used for https://progress.opensuse.org/issues/64776 with
the reason
`setup failure: Cache service status error: Premature
connection close`
which is not in autoinst-log.txt .

Related progress issue: https://progress.opensuse.org/issues/69178