### PR TITLE
WIP -- would need openQA to take test parameters as arguments on jobs/$id/restart route -- openqa-label-known-issues: Add parsing of optional comma-separated test parameters

### DIFF
--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -28,7 +28,7 @@ trap 'test "$KEEP_REPORT_FILE" == "1" || rm "$out"' EXIT
 echoerr() { echo "$@" >&2; }
 
 label_on_issue() {
-    local id=$1 search_term=$2 comment=$3 restart=$4
+    local id=$1 search_term=$2 comment=$3 restart=$4 test_params=$5
     local rc=0 grep_output
     local grep_opts="${grep_opts:-"-qPzo"}"
     # shellcheck disable=SC2086
@@ -45,7 +45,7 @@ label_on_issue() {
     fi
     "${client_call[@]}" -X POST jobs/"$id"/comments text="$comment"
     if [ "$restart" = "1" ]; then
-        "${client_call[@]}" -X POST jobs/"$id"/restart
+        openqa-clone-job --within-instance "$host_url/t$id" "${test_params/,/ }"
     fi
 }
 
@@ -104,7 +104,7 @@ label_on_issues_from_issue_tracker() {
     # splice each line with a call to label_on_issue
     echo "$issues" | (while read -r issue; do
         read -r subject
-        after=${subject#*\"} && search=${after%\"*} && [[ ${#search} -ge $min_search_term ]] && label_on_issue "$id" "$search" "poo#$issue $subject" "${after//*\":retry*/1}" && break; done)
+        after=${subject#*\"} && search=${after%\"*} && [[ ${#search} -ge $min_search_term ]] && label_on_issue "$id" "$search" "poo#$issue $subject" "${after//*\":retry*/1}" "${after/*:retry:/}" && break; done)
 }
 
 label_on_issues_without_tickets() {


### PR DESCRIPTION
Tested manually with:

```
echo https://openqa.suse.de/tests/6097966 | env host=openqa.suse.de dry_run=1 bash -ex ./openqa-label-known-issues
```

using ticket
https://progress.opensuse.org/issues/93119
with subject

```
[s390x] Update of s390x Test infrastructure after shutdown of Mainframe zEC12 auto_review:"(?s)2021-05-2[1-5]T.*Error connecting to <root@s390p.*.suse.de>: No route to host":retry:WORKER_CLASS=s390-kvm-sle12
```