### PR TITLE
Avoid errors when accessing variables `client_prefix` and `BUILD_TAG`

### DIFF
--- a/trigger-openqa_in_openqa
+++ b/trigger-openqa_in_openqa
@@ -15,6 +15,8 @@ tw_group_id="${tw_group_id:-"1"}"
 openqa_cli="${openqa_cli:-"openqa-cli"}"
 arch="${arch:-"x86_64"}"
 machine="${machine:-"64bit"}"
+build_tag=${BUILD_TAG:-}
+client_prefix=${client_prefix:-}
 
 # shellcheck source=/dev/null
 . "$(dirname "$0")"/_common
@@ -55,7 +57,7 @@ find_latest_published_tumbleweed_image() {
         ${client_prefix} wget -c "$url" -O /var/lib/openqa/factory/hdd/"$qcow"
     fi
     # ensure the build tag conforms to coolo's unwritten rules for the openQA dashboard
-    build=$(echo "$BUILD_TAG" | sed -e "s/jenkins-trigger-openQA_in_openQA-/:/" -e "s/-/./g")
+    build=$(echo "$build_tag" | sed -e "s/jenkins-trigger-openQA_in_openQA-/:/" -e "s/-/./g")
 }
 
 trigger() {


### PR DESCRIPTION
* See https://progress.opensuse.org/issues/95006
* This problem has been introduced when making the error handling stricter
  in https://github.com/os-autoinst/scripts/commit/c048950b2ae30bd909d8bff4666bd2e3a7cb36c7