### PR TITLE
Don't write an empty comment if there are no investigation jobs

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -119,6 +119,7 @@ investigate() {
     # have more, ambiguous potential changes that we need to bisect on
 
     out=$(trigger_jobs "$id" "${@:2}")
+    [[ $out ]] || return 0
     comment="Automatic investigation jobs:
 
 $out"


### PR DESCRIPTION
The creation of investigation jobs is skipped if the jobs have certain
dependencies. In this case no output is generated and no comment should be
created.