### PR TITLE
Simplify query in openqa-incompletes-stats and allow showing job IDs

### DIFF
--- a/openqa-incompletes-stats
+++ b/openqa-incompletes-stats
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 host="${host:-"openqa.opensuse.org"}"
 ssh_host="${ssh_host:-"$host"}"
 scheme="${scheme:-"https"}"
@@ -6,6 +6,7 @@ interval="${interval:-"24 hour"}"
 failed_since="${failed_since:-"(NOW() - interval '$interval')"}"
 width="${width:-80}"
 threshold="${threshold:-0}"
-query="${query:-"select left(text, $width), count(text) from jobs, comments where (result='incomplete' and t_finished >= $failed_since and jobs.id in (select job_id from comments where id is not null)) and jobs.id = job_id group by text having count(text) > $threshold order by count(text) desc;"}"
+[[ ${show_job_ids:-} ]] && additional_columns+=', array_agg(jobs.id) as job_ids'
+query="${query:-"select left(text, $width) as comment_text, count(text) as job_count $additional_columns from jobs join comments on jobs.id = comments.job_id where result='incomplete' and t_finished >= $failed_since group by text having count(text) > $threshold order by job_count desc;"}"
 # shellcheck disable=SC2029
 ssh "$ssh_host" "cd /tmp; sudo -u geekotest psql --command=\"$query\" openqa"

--- a/openqa-incompletes-stats
+++ b/openqa-incompletes-stats
@@ -7,6 +7,9 @@ failed_since="${failed_since:-"(NOW() - interval '$interval')"}"
 width="${width:-80}"
 threshold="${threshold:-0}"
 [[ ${show_job_ids:-} ]] && additional_columns+=', array_agg(jobs.id) as job_ids'
+if [[ ${show_worker_hosts:-} ]]; then
+    additional_columns+=', array(select distinct host from workers where id = any(array_agg(jobs.assigned_worker_id))) as worker_hosts'
+fi
 query="${query:-"select left(text, $width) as comment_text, count(text) as job_count $additional_columns from jobs join comments on jobs.id = comments.job_id where result='incomplete' and t_finished >= $failed_since group by text having count(text) > $threshold order by job_count desc;"}"
 # shellcheck disable=SC2029
 ssh "$ssh_host" "cd /tmp; sudo -u geekotest psql --command=\"$query\" openqa"


### PR DESCRIPTION
The query still returns the same jobs but uses a simple JOIN instead of selecting from multiple databases at once and filtering via a
sub query.

I also improved the column headers and added an option to list the job IDs.