### PR TITLE
Fix client_call variable

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -19,7 +19,7 @@ exclude_name_regex="${exclude_name_regex:-":investigate:"}"
 exclude_no_group="${exclude_no_group:-"true"}"
 # exclude_group_regex checks a combined string "<parent job group name> / <job group name>"
 exclude_group_regex="${exclude_group_regex:-"Development.*/ "}"
-client_args="--host $host_url"
+client_args=(--host "$host_url")
 jq_output_limit="${jq_output_limit:-15}"
 curl_args=(--user-agent "openqa-investigate")
 echoerr() { echo "$@" >&2; }
@@ -31,7 +31,7 @@ clone() {
     id=${2:?"Need 'id'"}
     name_suffix=${3+":$3"}
     refspec=${4+$4}
-    job_data=$($client_call --json jobs/"$id")
+    job_data=$("${client_call[@]}" --json jobs/"$id")
     # shellcheck disable=SC2181
     [[ $? != 0 ]] && echoerr "unable to query job data for $id: $job_data" && return 1
     unsupported_cluster_jobs=$(echo "$job_data" | runjq -r '(.job.children["Parallel"] | length) + (.job.parents["Parallel"] | length) + (.job.children["Directly chained"] | length) + (.job.parents["Directly chained"] | length)') || return $?
@@ -57,7 +57,7 @@ clone() {
     url=$(echo "$out" | sed -n 's/^Created job.*-> //p')
     echo "* **$name**: $url"
     clone_id=${out/:*/}; clone_id=${clone_id/*#/}
-    $client_call --json --data "{\"priority\": $((base_prio + prio_add))}" -X PUT jobs/"$clone_id" >/dev/null
+    "${client_call[@]}" --json --data "{\"priority\": $((base_prio + prio_add))}" -X PUT jobs/"$clone_id" >/dev/null
 }
 
 trigger_jobs() {
@@ -129,7 +129,7 @@ trigger_jobs() {
 investigate() {
     id="${1##*/}"
 
-    job_data=$($client_call --json jobs/"$id")
+    job_data=$("${client_call[@]}" --json jobs/"$id")
     # shellcheck disable=SC2181
     [[ $? != 0 ]] && echoerr "unable to query job data for $id: $job_data" && return 1
     old_name="$(echo "$job_data" | runjq -r '.job.test')" || return $?
@@ -148,13 +148,17 @@ investigate() {
     comment="Automatic investigation jobs:
 
 $out"
-    $client_call -X POST jobs/"$id"/comments text="$comment"
+    "${client_call[@]}" -X POST jobs/"$id"/comments text="$comment"
 }
 
 main() {
     client_prefix=''
     [ "$dry_run" = "1" ] && client_prefix="echo"
-    client_call="${client_call:-"$client_prefix openqa-cli api --header 'User-Agent: openqa-investigate (https://github.com/os-autoinst/scripts)' $client_args"}"
+    set +u
+    if [[ -z "$client_call" ]]; then
+        client_call=("$client_prefix" openqa-cli api --header 'User-Agent: openqa-investigate (https://github.com/os-autoinst/scripts)' "${client_args[@]}")
+    fi
+    set -u
     clone_call="${clone_call:-"$client_prefix openqa-clone-job --skip-chained-deps --within-instance"}"
     error_count=0
     # shellcheck disable=SC2013

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -45,9 +45,9 @@ label_on_issue() {
             return $rc
         fi
     fi
-    $client_call -X POST jobs/"$id"/comments text="$comment"
+    "${client_call[@]}" -X POST jobs/"$id"/comments text="$comment"
     if [ "$restart" = "1" ]; then
-        $client_call -X POST jobs/"$id"/restart
+        "${client_call[@]}" -X POST jobs/"$id"/restart
     fi
 }
 
@@ -84,8 +84,8 @@ handle_unreachable_or_no_log() {
         return
     fi
     if hxnormalize -x "$out" | hxselect -s '\n' -c '.links_a .resborder' | grep -qPzo '(?s)Gru job failed.*connection error.*Inactivity timeout'; then
-        $client_call -X POST jobs/"$id"/comments text='poo#62456 test incompletes after failing in GRU download task on "Inactivity timeout" with no logs'
-        $client_call -X POST jobs/"$id"/restart
+        "${client_call[@]}" -X POST jobs/"$id"/comments text='poo#62456 test incompletes after failing in GRU download task on "Inactivity timeout" with no logs'
+        "${client_call[@]}" -X POST jobs/"$id"/restart
         return
     fi
 }
@@ -137,7 +137,7 @@ investigate_issue() {
     local id="${1##*/}"
     local reason
     local curl_output
-    reason=$($client_call jobs/"$id" | runjq -r '.job.reason')
+    reason=$("${client_call[@]}" jobs/"$id" | runjq -r '.job.reason')
     curl_output=$(curl "${curl_args[@]}" -s -w "%{http_code}" "$testurl/file/autoinst-log.txt" -o "$out")
     # combine both the reason and autoinst-log.txt to check known issues
     # against even in case when autoinst-log.txt is missing the details, e.g.
@@ -172,7 +172,9 @@ print_summary() {
 
 main() {
     [ "$dry_run" = "1" ] && client_prefix="echo"
-    client_call="${client_call:-"$client_prefix openqa-cli api --header 'User-Agent: openqa-label-known-issues (https://github.com/os-autoinst/scripts)' --host $host_url"}"
+    if [[ -z "$client_call" ]]; then
+        client_call=("$client_prefix" openqa-cli api --header 'User-Agent: openqa-label-known-issues (https://github.com/os-autoinst/scripts)' --host "$host_url")
+    fi
     issues=$(runcurl "${curl_args[@]}" -s "$issue_query" | runjq -r '.issues | .[] | (.id,.subject)')
     # shellcheck disable=SC2013
     for testurl in $(cat - | sed 's/ .*$//'); do


### PR DESCRIPTION
Now that there is a space in one of the arguments, we need to use bash arrays.

It led to urls like:
    /api/v1/openqa-label-known-issues

Fixes bug introduced in #105 