### PR TITLE
Fix mergify configuration for GHA

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,7 @@ pull_request_rules:
       - "#review-requested=0"
       - -label~=^acceptance-tests-needed|not-ready
       - base=master
-      - "status-success=ci / test (pull_request)"
+      - "status-success~=test"
     actions:
       merge:
         method: merge
@@ -17,7 +17,7 @@ pull_request_rules:
       - -label~=^acceptance-tests-needed|not-ready
       - "label=merge-fast"
       - base=master
-      - "status-success=ci / test (pull_request)"
+      - "status-success~=test"
     actions:
       merge:
         method: merge


### PR DESCRIPTION
Apparently as observed in
https://github.com/os-autoinst/scripts/pull/116/checks?check_run_id=3827461228
mergify never found the results from github actions.

According to https://docs.mergify.io/conditions/#github-actions only the
job name is used, i.e. only "test" in our case.