### PR TITLE
Add a link to the original job in the investigation ones

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -58,6 +58,7 @@ clone() {
     echo "* **$name**: $url"
     clone_id=${out/:*/}; clone_id=${clone_id/*#/}
     $client_call --json --data "{\"priority\": $((base_prio + prio_add))}" -X PUT jobs/"$clone_id" >/dev/null
+    $client_call -X POST jobs/"$clone_id"/comments text="This is an investigation job from the original job $host_url/t$origin and cloned from $host_url/t$id"
 }
 
 trigger_jobs() {


### PR DESCRIPTION
Add a link pointing the original job from every investigation job
created from this. And also a link to the job from the investigation
job is cloned from

Example: https://openqa.opensuse.org/tests/1886978#comments

https://progress.opensuse.org/issues/95746