### PR TITLE
openqa-investigate: Add URL to original job in settings

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -40,6 +40,7 @@ clone() {
     # clear "PUBLISH_" settings to avoid overriding production assets
     # shellcheck disable=SC2207
     clone_settings+=($(echo "$job_data" | jq -r '.job.settings | keys[] | select (startswith("PUBLISH_")) | . + "="'))
+    clone_settings+=("OPENQA_INVESTIGATE_ORIGIN=$host_url/t$id")
     out=$($clone_call "$host_url/tests/$id" "${clone_settings[@]}")
     [[ $dry_run = 1 ]] && echo "$out"
     # output is in $out, should change that text to a markdown list entry


### PR DESCRIPTION
To be able to find for which original job an openqa-investigate job was
triggered we should put the original job's URL in settings of each
openqa-investigate job. The openQA webUI automatically renders clickable links
for the URL in the settings table of job details.

Tested manually with dry-run using
`echo https://openqa.opensuse.org/tests/1848412 | env dry_run=1 ./openqa-investigate`:

```
openqa-cli api --host https://openqa.opensuse.org -X POST jobs/1848412/comments text=Automatic investigation jobs:

openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/1848412 TEST=openqa_install+publish:investigate:retry _GROUP_ID=0 BUILD= PUBLISH_HDD_1= PUBLISH_PFLASH_VARS= OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/t1848412
* **openqa_install+publish:investigate:retry**:
No test changes recorded, test regression unlikely. Skipping test regression investigation job.
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/1848402 TEST=openqa_install+publish:investigate:last_good_build::TW.8704 _GROUP_ID=0 BUILD= PUBLISH_HDD_1= PUBLISH_PFLASH_VARS= OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/t1848402
* **openqa_install+publish:investigate:last_good_build::TW.8704**:
No test regression expected. Not triggered 'good build+test' as it would be the same as 3., good build + current test
```

Related progress issue: https://progress.opensuse.org/issues/95742