### PR TITLE
openqa-investigate: Fix handling of jobs without previous jobs

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -90,7 +90,7 @@ trigger_jobs() {
     job_url="$host_url/tests/$id"
     investigation=$(runcurl -s "$job_url"/investigation_ajax) || return $?
     last_good_exists=$(echo "$investigation" | runjq -r '.last_good') || return $?
-    if [[ "$last_good_exists" = "not found" ]]; then
+    if [[ "$last_good_exists" = "null" || "$last_good_exists" = "not found" ]]; then
         echo "No last good recorded, skipping regression investigation jobs" && return 1
     fi
     last_good=$(echo "$investigation" | runjq -r '.last_good.text') || return $?


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/95830

.last_good can be "not found", but also null when there are no previous
jobs.

(I simply missed that last_good_exists was never checked for "null")

The posted comment will now contain `No last good recorded, skipping regression investigation jobs` like in other cases where no last good is found.