### PR TITLE
openqa-incomplete-stats: Propose a default threshold of 0

### DIFF
--- a/openqa-incompletes-stats
+++ b/openqa-incompletes-stats
@@ -5,7 +5,7 @@ scheme="${scheme:-"https"}"
 interval="${interval:-"24 hour"}"
 failed_since="${failed_since:-"(NOW() - interval '$interval')"}"
 width="${width:-80}"
-threshold="${threshold:-5}"
+threshold="${threshold:-0}"
 query="${query:-"select left(text, $width), count(text) from jobs, comments where (result='incomplete' and t_finished >= $failed_since and jobs.id in (select job_id from comments where id is not null)) and jobs.id = job_id group by text having count(text) > $threshold order by count(text) desc;"}"
 # shellcheck disable=SC2029
 ssh "$ssh_host" "cd /tmp; sudo -u geekotest psql --command=\"$query\" openqa"


### PR DESCRIPTION
Due to our numbers of incompletes being so low recently we should output
the complete list by default but keep the option to limit.