### PR TITLE
Add backlog-set-due-date script

### DIFF
--- a/backlog-set-due-date
+++ b/backlog-set-due-date
@@ -1,0 +1,40 @@
+#!/bin/sh -e
+
+# This script sets the due date on tickets in Redmine based on 
+# these conditions:
+# - The priority is not Low
+# - No previous due date set
+# - Not assigned to anyone
+# - Not blocked or resolved
+#
+# If you want to run this for testing there are two options
+# 1. Run the script without updating the tickets
+# dry_run=1 ./backlog-set-due-date
+#
+# 2. Like #1 but also read the tickets from a file
+# dry_run=1 ./backlog-set-due-date <issues-json-file>
+
+dry_run="${dry_run:-"0"}"
+project_id="${project_id:-18}"
+ticket_limit="${ticket_limit:-200}"
+host="${host:-"https://progress.opensuse.org"}"
+issues=$(mktemp)
+jquery='.issues | .[] | select(.priority.name!="Low" and .due_date==null and .assigned_to!=null and .status.name!="Blocked" and .status.name!="Feedback")'
+
+if [ $# -eq 1 ] && [ -f "$1" ] && [ "$dry_run" = "1" ]; then
+  jq -r "$jquery" "$1" >"$issues"
+else
+  redmine_api_key="${redmine_api_key:?"Need redmine API key"}"
+  curl -s -H "X-Redmine-API-Key: $redmine_api_key" "$host/issues.json?project_id=$project_id&limit=$ticket_limit" | jq -r "$jquery" >"$issues"
+fi
+
+[ "$dry_run" = "1" ] && prefix="echo"
+
+for id in $(jq .id "$issues"); do
+  due_date=$(date -d"+14 days" +%Y-%m-%d)
+  echo "Updating ticket $id, new due date setup to $due_date"
+  $prefix curl -v -H "X-Redmine-API-Key: $redmine_api_key" -H 'Content-Type: application/json' -X PUT \
+  -d "{\"issue\": {\"due_date\": \"$due_date\", \"notes\": \"Setting due date based on mean cycle time of SUSE QE Tools\"}}" \
+  "$host/issues/$id.json"
+done
+


### PR DESCRIPTION
This script sets the duedate to 14 days from the script's
execution time for tickets that are not low priority and
have not been assigned to anyone

Add dry_run mode. It uses a test json file as first parameter
to perform the tests and thus have predictable results

https://progress.opensuse.org/issues/73468