### PR TITLE
openqa-monitor-investigation-candidates: Add option to exclude job groups by regex

### DIFF
--- a/openqa-monitor-investigation-candidates
+++ b/openqa-monitor-investigation-candidates
@@ -5,8 +5,28 @@ host="${host:-"openqa.opensuse.org"}"
 ssh_host="${ssh_host:-"$host"}"
 scheme="${scheme:-"https"}"
 failed_since="${failed_since:-"(NOW() - interval '24 hour')"}"
-group_id="${group_id:-"1"}"
-query="${query:-"select id,test from jobs where (result='failed' and clone_id is null and group_id=$group_id and t_finished >= $failed_since and id not in (select job_id from comments where job_id is not null));"}"
+# use an environment variable "group_id" to limit the search to that job group, e.g.
+# "1" for "openSUSE Tumbleweed" on openqa.opensuse.org
+# shellcheck disable=SC2154
+group_query="${group_id+" group_id=$group_id and"}"
+# use an environment variable "exclude_parent" with an SQL regex string to
+# exclude all jobs that match the parent group name specified, e.g.
+# "%Development|Open Build Service%"
+exclude_parent="${exclude_parent:-"%Development|Open Build Service|Others%"}"
+exclude_parent_query="${exclude_parent+" and job_group_parents.name not similar to '${exclude_parent}'"}"
+
+# Define common query parts that we can reuse when we look for both jobs in groups with a parent groups and jobs in groups without a parent group
+query_common_prefix="${query_common_prefix:-"
+  select jobs.id,jobs.test from jobs join job_groups on jobs.group_id = job_groups.id
+"}"
+query_common_suffix="${query_common_suffix:-"
+  where result='failed' and clone_id is null and$group_query t_finished >= $failed_since and jobs.id not in (select job_id from comments where job_id is not null)
+"}"
+query="${query:-"
+  $query_common_prefix left join job_group_parents on job_groups.parent_id = job_group_parents.id $query_common_suffix$exclude_parent_query;
+  $query_common_prefix $query_common_suffix;
+"}"
+
 # shellcheck disable=SC2029
 for i in $(ssh "$ssh_host" "cd /tmp; sudo -u geekotest psql --no-align --tuples-only --command=\"$query\" openqa"); do
     url="$scheme://$host/tests/${i%|*}"

--- a/openqa-monitor-investigation-candidates
+++ b/openqa-monitor-investigation-candidates
@@ -9,6 +9,11 @@ failed_since="${failed_since:-"(NOW() - interval '24 hour')"}"
 # "1" for "openSUSE Tumbleweed" on openqa.opensuse.org
 # shellcheck disable=SC2154
 group_query="${group_id+" group_id=$group_id and"}"
+# use an environment variable "exclude_group" with an SQL regex string to
+# exclude all jobs that match the group name specified, e.g.
+# "%Not This Group%"
+exclude_group="${exclude_group:-"%Kernel%|%Development%|%Staging%|%MicroOS%"}"
+exclude_group_query="${exclude_group+" and job_groups.name not similar to '${exclude_group}'"}"
 # use an environment variable "exclude_parent" with an SQL regex string to
 # exclude all jobs that match the parent group name specified, e.g.
 # "%Development|Open Build Service%"
@@ -17,14 +22,14 @@ exclude_parent_query="${exclude_parent+" and job_group_parents.name not similar 
 
 # Define common query parts that we can reuse when we look for both jobs in groups with a parent groups and jobs in groups without a parent group
 query_common_prefix="${query_common_prefix:-"
-  select jobs.id,jobs.test from jobs join job_groups on jobs.group_id = job_groups.id
+  select jobs.id,jobs.test from jobs left join job_groups on jobs.group_id = job_groups.id
 "}"
 query_common_suffix="${query_common_suffix:-"
-  where result='failed' and clone_id is null and$group_query t_finished >= $failed_since and jobs.id not in (select job_id from comments where job_id is not null)
+  result='failed' and clone_id is null and$group_query t_finished >= $failed_since and jobs.id not in (select job_id from comments where job_id is not null)$exclude_group_query
 "}"
 query="${query:-"
-  $query_common_prefix left join job_group_parents on job_groups.parent_id = job_group_parents.id $query_common_suffix$exclude_parent_query;
-  $query_common_prefix $query_common_suffix;
+  $query_common_prefix left join job_group_parents on job_groups.parent_id = job_group_parents.id where $query_common_suffix$exclude_parent_query;
+  $query_common_prefix where job_groups.parent_id is null and $query_common_suffix;
 "}"
 
 # shellcheck disable=SC2029


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/80806