### PR TITLE
Correctly check if a published Tumbleweed image was found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ test: checkstyle
 .PHONY: test-online
 test-online:
 	cat ./tests/incompletes | env dry_run=1 bash -ex ./openqa-label-known-issues
+	env dry_run=1 ./trigger-openqa_in_openqa
+	# Invalid JSON causes the job to abort with an error
+	env tw_openqa_host=example.com dry_run=1 ./trigger-openqa_in_openqa | grep -v 'parse error:'
 
 .PHONY: checkstyle
 checkstyle: test-shellcheck test-yaml

--- a/trigger-openqa_in_openqa
+++ b/trigger-openqa_in_openqa
@@ -12,7 +12,7 @@ target_host_proto="${target_host_proto:-"https"}"
 dry_run="${dry_run:-"0"}"
 tw_openqa_host="${tw_openqa_host:-"https://openqa.opensuse.org"}"
 tw_group_id="${tw_group_id:-"1"}"
-openqa_client="${openqa_client:-"/usr/share/openqa/script/client"}"
+openqa_cli="${openqa_cli:-"/usr/share/openqa/script/openqa-cli"}"
 arch="${arch:-"x86_64"}"
 machine="${machine:-"64bit"}"
 
@@ -29,7 +29,7 @@ find_latest_published_tumbleweed_image() {
         echo "Unable to find latest published Tumbleweed build."
         exit 1
     fi
-    qcow=$(/usr/share/openqa/script/openqa-cli api --host "${tw_openqa_host}" assets get \
+    qcow=$(${openqa_cli} api --host "${tw_openqa_host}" assets get \
         | jq -r "[.assets[] | select(.name | test(\"Tumbleweed-$arch-$latest_published_tw_build-Tumbleweed\\\\@$machine.qcow\"))] | .[0] | .name")
     if ! [[ $qcow ]]; then
         echo "Unable to determine qcow image for Tumbleweed build '$latest_published_tw_build' (for architecture '$arch' and machine '$machine')."
@@ -53,8 +53,8 @@ trigger() {
         ARGS="OPENQA_HOST=http://openqa.opensuse.org"
     fi
 
-    ${client_prefix} "${openqa_client}" \
-        --host "${target_host_proto}"://"${target_host}" isos post \
+    ${client_prefix} "${openqa_cli}" api -X POST \
+        --host "${target_host_proto}"://"${target_host}" isos \
         VERSION=Tumbleweed \
         DISTRI=openQA FLAVOR=dev BUILD="${build}" \
         ARCH="${arch}" BACKEND=qemu WORKER_CLASS=qemu_x86_64 \

--- a/trigger-openqa_in_openqa
+++ b/trigger-openqa_in_openqa
@@ -25,18 +25,17 @@ main() {
 find_latest_published_tumbleweed_image() {
     latest_published_tw_build=$(curl "$tw_openqa_host/group_overview/$tw_group_id.json" \
         | jq -r '[.build_results[] | select(.tag.description=="published") | select(.version=="Tumbleweed") | .build] | sort | reverse | .[0]')
-    if ! [[ $latest_published_tw_build ]]; then
+    if [[ "$latest_published_tw_build" = "null" ]]; then
         echo "Unable to find latest published Tumbleweed build."
         exit 1
     fi
     qcow=$(${openqa_cli} api --host "${tw_openqa_host}" assets get \
         | jq -r "[.assets[] | select(.name | test(\"Tumbleweed-$arch-$latest_published_tw_build-Tumbleweed\\\\@$machine.qcow\"))] | .[0] | .name")
-    if ! [[ $qcow ]]; then
+    if [[ "$qcow" = "null" ]]; then
         echo "Unable to determine qcow image for Tumbleweed build '$latest_published_tw_build' (for architecture '$arch' and machine '$machine')."
         exit 2
     fi
     if [ "$target_host_proto://$target_host" != "$tw_openqa_host" ]; then
-        [ "$qcow" = "" ] && (echo "could not find valid asset" && exit 2)
         url="${tw_openqa_host}/assets/hdd/${qcow}"
 
         # instead of manual wget it should also work to provide a whitelisted url to openqa as HDD_1_URL which should then download it itself but a first experiment didn't work


### PR DESCRIPTION
- `jq` returns *null* not empty when nothing is found
- Always use `openqa-cli` in place of `openqa-client`
- Add tests for successful (dry_run) and parse error

See: [poo#81492](https://progress.opensuse.org/issues/81492)