### PR TITLE
openqa-label-known-issues: Simplify by deleting obsolete ticket references

### DIFF
--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -100,24 +100,6 @@ label_on_issues_from_issue_tracker() {
         after=${subject#*\"} && search=${after%\"*} && [[ ${#search} -ge $min_search_term ]] && label_on_issue "$id" "$search" "poo#$issue $subject" "${after//*\":retry*/1}" && break; done)
 }
 
-label_on_issues_with_tickets() {
-    if label_on_issue "$id" 'Migrate to file failed, it has been running for more than' 'poo#59858 migrate failed, took too long' 1; then return
-    elif label_on_issue "$id" 'Could not open backing file.*: No such file or directory' 'poo#46742 premature deletion of files from cache' 1; then return
-    elif label_on_issue "$id" 'Unexpected end of data 0' 'poo#59926 test incompletes just in the middle of execution with Unexpected end of data 0' 1; then return
-    elif label_on_issue "$id" 'Asset was already requested by another job' 'poo#60140 job incompletes failing on initial asset download with "Asset was already requested by another job"' 1; then return
-    elif label_on_issue "$id" 'needledir not found: .*null' 'poo#59330 openqa-clone-custom-git-refspec fails setting NEEDLES_DIR=null with new os-autoinst or openQA'; then return
-    elif label_on_issue "$id" 'The console .sut. is not responding (half-open socket?)' 'poo#60161 test incompletes in t20_teaming_ab_all_link'; then return
-    elif label_on_issue "$id" 'Download .* failed with: 521 - Connect timeout' 'poo#60167 jobs incomplete trying to download from cache, potentially worker specific' 1; then return
-    elif label_on_issue "$id" 'qemu-img: Could not open ..: The .file. block driver requires a file name' 'poo#60170 job incompletes trying to load empty value ISO_1'; then return
-    elif label_on_issue "$id" 'Result: done' 'poo#43631 Job ending up incomplete but everything else looks fine' 1; then return
-    elif label_on_issue "$id" 'svirt serial: unable to read: transport read (error code: -43)' 'poo#60416 The console .* is not responding (half-open socket?)", very big log files with repetition of "svirt serial: unable to read: transport read (error code: -43)"'; then return
-    elif label_on_issue "$id" 'SOL payload already de-activated' 'poo#60437 Failed trying to deactivate ipmi SOL'; then return
-    elif label_on_issue "$id" 'Can.* undefined value as a symbol reference at .*serial_screen.pm' 'poo#60416 unable to read svirt serial'; then return
-    elif label_on_issue "$id" '' 'poo#62420 Improve reporting on incompletes with result "setup-failure" and no further explanation' 1 "grep -q 'setup failure' $out && [ $(wc -l < "$out") -lt 8 ]"; then return
-    fi
-    false
-}
-
 label_on_issues_without_tickets() {
     if label_on_issue "$id" '(?s)([dD]ownload.*failed.*404).*Result: setup failure' 'label:non_existing asset, candidate for removal or wrong settings'; then return
     elif label_on_issue "$id" 'File .*\.yaml.* does not exist at .*scheduler.pm' 'label:missing_schedule_file'; then return
@@ -158,7 +140,6 @@ investigate_issue() {
         # if we can not even access the page it is something more critical
         handle_unreachable_or_no_log "$id" "$i" "$out"
     elif label_on_issues_from_issue_tracker "$id"; then return
-    elif label_on_issues_with_tickets "$id"; then return
 
     ## Issues without tickets, e.g. potential singular, manual debug jobs,
     # wrong user settings, etc.


### PR DESCRIPTION
Removing ticket references for issues that are resolved or where we can
just rely on the regex within the ticket subject lines instead.