### PR TITLE
Add User-Agent header to curl commands

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -21,6 +21,7 @@ exclude_no_group="${exclude_no_group:-"true"}"
 exclude_group_regex="${exclude_group_regex:-"Development.*/ "}"
 client_args="--host $host_url"
 jq_output_limit="${jq_output_limit:-15}"
+curl_args=(--user-agent "openqa-investigate")
 echoerr() { echo "$@" >&2; }
 
 
@@ -64,7 +65,7 @@ trigger_jobs() {
     clone "$id" 'retry' '' "${@:2}"
 
     job_url="$host_url/tests/$id"
-    investigation=$(runcurl -s "$job_url"/investigation_ajax) || return $?
+    investigation=$(runcurl "${curl_args[@]}" -s "$job_url"/investigation_ajax) || return $?
     last_good_exists=$(echo "$investigation" | runjq -r '.last_good') || return $?
     if [[ "$last_good_exists" = "null" || "$last_good_exists" = "not found" ]]; then
         echo "No last good recorded, skipping regression investigation jobs" && return 1
@@ -79,7 +80,7 @@ trigger_jobs() {
         echo "$test_log. Skipping test regression investigation job."
         last_good_tests=''
     else
-        vars_last_good=$(runcurl -s "$host_url/tests/$last_good"/file/vars.json) || return $?
+        vars_last_good=$(runcurl "${curl_args[@]}" -s "$host_url/tests/$last_good"/file/vars.json) || return $?
         last_good_tests=$(echo "$vars_last_good" | runjq -r '.TEST_GIT_HASH') || return $?
         # here we could apply the same approach for needles, not only tests
         # With https://github.com/os-autoinst/os-autoinst/pull/1358 we could
@@ -98,7 +99,7 @@ trigger_jobs() {
         echo "Current job has same build as last good, product regression unlikely. Skipping product regression investigation job."
         last_good_build=''
     else
-        vars_last_good=${vars_last_good:-$(runcurl -s "$host_url/tests/$last_good"/file/vars.json)} || return $?
+        vars_last_good=${vars_last_good:-$(runcurl "${curl_args[@]}" -s "$host_url/tests/$last_good"/file/vars.json)} || return $?
         last_good_build=$(echo "$vars_last_good" | runjq -r '.BUILD') || return $?
         # here we clone with unspecified test refspec, i.e. this could be a
         # more recent tests version. As an alternative we could explicitly

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -18,6 +18,7 @@ issue_query="${issue_query:-"https://progress.opensuse.org/projects/openqav3/iss
 reason_min_length="${reason_min_length:-"8"}"
 grep_timeout="${grep_timeout:-5}"
 to_review=()
+curl_args=(--user-agent "openqa-label-known-issues")
 
 out="${REPORT_FILE:-$(mktemp)}"
 trap 'test "$KEEP_REPORT_FILE" == "1" || rm "$out"' EXIT
@@ -55,24 +56,24 @@ handle_unreachable_or_no_log() {
     local testurl=$2
     local out=$3
 
-    if ! curl -s --head "$testurl" -o /dev/null; then
+    if ! curl "${curl_args[@]}" -s --head "$testurl" -o /dev/null; then
         # the page might be gone, try the scheme+host we configured (might be different one though)
         if ! grep -q "$host_url" <<< "$testurl"; then
             echo "'$testurl' is not reachable and 'host_url' parameter does not match '$testurl', can not check further, continuing with next"
             return
         fi
-        if ! curl -s --head "$host_url"; then
+        if ! curl "${curl_args[@]}" -s --head "$host_url"; then
             echo "'$host_url' is not reachable, bailing out"
-            curl --head "$host_url"
+            curl "${curl_args[@]}" --head "$host_url"
         fi
         echo "'$testurl' is not reachable, assuming deleted, continuing with next"
         return
     fi
     # resorting to downloading the job details page instead of the
     # log, overwrites $out
-    if ! curl -s "$testurl" -o "$out"; then
+    if ! curl "${curl_args[@]}" -s "$testurl" -o "$out"; then
         echo "'$testurl' can be reached but not downloaded, bailing out"
-        curl "$testurl"
+        curl "${curl_args[@]}" "$testurl"
         exit 2
     fi
     # if the page is there but not even an autoinst-log.txt exists
@@ -137,7 +138,7 @@ investigate_issue() {
     local reason
     local curl_output
     reason=$(openqa-cli api --host "$host_url" jobs/"$id" | runjq -r '.job.reason')
-    curl_output=$(curl -s -w "%{http_code}" "$testurl/file/autoinst-log.txt" -o "$out")
+    curl_output=$(curl "${curl_args[@]}" -s -w "%{http_code}" "$testurl/file/autoinst-log.txt" -o "$out")
     # combine both the reason and autoinst-log.txt to check known issues
     # against even in case when autoinst-log.txt is missing the details, e.g.
     # see https://progress.opensuse.org/issues/69178
@@ -172,7 +173,7 @@ print_summary() {
 main() {
     [ "$dry_run" = "1" ] && client_prefix="echo"
     client_call="${client_call:-"$client_prefix openqa-cli api --host $host_url"}"
-    issues=$(runcurl -s "$issue_query" | runjq -r '.issues | .[] | (.id,.subject)')
+    issues=$(runcurl "${curl_args[@]}" -s "$issue_query" | runjq -r '.issues | .[] | (.id,.subject)')
     # shellcheck disable=SC2013
     for testurl in $(cat - | sed 's/ .*$//'); do
         investigate_issue "$testurl"


### PR DESCRIPTION
This way we can see in the access_log how many of those requests are made and
how long they take.

Motivation:
We have a lot of requests made by bots (Go-http-client, curl, python-requests, Mojolicious), and it would be nice to see which app is actually making them, especially when we have high load.