### PR TITLE
Add matrix chat notifications to Actions

### DIFF
--- a/.github/workflows/backlog.yml
+++ b/.github/workflows/backlog.yml
@@ -15,7 +15,22 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install curl jq
       - name: Check SUSE QE Tools WIP-Limit
+        id: wip-limit
         run: sh -ex backlog-check-wip-limit
+      - name: Check step status
+        id: step_check
+        if: always()
+        continue-on-error: true
+        run: |
+          . steps.sh ${{github.job}} ${{github.repository}} ${{github.run_id}}
+        env:
+          step_context: ${{ toJson(steps) }}
+      - name: send message
+        if: (success() || failure()) && steps.step_check.outcome == 'failure'
+        continue-on-error: true
+        run: |
+          . chat_notify.sh "matrix.org" "${{steps.step_check.outputs.result}}" \
+            "${{secrets.MATRIX_ACCESS_TOKEN}}" "${{secrets.MATRIX_ROOM_ID}}"
   set_suse_qe_tools_due_dates:
     name: Set SUSE QE Tools due dates
     runs-on: ubuntu-latest

--- a/chat_notify.sh
+++ b/chat_notify.sh
@@ -1,0 +1,15 @@
+send_message() {
+  out="$(curl -XPOST -d "$1" "https://$2/_matrix/client/r0/rooms/$3/send/m.room.message?access_token=$4")"
+  if [ "$(echo "$out" | jq .errcode)" = "null" ]; then
+    echo "[+] Message sent!"
+  else
+    echo '[!] Something went wrong sending the message'
+    echo "$out" | jq '.error'
+  fi
+}
+
+server=$1
+body='{"msgtype": "m.text", "body": "'$2'", "format": "org.matrix.custom.html", "formatted_body": "'$2'"}'
+access_token=$3
+room_id=$4
+send_message "$body" "$server" "$room_id" "$access_token"

--- a/steps.sh
+++ b/steps.sh
@@ -1,0 +1,38 @@
+steps="${step_context}"
+job=$1
+repo_url="https://github.com/$2"
+run_url="https://github.com/$2/actions/runs/$3"
+sed_c='s/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g'
+results=""
+if [ -z "$steps" ]
+then
+  exit 0
+else
+  for k in $(jq -c 'keys[]' <<< "$steps"); do
+    outcome="$(jq -c ".${k}.outcome" <<< "$steps")"
+    if [[ $outcome != \"success\" ]]
+    then
+      if [ -z "$results" ]
+      then
+        repo_url="$(sed "$sed_c" <<< "$repo_url")"
+        repo="$(sed "$sed_c" <<< "$repo")"
+        results="<p><b>There are failures in the GitHub Actions pipeline for repo"
+        results="${results}<a href='${repo_url}'>${2}</a></b></p>"
+        results="${results}<table><tr><th>Job</th><th>Step</th><th>State</th></tr>"
+      fi
+      pipeline="$(sed -e 's/^"//' -e 's/"$//' <<<"$k")"
+      pipeline="$(sed "$sed_c" <<< "$pipeline")"
+      outcome="$(sed -e 's/^"//' -e 's/"$//' <<<"$outcome")"
+      run_url="$(sed "$sed_c" <<< "$run_url")"
+      job="$(sed "$sed_c" <<< "$job")"
+      results="${results}<tr><td><a href='${run_url}'>${job}</td><td>${pipeline}</td><td>${outcome}</td></tr>"
+    fi
+    if [ -n "$results" ]; then
+      results="${results}</table>"
+    else
+      exit 0
+    fi
+  done
+fi
+echo "::set-output name=result::${results}"
+exit 1


### PR DESCRIPTION
Add matrix chat notifications for the `check-wip-limits` step of the Github Actions workflow.

The notification is html-encoded and sent on the occasion the `check-wip-limits` step fails. It contains information and links about the failing steps.

When the steps `Check step status` and `send message` are applied at the end of any workflow job, it will automatically send a notification for all steps that failed in that job (the code can be copied and pasted asis, without the need for any changes specific for that job or steps).

This takes into account only steps that have an id, so they appear in the `steps` context.

Requirements:
secrets.MATRIX_ACCESS_TOKEN: a user access token (for the user sending the message)
secrets.MATRIX_ROOM_ID: the room id of the room to send the message to