### PR TITLE
openqa-investigate: Fix "arg does not match" errors

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -46,7 +46,7 @@ clone() {
         repo=${casedir:-'https://github.com/os-autoinst/os-autoinst-distri-opensuse.git'}
         clone_settings+=("CASEDIR=${repo%#*}#${refspec}")
     fi
-    clone_settings+=("${@:4}")
+    [[ -n ${*:5} ]] && clone_settings+=("${@:5}")
     # clear "PUBLISH_" settings to avoid overriding production assets
     # shellcheck disable=SC2207
     clone_settings+=($(echo "$job_data" | runjq -r '.job.settings | keys[] | select (startswith("PUBLISH_")) | . + "="')) || return $?

--- a/openqa-investigate
+++ b/openqa-investigate
@@ -137,7 +137,13 @@ investigate() {
         [[ ! "$old_name" =~ investigate:retry$ ]] && echo "Job is ':investigate:' already, skipping investigation" && return 0
         investigate_origin="$(echo "$job_data" | runjq -r '.job.settings.OPENQA_INVESTIGATE_ORIGIN')" || return 1
         origin_job_id=${investigate_origin#$host_url/t}
-        "${client_call[@]}" -X POST jobs/"$origin_job_id"/comments text="Investigate retry job: $host_url/t$id failed, likely not a sporadic test"
+        # meanwhile the original job might have been deleted already, handle
+        # gracefully
+        out=$("${client_call[@]}" -X POST jobs/"$origin_job_id"/comments text="Investigate retry job: $host_url/t$id failed, likely not a sporadic test" 2>/dev/null) || \
+            if [[ $(echo "$out" | runjq .error_status) != "404" ]]; then
+                echo "Unexpected error encountered when posting comments: '$out'"
+                return 2
+            fi
         return 0
     fi
     [[ "$old_name" =~ $exclude_name_regex ]] && echo "Job name '$old_name' matches \$exclude_name_regex '$exclude_name_regex', skipping investigation" && return 0


### PR DESCRIPTION
We observed in the log of openqa-gru that openqa-investigate often
triggers warnings like:

```
arg '3a265afc6fc7c1f1ef3e6147631ee5fad9dfc81b' does not match at /usr/share/openqa/script/../lib/OpenQA/Script/CloneJob.pm line 59
arg '' does not match at /usr/share/openqa/script/../lib/OpenQA/Script/CloneJob.pm line 59
```

in the two variants, etiher with what looks like a git hash as well as
an empty string `''` that is passed to openqa-clone-job which expects
key=value pairs and here instead receives a bare parameter which has no
meaning.

The first problem was introduced in e84a719 which caused the empty `''`
to be passed to openqa-clone-job. This is fixed by only supplying the
parameters to openqa-clone-job if the argument list is non-empty. The
second problem was introduced in 2e19896 which added another parameter
without incrementing the index of the first unnamed parameter. This is
fixed by replacing `@:4` with `@:5`.

Tested locally with various combinations of dry-run and finally verified
with a command:

```
echo https://openqa.suse.de/tests/7275485 | host=openqa.suse.de verbose=true ./openqa-investigate FOO=bar| less 2>&1
```

and deleting the generated openQA jobs for cleanup afterwards.

The relevant output of the above command with a custom output of the generated
openqa-clone-job command:

```
CLONE:  openqa-clone-job --skip-chained-deps --within-instance https://openqa.suse.de/tests/7275485 TEST=online_slehpc15sp3_pscc_basesys-desk-dev-hpc-python2-srv-wsm_def_full_zypp_tm:investigate:retry _GROUP_ID=0 BUILD= FOO=bar OPENQA_INVESTIGATE_ORIGIN=https://openqa.suse.de/t7275485
* **online_slehpc15sp3_pscc_basesys-desk-dev-hpc-python2-srv-wsm_def_full_zypp_tm:investigate:retry**: https://openqa.suse.de/t7282667
CLONE:  openqa-clone-job --skip-chained-deps --within-instance https://openqa.suse.de/tests/7275485 TEST=online_slehpc15sp3_pscc_basesys-desk-dev-hpc-python2-srv-wsm_def_full_zypp_tm:investigate:last_good_tests:3a265afc6fc7c1f1ef3e6147631ee5fad9dfc81b _GROUP_ID=0 BUILD= CASEDIR=https://github.com/os-autoinst/os-autoinst-distri-opensuse.git#3a265afc6fc7c1f1ef3e6147631ee5fad9dfc81b FOO=bar OPENQA_INVESTIGATE_ORIGIN=https://openqa.suse.de/t7275485
* **online_slehpc15sp3_pscc_basesys-desk-dev-hpc-python2-srv-wsm_def_full_zypp_tm:investigate:last_good_tests:3a265afc6fc7c1f1ef3e6147631ee5fad9dfc81b**: https://openqa.suse.de/t7282668
CLONE:  openqa-clone-job --skip-chained-deps --within-instance https://openqa.suse.de/tests/7012273 TEST=online_slehpc15sp3_pscc_basesys-desk-dev-hpc-python2-srv-wsm_def_full_zypp_tm:investigate:last_good_build:31.2 _GROUP_ID=0 BUILD= FOO=bar OPENQA_INVESTIGATE_ORIGIN=https://openqa.suse.de/t7275485
* **online_slehpc15sp3_pscc_basesys-desk-dev-hpc-python2-srv-wsm_def_full_zypp_tm:investigate:last_good_build:31.2**: https://openqa.suse.de/t7282669
CLONE:  openqa-clone-job --skip-chained-deps --within-instance https://openqa.suse.de/tests/7012273 TEST=online_slehpc15sp3_pscc_basesys-desk-dev-hpc-python2-srv-wsm_def_full_zypp_tm:investigate:last_good_tests_and_build:3a265afc6fc7c1f1ef3e6147631ee5fad9dfc81b+31.2 _GROUP_ID=0 BUILD= CASEDIR=https://github.com/os-autoinst/os-autoinst-distri-opensuse.git#3a265afc6fc7c1f1ef3e6147631ee5fad9dfc81b FOO=bar OPENQA_INVESTIGATE_ORIGIN=https://openqa.suse.de/t7275485
* **online_slehpc15sp3_pscc_basesys-desk-dev-hpc-python2-srv-wsm_def_full_zypp_tm:investigate:last_good_tests_and_build:3a265afc6fc7c1f1ef3e6147631ee5fad9dfc81b+31.2**: https://openqa.suse.de/t7282670
```

observe that there is no parameter `''` passed anymore and the additional
key-value pair `FOO=bar` is still passed to all correctly triggered jobs.