### PR TITLE
Fix client_call/openqa-cli again

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -19,7 +19,7 @@ exclude_name_regex="${exclude_name_regex:-":investigate:"}"
 exclude_no_group="${exclude_no_group:-"true"}"
 # exclude_group_regex checks a combined string "<parent job group name> / <job group name>"
 exclude_group_regex="${exclude_group_regex:-"Development.*/ "}"
-client_args=(--host "$host_url")
+client_args=(api --header 'User-Agent: openqa-investigate (https://github.com/os-autoinst/scripts)' --host "$host_url")
 jq_output_limit="${jq_output_limit:-15}"
 curl_args=(--user-agent "openqa-investigate")
 echoerr() { echo "$@" >&2; }
@@ -31,7 +31,7 @@ clone() {
     id=${2:?"Need 'id'"}
     name_suffix=${3+":$3"}
     refspec=${4+$4}
-    job_data=$("${client_call[@]}" --json jobs/"$id")
+    job_data=$(openqa-cli "${client_args[@]}" --json jobs/"$id")
     # shellcheck disable=SC2181
     [[ $? != 0 ]] && echoerr "unable to query job data for $id: $job_data" && return 1
     unsupported_cluster_jobs=$(echo "$job_data" | runjq -r '(.job.children["Parallel"] | length) + (.job.parents["Parallel"] | length) + (.job.children["Directly chained"] | length) + (.job.parents["Directly chained"] | length)') || return $?
@@ -129,7 +129,7 @@ trigger_jobs() {
 investigate() {
     id="${1##*/}"
 
-    job_data=$("${client_call[@]}" --json jobs/"$id")
+    job_data=$(openqa-cli "${client_args[@]}" --json jobs/"$id")
     # shellcheck disable=SC2181
     [[ $? != 0 ]] && echoerr "unable to query job data for $id: $job_data" && return 1
     old_name="$(echo "$job_data" | runjq -r '.job.test')" || return $?
@@ -156,7 +156,10 @@ main() {
     [ "$dry_run" = "1" ] && client_prefix="echo"
     set +u
     if [[ -z "$client_call" ]]; then
-        client_call=("$client_prefix" openqa-cli api --header 'User-Agent: openqa-investigate (https://github.com/os-autoinst/scripts)' "${client_args[@]}")
+        client_call=(openqa-cli "${client_args[@]}")
+        if [[ -n "$client_prefix" ]]; then
+            client_call=("$client_prefix" "${client_call[@]}")
+        fi
     fi
     set -u
     clone_call="${clone_call:-"$client_prefix openqa-clone-job --skip-chained-deps --within-instance"}"

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -19,6 +19,7 @@ reason_min_length="${reason_min_length:-"8"}"
 grep_timeout="${grep_timeout:-5}"
 to_review=()
 curl_args=(--user-agent "openqa-label-known-issues")
+client_args=(api --header 'User-Agent: openqa-label-known-issues (https://github.com/os-autoinst/scripts)' --host "$host_url")
 
 out="${REPORT_FILE:-$(mktemp)}"
 trap 'test "$KEEP_REPORT_FILE" == "1" || rm "$out"' EXIT
@@ -137,7 +138,7 @@ investigate_issue() {
     local id="${1##*/}"
     local reason
     local curl_output
-    reason=$("${client_call[@]}" jobs/"$id" | runjq -r '.job.reason')
+    reason=$(openqa-cli "${client_args[@]}" jobs/"$id" | runjq -r '.job.reason')
     curl_output=$(curl "${curl_args[@]}" -s -w "%{http_code}" "$testurl/file/autoinst-log.txt" -o "$out")
     # combine both the reason and autoinst-log.txt to check known issues
     # against even in case when autoinst-log.txt is missing the details, e.g.
@@ -173,7 +174,10 @@ print_summary() {
 main() {
     [ "$dry_run" = "1" ] && client_prefix="echo"
     if [[ -z "$client_call" ]]; then
-        client_call=("$client_prefix" openqa-cli api --header 'User-Agent: openqa-label-known-issues (https://github.com/os-autoinst/scripts)' --host "$host_url")
+        client_call=(openqa-cli "${client_args[@]}")
+        if [[ -n "$client_prefix" ]]; then
+            client_call=("$client_prefix" "${client_call[@]}")
+        fi
     fi
     issues=$(runcurl "${curl_args[@]}" -s "$issue_query" | runjq -r '.issues | .[] | (.id,.subject)')
     # shellcheck disable=SC2013


### PR DESCRIPTION
Now dry_run should work again, and all common args are now in client_args
in *both* scripts.

Another fix for #105 and #106

This time I tested it on osd in normal **and** dry_run mode.