### PR TITLE
backlog-set-due-date: Look at complete backlog by query

### DIFF
--- a/backlog-set-due-date
+++ b/backlog-set-due-date
@@ -15,7 +15,7 @@
 # dry_run=1 ./backlog-set-due-date <issues-json-file>
 
 dry_run="${dry_run:-"0"}"
-project_id="${project_id:-18}"
+query_id="${query_id:-230}"
 ticket_limit="${ticket_limit:-200}"
 host="${host:-"https://progress.opensuse.org"}"
 issues=$(mktemp)
@@ -25,7 +25,7 @@ if [ $# -eq 1 ] && [ -f "$1" ] && [ "$dry_run" = "1" ]; then
   jq -r "$jquery" "$1" >"$issues"
 else
   redmine_api_key="${redmine_api_key:?"Need redmine API key"}"
-  curl -s -H "X-Redmine-API-Key: $redmine_api_key" "$host/issues.json?project_id=$project_id&limit=$ticket_limit" | jq -r "$jquery" >"$issues"
+  curl -s -H "X-Redmine-API-Key: $redmine_api_key" "$host/issues.json?query_id=$query_id&limit=$ticket_limit" | jq -r "$jquery" >"$issues"
 fi
 
 [ "$dry_run" = "1" ] && prefix="echo"


### PR DESCRIPTION
Rather than selecting a single redmine project we should consider the
complete backlog of the team SUSE QE Tools as decided together.

Tested locally.