### PR TITLE
Improve error handling

### DIFF
--- a/_common
+++ b/_common
@@ -3,6 +3,13 @@
 # Common shell script snippets to be used when interacting with openQA
 # instances, for example over openqa-cli.
 
+error-handler() {
+    local line=$1
+    # shellcheck disable=SC2207
+    local c=($(caller))
+    echo "${c[1]}: ERROR: line $line" >&2
+}
+
 # From openqa-cli JSON output filter and return the id/ids of jobs,
 # for example from a query to the 'jobs get' route or the result string of a
 # 'jobs post' or 'isos post'

--- a/openqa-investigate
+++ b/openqa-investigate
@@ -24,7 +24,6 @@ jq_output_limit="${jq_output_limit:-15}"
 curl_args=(--user-agent "openqa-investigate")
 echoerr() { echo "$@" >&2; }
 
-
 clone() {
     local origin id name_suffix refspec job_data unsupported_cluster_jobs name base_prio clone_settings casedir repo out url clone_id
     origin=${1:?"Need 'origin'"}
@@ -141,7 +140,7 @@ investigate() {
         # gracefully
         out=$("${client_call[@]}" -X POST jobs/"$origin_job_id"/comments text="Investigate retry job: $host_url/t$id failed, likely not a sporadic test" 2>/dev/null) || \
             if [[ $(echo "$out" | runjq .error_status) != "404" ]]; then
-                echo "Unexpected error encountered when posting comments: '$out'"
+                echoerr "Unexpected error encountered when posting comments: '$out'"
                 return 2
             fi
         return 0

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -3,7 +3,7 @@
 # Usage
 # echo https://openqahost/tests/1234 | openqa-label-known-issues
 
-set -o pipefail
+set -o pipefail -o errtrace
 
 # shellcheck source=/dev/null
 . "$(dirname "$0")"/_common
@@ -22,6 +22,7 @@ curl_args=(--user-agent "openqa-label-known-issues")
 client_args=(api --header 'User-Agent: openqa-label-known-issues (https://github.com/os-autoinst/scripts)' --host "$host_url")
 
 out="${REPORT_FILE:-$(mktemp)}"
+trap 'error-handler "$LINENO"' ERR
 trap 'test "$KEEP_REPORT_FILE" == "1" || rm "$out"' EXIT
 
 echoerr() { echo "$@" >&2; }
@@ -38,11 +39,11 @@ label_on_issue() {
         if (( "$rc" == 1 )); then
             return 1
         elif (( "$rc" == 124 )); then
-            echo "grep was killed, possibly timed out: cmd=>grep $grep_opts '$search_term' '$out'< output='$grep_output'"
+            echoerr "grep was killed, possibly timed out: cmd=>grep $grep_opts '$search_term' '$out'< output='$grep_output'"
             return $rc
         elif (( "$rc" != 0 )); then
             # unexpected error, e.g. "exceeded PCRE's backtracking limit"
-            echo "grep failed: cmd=>grep $grep_opts '$search_term' '$out'< output='$grep_output'"
+            echoerr "grep failed: cmd=>grep $grep_opts '$search_term' '$out'< output='$grep_output'"
             return $rc
         fi
     fi


### PR DESCRIPTION
Add a trap call to make sure we always get a message on stderr in which script
and which line the error happened. We sometimes get a non-zero exit code but
don't know where the error happened.

I didn't add the trap to openqa-investigate, because practically the whole
code is wrapped in a conditional (`investigate || error_count++`), and
`-e` (and trap) is disabled by that.

Also turned several echos into echoerr as it was supposed to land in our
log, not in stdout.

Issue: https://progress.opensuse.org/issues/99519