### PR TITLE
Add User-Agent header to openqa-cli calls

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -31,7 +31,7 @@ clone() {
     id=${2:?"Need 'id'"}
     name_suffix=${3+":$3"}
     refspec=${4+$4}
-    job_data=$(openqa-cli api --json --host "$host_url" jobs/"$id")
+    job_data=$($client_call --json jobs/"$id")
     # shellcheck disable=SC2181
     [[ $? != 0 ]] && echoerr "unable to query job data for $id: $job_data" && return 1
     unsupported_cluster_jobs=$(echo "$job_data" | runjq -r '(.job.children["Parallel"] | length) + (.job.parents["Parallel"] | length) + (.job.children["Directly chained"] | length) + (.job.parents["Directly chained"] | length)') || return $?
@@ -129,7 +129,7 @@ trigger_jobs() {
 investigate() {
     id="${1##*/}"
 
-    job_data=$(openqa-cli api --json --host "$host_url" jobs/"$id")
+    job_data=$($client_call --json jobs/"$id")
     # shellcheck disable=SC2181
     [[ $? != 0 ]] && echoerr "unable to query job data for $id: $job_data" && return 1
     old_name="$(echo "$job_data" | runjq -r '.job.test')" || return $?
@@ -154,7 +154,7 @@ $out"
 main() {
     client_prefix=''
     [ "$dry_run" = "1" ] && client_prefix="echo"
-    client_call="${client_call:-"$client_prefix openqa-cli api $client_args"}"
+    client_call="${client_call:-"$client_prefix openqa-cli api --header 'User-Agent: openqa-investigate (https://github.com/os-autoinst/scripts)' $client_args"}"
     clone_call="${clone_call:-"$client_prefix openqa-clone-job --skip-chained-deps --within-instance"}"
     error_count=0
     # shellcheck disable=SC2013

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -137,7 +137,7 @@ investigate_issue() {
     local id="${1##*/}"
     local reason
     local curl_output
-    reason=$(openqa-cli api --host "$host_url" jobs/"$id" | runjq -r '.job.reason')
+    reason=$($client_call jobs/"$id" | runjq -r '.job.reason')
     curl_output=$(curl "${curl_args[@]}" -s -w "%{http_code}" "$testurl/file/autoinst-log.txt" -o "$out")
     # combine both the reason and autoinst-log.txt to check known issues
     # against even in case when autoinst-log.txt is missing the details, e.g.
@@ -172,7 +172,7 @@ print_summary() {
 
 main() {
     [ "$dry_run" = "1" ] && client_prefix="echo"
-    client_call="${client_call:-"$client_prefix openqa-cli api --host $host_url"}"
+    client_call="${client_call:-"$client_prefix openqa-cli api --header 'User-Agent: openqa-label-known-issues (https://github.com/os-autoinst/scripts)' --host $host_url"}"
     issues=$(runcurl "${curl_args[@]}" -s "$issue_query" | runjq -r '.issues | .[] | (.id,.subject)')
     # shellcheck disable=SC2013
     for testurl in $(cat - | sed 's/ .*$//'); do


### PR DESCRIPTION
This way we have more information in our logs (if the scripts are making
any requests, or how many)

Related issue: https://progress.opensuse.org/issues/96959