### PR TITLE
openqa-label-known-issues: Remove obsolete handling of poo#61922

### DIFF
--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -73,16 +73,6 @@ handle_unreachable_or_no_log() {
         $client_call -X POST jobs/"$id"/restart
         return
     fi
-    # if the job is not too old but there is no log file it is most
-    # likely poo#57620 See "openqa-label-all" as an interesting
-    # alternative which can label and optionally restart jobs based on
-    # group, build, module parameters
-    # As long as we have a ticket for "incomplete jobs with no logs"
-    # of higher priority we should use that one instead:
-    $client_call -X POST jobs/"$id"/comments text='poo#61922 Incomplete jobs with no logs at all'
-    #$client_call -X POST jobs/"$id"/comments text='poo#57620 job is incomplete if websockets server (or webui?) is unreachable for a minute, e.g. during upgrade'
-    # triggering a restart on jobs that already have a clone does not have an effect
-    $client_call -X POST jobs/"$id"/restart
 }
 
 label_on_issues_from_issue_tracker() {


### PR DESCRIPTION
We encountered many jobs that have poo#61922 as label from
openqa-label-known-issues. This comes from openqa-label-known-issues that
directly detects openQA jobs without any logs and marks as such. In the
meantime we have the "reason" field which in the case of the mentioned jobs
says something along the lines of "abandoned: associated worker $host:instance
re-connected but abandoned the job" and likely the job was automatically
retriggered at that time by openQA itself so we should not need to handle the
issue anymore in openqa-label-known-issues explicitly.

Related progress issue: https://progress.opensuse.org/issues/96019