### PR TITLE
Pick the last published build that we have an image for

### DIFF
--- a/trigger-openqa_in_openqa
+++ b/trigger-openqa_in_openqa
@@ -23,16 +23,26 @@ main() {
 }
 
 find_latest_published_tumbleweed_image() {
-    latest_published_tw_build=$(curl "$tw_openqa_host/group_overview/$tw_group_id.json" \
-        | jq -r '[.build_results[] | select(.tag.description=="published") | select(.version=="Tumbleweed") | .build] | sort | reverse | .[0]')
-    if [[ "$latest_published_tw_build" = "null" ]]; then
-        echo "Unable to find latest published Tumbleweed build."
+    latest_published_tw_builds=$(curl "$tw_openqa_host/group_overview/$tw_group_id.json" \
+        | jq -r '[.build_results[] | select(.tag.description=="published") | select(.version=="Tumbleweed") | .build] | sort | reverse | join(" ")')
+    if [[ "$latest_published_tw_builds" = "null" ]]; then
+        echo "Unable to find latest published Tumbleweed builds."
         exit 1
     fi
-    qcow=$(${openqa_cli} api --host "${tw_openqa_host}" assets get \
-        | jq -r "[.assets[] | select(.name | test(\"Tumbleweed-$arch-$latest_published_tw_build-Tumbleweed\\\\@$machine.qcow\"))] | .[0] | .name")
+    qcow=null
+    for latest_published_tw_build in $latest_published_tw_builds; do
+        qcow=$(${openqa_cli} api --host "${tw_openqa_host}" assets get \
+            | jq -r "[.assets[] | select(.name | test(\"Tumbleweed-$arch-$latest_published_tw_build-Tumbleweed\\\\@$machine.qcow\"))] | .[0] | .name")
+        # This published build has an image available
+        if [[ "$qcow" != "null" ]]; then
+            break
+        else
+            # Published but no image available, we'll try and continue
+            echo "Unable to determine qcow image for Tumbleweed build '$latest_published_tw_build' (for architecture '$arch' and machine '$machine')."
+        fi
+    done
+    # No published image available
     if [[ "$qcow" = "null" ]]; then
-        echo "Unable to determine qcow image for Tumbleweed build '$latest_published_tw_build' (for architecture '$arch' and machine '$machine')."
         exit 2
     fi
     if [ "$target_host_proto://$target_host" != "$tw_openqa_host" ]; then


### PR DESCRIPTION
When published builds and assets are out of sync the very latest may not exist. But we can use the next most recent.

This is a follow-up to #63 which made the trigger fail cleanly.

See: [poo#81492](https://progress.opensuse.org/issues/81492)