### PR TITLE
openqa-investigate: Allow to filter out by name, job group, parent group, no group

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -8,6 +8,10 @@ scheme="${scheme:-"https"}"
 host_url="$scheme://$host"
 dry_run="${dry_run:-"0"}"
 prio_add="${prio_add:-"100"}"
+exclude_name_regex="${exclude_name_regex:-":investigate:"}"
+exclude_no_group="${exclude_no_group:-"true"}"
+# exclude_group_regex checks a combined string "<parent job group name> / <job group name>"
+exclude_group_regex="${exclude_group_regex:-"Development.*/ "}"
 client_args="--json-output --host $host_url"
 echoerr() { echo "$@" >&2; }
 
@@ -98,6 +102,10 @@ investigate() {
     [[ $? != 0 ]] && echoerr "unable to query job data for $id: $job_data" && return 1
     old_name="$(echo "$job_data" | jq -r '.job.test')"
     [[ "$old_name" =~ ":investigate:" ]] && echo "Job is ':investigate:' already, skipping investigation" && return 0
+    [[ "$old_name" =~ $exclude_name_regex ]] && echo "Job name '$old_name' matches \$exclude_name_regex '$exclude_name_regex', skipping investigation" && return 0
+    group="$(echo "$job_data" | jq -r '.job.group + " / " + .job.parent_group')"
+    [[ "$group" = " / " ]] && [[ "$exclude_no_group" = "true" ]] && echo "Job w/o job group, \$exclude_no_group is set, skipping investigation" && return 0
+    [[ "$group" =~ $exclude_group_regex ]] && echo "Job group '$group' matches \$exclude_group_regex '$exclude_group_regex', skipping investigation" && return 0
 
     # Optionally we can find "first failed", could extend openQA investigation
     # method instead for we are just working based on supplied job which can


### PR DESCRIPTION
Tested manually locally with current jobs that I could find on o3:

* 1502469 in "Development / Development Tumbleweed"
  -> "Job group 'Development Tumbleweed / Development' matches
  $exclude_group_regex 'Development.*/ ', skipping investigation"
* 1502404 outside any job group
  -> "Job w/o job group, $exclude_no_group is set, skipping
  investigation"

Related progress issue: https://progress.opensuse.org/issues/80830