### PR TITLE
monitor-openqa_job: Fix cleanup of previous OBS comments broken by c9a8e04

### DIFF
--- a/monitor-openqa_job
+++ b/monitor-openqa_job
@@ -41,7 +41,7 @@ done
 
 [[ ${failed_jobs[*]} ]] || exit 0
 
-osc api "/comments/$obs_component/$obs_package_name" | grep id= | sed -n 's/.*id="\([^"]*\)">test failed.*/\1/p' | while read -r id; do
+osc api "/comments/$obs_component/$obs_package_name" | grep id= | sed -n 's/.*id="\([^"]*\)">.*test.* failed.*/\1/p' | while read -r id; do
     osc api -X DELETE /comment/"$id"
 done
 comment="openQA-in-openQA test(s) failed (job IDs: ${failed_jobs[*]}), see https://openqa.opensuse.org/tests/overview?"


### PR DESCRIPTION


Now that the comment text has changed the regex for deleting previous
comments needs to be adapted.