### PR TITLE
Improve error handling and print only first 15 lines

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -16,6 +16,7 @@ exclude_no_group="${exclude_no_group:-"true"}"
 # exclude_group_regex checks a combined string "<parent job group name> / <job group name>"
 exclude_group_regex="${exclude_group_regex:-"Development.*/ "}"
 client_args="--host $host_url"
+jq_output_limit="${jq_output_limit:-15}"
 echoerr() { echo "$@" >&2; }
 
 runjq() {
@@ -26,6 +27,7 @@ runjq() {
     rc=$?
     set -e
     (( "$rc" == 0 )) && echo "$output" && return
+    output=$(echo "$output" | head -"$jq_output_limit")
     echo "jq ($(caller)): $output (Input: >>>$input<<<)" >&2
     exit $rc
 }


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/95830

We saw that we are getting a 404 Not Found response in some cases,
which returns a huge HTML page that fills our logs.

Simply get the first 15 lines for now and improve handling of
status codes later.