### PR TITLE
README: Add description for "openqa-investigate" and the possible combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,16 @@ Checkout the individual scripts and either call them manually or automatically, 
 
 ### auto-review - Automatically detect known issues in openQA jobs, label openQA jobs with ticket references and optionally retrigger
 
-* [openqa-monitor-incompletes](https://github.com/os-autoinst/scripts/blob/master/openqa-monitor-incompletes) queries the database of an openQA instance (ssh access is necessary) and output the list of "interesting" incompletes, where "interesting" means not all incompletes but the ones likely needing actions by admins, e.g. unreviewed, no clones, no obvious "setup failure", etc.
-* [openqa-monitor-investigation-candidates](https://github.com/os-autoinst/scripts/blob/master/openqa-monitor-investigation-candidates) queries the dabase of an openQA instance (ssh access is necessary) and output the list of failed jobs that are suitable for triggering investigation jobs on, compare to "openqa-monitor-incompletes"
-* [openqa-label-known-issues](https://github.com/os-autoinst/scripts/blob/master/openqa-label-known-issues) can take a list of openQA jobs, for example output from "openqa-monitor-incompletes" and look for matching "known issues", for example from progress.opensuse.org, label the job and retrigger if specified in the issue (see the source code for details how to mark tickets)
+* [openqa-monitor-incompletes](https://github.com/os-autoinst/scripts/blob/master/openqa-monitor-incompletes)
+  queries the database of an openQA instance (ssh access is necessary) and
+  output the list of "interesting" incompletes, where "interesting" means not
+  all incompletes but the ones likely needing actions by admins, e.g.
+  unreviewed, no clones, no obvious "setup failure", etc.
+* [openqa-label-known-issues](https://github.com/os-autoinst/scripts/blob/master/openqa-label-known-issues)
+  can take a list of openQA jobs, for example output from
+  "openqa-monitor-incompletes" and look for matching "known issues", for
+  example from progress.opensuse.org, label the job and retrigger if specified
+  in the issue (see the source code for details how to mark tickets)
 
 For tickets referencing "auto_review" it is suggested to add a text section based on the following template:
 
@@ -24,6 +31,30 @@ For tickets referencing "auto_review" it is suggested to add a text section base
 Find jobs referencing this ticket with the help of
 https://raw.githubusercontent.com/os-autoinst/scripts/master/openqa-query-for-job-label ,
 for example to look for ticket 12345 call `openqa-query-for-job-label poo#12345`
+```
+
+### openqa-investigate - Automatic investigation jobs with failure analysis in openQA
+
+* [openqa-monitor-investigation-candidates](https://github.com/os-autoinst/scripts/blob/master/openqa-monitor-investigation-candidates)
+  queries the dabase of an openQA instance (ssh access is necessary) and
+  output the list of failed jobs that are suitable for triggering
+  investigation jobs on, compare to "openqa-monitor-incompletes"
+
+* [openqa-investigate](https://github.com/os-autoinst/scripts/blob/master/openqa-investigate)
+  can take a list of openQA jobs, for example output of
+  "openqa-monitor-investigation-candidates" and trigger "investigation jobs",
+  e.g. a plain retrigger, using the "last good" tests as well as "last good"
+  build
+
+
+### Combine auto-review and openqa-investigate
+
+A possible approach to combine handling known issues and unknown issues is to
+run "openqa-label-known-issues" against all "investigation candidates" and
+pass all unknown issues to "openqa-investigate":
+
+```
+./openqa-monitor-investigation-candidates | ./openqa-label-known-issues 3>&1 1>/dev/null 2>&3- | sed -n 's/\(\S*\) : Unknown issue, to be reviewed.*$/\1/p' | ./openqa-investigate
 ```
 
 ## Contribute

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -130,14 +130,6 @@ investigate_issue() {
     local out
     local reason
     local curl
-    # reason specified with insufficient length
-    # we could accept sufficient length of reason as explanation enough not
-    # needing any comment but then we should distinguish between real
-    # user-errors or infrastructure related ones that we need to care about
-    reason="$(openqa-client --json-output --host "$host_url" jobs/"$id" | jq -r '.job.reason')"
-    if [ -n "$reason" ] && [ ${#reason} -lt "$reason_min_length" ]; then
-        $client_call jobs/"$id"/comments post text="poo#63718 incomplete reason with just 'quit' could provide more information"
-    fi
     out=$(mktemp)
     curl=$(curl -s -w "%{http_code}" "$i/file/autoinst-log.txt" -o "$out")
     # combine both the reason and autoinst-log.txt to check known issues

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -165,7 +165,7 @@ investigate_issue() {
 print_summary() {
     local to_review_count=${#to_review[@]}
     [[ $to_review_count -eq 0 ]] && return
-    local msg="\n\e[1m\e[31m$to_review_count unknown incompletes to be reviewed:\e[0m"
+    local msg="\n\e[1m\e[31m$to_review_count unknown issues to be reviewed:\e[0m"
     for job in "${to_review[@]}"; do
         msg+="\n - $job"
     done


### PR DESCRIPTION
We can combine the existing "auto-review" workflow with
"openqa-investigate" to trigger investigation jobs for all left "unknown
issues" after "openqa-label-known-issues" has been running.

Related progress issue: https://progress.opensuse.org/issues/77899