### PR TITLE
openqa-investigate: Add verbose output of clone result

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -150,6 +150,7 @@ investigate() {
     # have more, ambiguous potential changes that we need to bisect on
 
     out=$(trigger_jobs "$id" "${@:2}")
+    $verbose && echo "$0, id: '$id', out: '$out'"
     [[ $out ]] || return 0
     comment="Automatic investigation jobs:
 


### PR DESCRIPTION
This is what I get locally:

```
/openqa-investigate, id: '7275485', out: '* **online_slehpc15sp3_pscc_basesys-desk-dev-hpc-python2-srv-wsm_def_full_zypp_tm:investigate:retry**: https://openqa.suse.de/t7281050
* **online_slehpc15sp3_pscc_basesys-desk-dev-hpc-python2-srv-wsm_def_full_zypp_tm:investigate:last_good_tests:3a265afc6fc7c1f1ef3e6147631ee5fad9dfc81b**: https://openqa.suse.de/t7281051
* **online_slehpc15sp3_pscc_basesys-desk-dev-hpc-python2-srv-wsm_def_full_zypp_tm:investigate:last_good_build:31.2**: https://openqa.suse.de/t7281053
* **online_slehpc15sp3_pscc_basesys-desk-dev-hpc-python2-srv-wsm_def_full_zypp_tm:investigate:last_good_tests_and_build:3a265afc6fc7c1f1ef3e6147631ee5fad9dfc81b+31.2**: https://openqa.suse.de/t7281054'
{"id":391528}
```