### PR TITLE
Improve error handling

### DIFF
--- a/_common
+++ b/_common
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 # Common shell script snippets to be used when interacting with openQA
 # instances, for example over openqa-cli.
@@ -9,3 +9,38 @@
 job_ids() {
     jq -r '.ids[]' "$@"
 }
+
+# Wrapper around jq that outputs the first lines of JSON in case
+# jq has a problem with it, and the calling command and line
+runjq() {
+    local rc output
+    local jq_output_limit="${jq_output_limit:-15}"
+    input=$(</dev/stdin)
+    set +e
+    output=$(echo "$input" | jq "$@" 2>&1)
+    rc=$?
+    set -e
+    (( "$rc" == 0 )) && echo "$output" && return
+    output=$(echo "$output" | head -"$jq_output_limit")
+    echo "jq ($(caller)): $output (Input: >>>$input<<<)" >&2
+    return $rc
+}
+
+# Wrapper around curl that reports the HTTP status if it is not 200, and the
+# calling command and line
+runcurl() {
+    local rc status_code body response
+    local verbose="${verbose:-"false"}"
+    $verbose && echo "[debug] curl: Fetching ($*)" >&2
+    set +e
+    response=$(curl -w "\n%{http_code}\n" "$@" 2>&1)
+    rc=$?
+    set -e
+    (( "$rc" != 0 )) && echo "curl ($(caller)): Error fetching ($*): $response" >&2 && return 1
+    status_code=$(echo "$response" | tail -1)
+    (( "$status_code" != 200 )) && echo "curl ($(caller)): Error fetching url ($*): Got Status $status_code" >&2 && return 1
+    # remove last line
+    body=$(echo "$response" | tac | tail -n+2 | tac)
+    echo "$body"
+}
+

--- a/openqa-investigate
+++ b/openqa-investigate
@@ -6,6 +6,9 @@
 # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 set -euo pipefail
 
+# shellcheck source=/dev/null
+. "$(dirname "$0")"/_common
+
 host="${host:-"openqa.opensuse.org"}"
 scheme="${scheme:-"https"}"
 host_url="$scheme://$host"
@@ -20,33 +23,6 @@ client_args="--host $host_url"
 jq_output_limit="${jq_output_limit:-15}"
 echoerr() { echo "$@" >&2; }
 
