### PR TITLE
Do not consider non-existing assets when finding latest published TW image

### DIFF
--- a/trigger-openqa_in_openqa
+++ b/trigger-openqa_in_openqa
@@ -37,7 +37,7 @@ find_latest_published_tumbleweed_image() {
     qcow=null
     for latest_published_tw_build in $latest_published_tw_builds; do
         qcow=$(${openqa_cli} api --host "${tw_openqa_host}" assets \
-            | jq -r "[.assets[] | select(.name | test(\"Tumbleweed-$arch-$latest_published_tw_build-Tumbleweed\\\\@$machine.qcow\"))] | .[0] | .name")
+            | jq -r "[.assets[] | select(.name | test(\"Tumbleweed-$arch-$latest_published_tw_build-Tumbleweed\\\\@$machine.qcow\")) | select(.size != null)] | .[0] | .name")
         # This published build has an image available
         if [[ "$qcow" != "null" ]]; then
             break


### PR DESCRIPTION
After https://github.com/os-autoinst/openQA/pull/4136 also non-existing
assets can be returned which can distinguished by a size of `null`.