-runjq() {
-    local rc output
-    input=$(</dev/stdin)
-    set +e
-    output=$(echo "$input" | jq "$@" 2>&1)
-    rc=$?
-    set -e
-    (( "$rc" == 0 )) && echo "$output" && return
-    output=$(echo "$output" | head -"$jq_output_limit")
-    echo "jq ($(caller)): $output (Input: >>>$input<<<)" >&2
-    return $rc
-}
-
-runcurl() {
-    local rc status_code body response
-    $verbose && echo "[debug] curl: Fetching ($*)" >&2
-    set +e
-    response=$(curl -w "\n%{http_code}\n" "$@" 2>&1)
-    rc=$?
-    set -e
-    (( "$rc" != 0 )) && echo "curl ($(caller)): Error fetching ($*): $response" >&2 && return 1
-    status_code=$(echo "$response" | tail -1)
-    (( "$status_code" != 200 )) && echo "curl ($(caller)): Error fetching url ($*): Got Status $status_code" >&2 && return 1
-    # remove last line
-    body=$(echo "$response" | tac | tail -n+2 | tac)
-    echo "$body"
-}
 
 clone() {
     local id name_suffix refspec job_data unsupported_cluster_jobs name base_prio clone_settings casedir repo out url clone_id

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -1,6 +1,12 @@
 #!/bin/bash -e
 
+# Usage
+# echo https://openqahost/tests/1234 | openqa-label-known-issues
+
 set -o pipefail
+
+# shellcheck source=/dev/null
+. "$(dirname "$0")"/_common
 
 host="${host:-"openqa.opensuse.org"}"
 scheme="${scheme:-"https"}"
@@ -42,34 +48,34 @@ label_on_issue() {
 
 handle_unreachable_or_no_log() {
     local id=$1
-    local i=$2
+    local testurl=$2
     local out=$3
 
-    if ! curl -s --head "$i" -o /dev/null; then
+    if ! curl -s --head "$testurl" -o /dev/null; then
         # the page might be gone, try the scheme+host we configured (might be different one though)
-        if ! grep -q "$host_url" <<< "$i"; then
-            echo "'$i' is not reachable and 'host_url' parameter does not match '$i', can not check further, continuing with next"
+        if ! grep -q "$host_url" <<< "$testurl"; then
+            echo "'$testurl' is not reachable and 'host_url' parameter does not match '$testurl', can not check further, continuing with next"
             return
         fi
         if ! curl -s --head "$host_url"; then
             echo "'$host_url' is not reachable, bailing out"
             curl --head "$host_url"
         fi
-        echo "'$i' is not reachable, assuming deleted, continuing with next"
+        echo "'$testurl' is not reachable, assuming deleted, continuing with next"
         return
     fi
     # resorting to downloading the job details page instead of the
     # log, overwrites $out
-    if ! curl -s "$i" -o "$out"; then
-        echo "'$i' can be reached but not downloaded, bailing out"
-        curl "$i"
+    if ! curl -s "$testurl" -o "$out"; then
+        echo "'$testurl' can be reached but not downloaded, bailing out"
+        curl "$testurl"
         exit 2
     fi
     # if the page is there but not even an autoinst-log.txt exists
     # then the job might be too old and logs are already deleted.
     # Checking timestamp
     if [[ $(date -uIs -d '-14days') > $(grep timeago "$out" | hxselect -s '\n' -c '.timeago::attr(title)') ]]; then
-        echo "'$i' does not have autoinst-log.txt but is rather old, ignoring"
+        echo "'$testurl' does not have autoinst-log.txt but is rather old, ignoring"
         return
     fi
     if hxnormalize -x "$out" | hxselect -s '\n' -c '.links_a .resborder' | grep -qPzo '(?s)Gru job failed.*connection error.*Inactivity timeout'; then
@@ -113,9 +119,9 @@ label_on_issues_without_tickets() {
 }
 
 handle_unknown() {
-    local i=$1 out=$2 reason=$3
-    to_review+=("$i ${reason:0:50}")
-    echoerr "$i : Unknown issue, to be reviewed -> $i/file/autoinst-log.txt"
+    local testurl=$1 out=$2 reason=$3
+    to_review+=("$testurl ${reason:0:50}")
+    echoerr "$testurl : Unknown issue, to be reviewed -> $testurl/file/autoinst-log.txt"
     echoerr -e "Likely the error is within this log excerpt, last lines before shutdown:\n---"
     # Look for different termination points with likely context
     (grep -A 12 'Backend process died, backend errors are reported below in the following lines' "$out" || grep -B 10 'sending magic and exit' "$out" || grep -B 5 'killing command server.*because test execution ended through exception' "$out" || grep -B 5 'EXIT 1' "$out" || grep -B 10 '\(Result: died\|isotovideo failed\)' "$out" || echo '(No log excerpt found)') | head -n -1 >&2
@@ -125,16 +131,16 @@ handle_unknown() {
 investigate_issue() {
     local id="${1##*/}"
     local reason
-    local curl
-    reason=$(openqa-cli api --host "$host_url" jobs/"$id" | jq -r '.job.reason')
-    curl=$(curl -s -w "%{http_code}" "$i/file/autoinst-log.txt" -o "$out")
+    local curl_output
+    reason=$(openqa-cli api --host "$host_url" jobs/"$id" | runjq -r '.job.reason')
+    curl_output=$(curl -s -w "%{http_code}" "$testurl/file/autoinst-log.txt" -o "$out")
     # combine both the reason and autoinst-log.txt to check known issues
     # against even in case when autoinst-log.txt is missing the details, e.g.
     # see https://progress.opensuse.org/issues/69178
     echo "$reason" >> "$out"
-    if [[ "$curl" != "200" ]] && [[ "$curl" != "301" ]]; then
+    if [[ "$curl_output" != "200" ]] && [[ "$curl_output" != "301" ]]; then
         # if we can not even access the page it is something more critical
-        handle_unreachable_or_no_log "$id" "$i" "$out"
+        handle_unreachable_or_no_log "$id" "$testurl" "$out"
     elif label_on_issues_from_issue_tracker "$id"; then return
 
     ## Issues without tickets, e.g. potential singular, manual debug jobs,
@@ -145,7 +151,7 @@ investigate_issue() {
     # subject line
     elif label_on_issues_without_tickets "$id"; then return
     else
-        handle_unknown "$i" "$out" "$reason"
+        handle_unknown "$testurl" "$out" "$reason"
     fi
 }
 
@@ -162,10 +168,10 @@ print_summary() {
 main() {
     [ "$dry_run" = "1" ] && client_prefix="echo"
     client_call="${client_call:-"$client_prefix openqa-cli api --host $host_url"}"
-    issues=$(curl -s "$issue_query" | jq -r '.issues | .[] | (.id,.subject)')
+    issues=$(runcurl -s "$issue_query" | runjq -r '.issues | .[] | (.id,.subject)')
     # shellcheck disable=SC2013
-    for i in $(cat - | sed 's/ .*$//'); do
-        investigate_issue "$i"
+    for testurl in $(cat - | sed 's/ .*$//'); do
+        investigate_issue "$testurl"
     done
     print_summary
 }


### PR DESCRIPTION
* Move runjq and runcurl to _common
* openqa-label-known-issues:
   * Rename variables, add usage, add runcurl and runjq
   * A variable called 'i' doesn't speak for itself.
   * A variable called 'curl' distracts if one is searching for all curl calls in a script.

Issue: https://progress.opensuse.org/issues/95830