### PR TITLE
Add force_result feature and automatic tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Static checks, unit- and integration tests
+      - name: unit- and integration tests
+        run: |
+         make test-unit
+
+  style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Static checks
         run: |
          sudo apt-get install yamllint shellcheck
-         make test
+         make checkstyle

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/test-more-bash/

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,7 @@ pull_request_rules:
       - -label~=^acceptance-tests-needed|not-ready
       - base=master
       - "status-success~=test"
+      - "status-success~=style"
     actions:
       merge:
         method: merge
@@ -18,6 +19,7 @@ pull_request_rules:
       - "label=merge-fast"
       - base=master
       - "status-success~=test"
+      - "status-success~=style"
     actions:
       merge:
         method: merge

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,11 @@ all:
 test: checkstyle test-unit
 
 .PHONY: test-unit
-test-unit:
+test-unit: test-more-bash
 	prove -r test/
+
+test-more-bash:
+	git clone https://github.com/ingydotnet/test-more-bash.git --depth 1 -b 0.0.5
 
 .PHONY: test-online
 test-online:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@
 all:
 
 .PHONY: test
-test: checkstyle
+test: checkstyle test-unit
+
+.PHONY: test-unit
+test-unit:
+	prove -r test/
 
 .PHONY: test-online
 test-online:

--- a/README.md
+++ b/README.md
@@ -17,18 +17,32 @@ progress.opensuse.org within https://progress.opensuse.org/projects/openqav3
 or any subproject of it, commonly
 https://progress.opensuse.org/projects/openqatests/ , openQA jobs can be
 automatically labeled with the corresponding ticket and optionally retriggered
-where it makes sense. For this the subject line of a ticket must include text
-following the format `auto_review:"<search_term>"[:retry]` with
-`<search_term>` being the perl extended regex to search for and an optional
-boolean switch `:retry` after the quoted search term to instruct for
-retriggering the according openQA job. Example: `auto_review:"error 42
-found":retry`. The search terms are crosschecked against the logfiles and
+where it makes sense.
+
+For this the subject line of a ticket must include text following the format
+`auto_review:"<search_term>"[:retry][:force_result:<result>]`
+
+* `<search_term>`: the perl extended regex to search for
+* `:retry`: (optional) boolean switch after the quoted search term to instruct
+   for retriggering the according openQA job.
+* `:force_result:<result>`: (optional) give the job a special label which forces the result
+   to be the given string
+
+Examples:
+* `auto_review:"error 42 found"`.
+* `auto_review:"error 42 found":retry`.
+* `auto_review:"error 42 found":force_result:softfailed`.
+* `auto_review:"error 42 found":retry:force_result:softfailed`.
+
+The search terms are crosschecked against the logfiles and
 "reason" field of the openQA jobs. A multi-line search is possible, for
-example using the `<search_term>` `(?s)something to match earlier.*something
-to match some lines further down`. Other double quotes in the subject line
-than around the search term should be avoided. Also be careful to not specify
-a too generic search term to prevent false matches of job failures unrelated
-to the specified ticket.
+example using the `<search_term>`
+
+  `(?s)something to match earlier.*something to match some lines further down`
+
+Other double quotes in the subject line than around the search term should be
+avoided. Also be careful to not specify a too generic search term to prevent
+false matches of job failures unrelated to the specified ticket.
 
 * [openqa-monitor-incompletes](https://github.com/os-autoinst/scripts/blob/master/openqa-monitor-incompletes)
   queries the database of an openQA instance (ssh access is necessary) and
@@ -120,6 +134,22 @@ If this is too much hassle for you feel free to provide incomplete pull
 requests for consideration or create an issue with a code change proposal.
 
 ### Local testing
+
+#### Functional testing
+
+This is done with the [Test::More bash
+library](https://github.com/ingydotnet/test-more-bash). It is included
+into this repository via a
+[git-subrepo](https://github.com/ingydotnet/git-subrepo) under `external/`.
+
+
+    # only a few functions from openqa-label-known-issues so far
+    make test
+
+#### Style checks
+
+    make checkstyle
+
 #### openqa-label-known-issues
 Generate a list of recent incomplete jobs of your local openQA instance. Here's an example using `psql`:
 

--- a/README.md
+++ b/README.md
@@ -138,9 +138,8 @@ requests for consideration or create an issue with a code change proposal.
 #### Functional testing
 
 This is done with the [Test::More bash
-library](https://github.com/ingydotnet/test-more-bash). It is included
-into this repository via a
-[git-subrepo](https://github.com/ingydotnet/git-subrepo) under `external/`.
+library](https://github.com/ingydotnet/test-more-bash).
+It will be automatically cloned.
 
 
     # only a few functions from openqa-label-known-issues so far

--- a/_common
+++ b/_common
@@ -3,6 +3,10 @@
 # Common shell script snippets to be used when interacting with openQA
 # instances, for example over openqa-cli.
 
+client_call=()
+
+warn() { echo "$@" >&2; }
+
 error-handler() {
     local line=$1
     # shellcheck disable=SC2207
@@ -51,3 +55,38 @@ runcurl() {
     echo "$body"
 }
 
+comment_on_job() {
+    local id=$1 comment=$2 force_result=${3:-''}
+    if [[ -n $force_result ]]; then
+        comment="label:force_result:$force_result:$comment"
+    fi
+    "${client_call[@]}" -X POST jobs/"$id"/comments text="$comment"
+}
+
+search_log() {
+    local id=$1 search_term=$2 out=$3 grep_timeout=${4:-5}
+    local rc=0 grep_output
+    local grep_opts="${grep_opts:-"-qPzo"}"
+    # shellcheck disable=SC2086
+    grep_output=$(timeout "$grep_timeout" grep $grep_opts "$search_term" "$out" 2>&1) || rc=$?
+    if [[ "$rc" == 1 ]]; then
+        return 1
+    elif [[ "$rc" == 124 ]]; then
+        warn "grep was killed, possibly timed out: cmd=>grep $grep_opts '$search_term' '$out'< output='$grep_output'"
+        return $rc
+    elif [[ "$rc" != 0 ]]; then
+        # unexpected error, e.g. "exceeded PCRE's backtracking limit"
+        warn "grep failed: cmd=>grep $grep_opts '$search_term' '$out'< output='$grep_output'"
+        return $rc
+    fi
+}
+
+label_on_issue() {
+    local id=$1 search_term=$2 label=$3 restart=${4:-''} force_result=${5:-''}
+    local out=${out:?}
+    search_log "$id" "$search_term" "$out" || return
+    comment_on_job "$id" "$label" "$force_result"
+    if [ "$restart" = "1" ]; then
+        "${client_call[@]}" -X POST jobs/"$id"/restart
+    fi
+}

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -27,28 +27,6 @@ trap 'test "$KEEP_REPORT_FILE" == "1" || rm "$out"' EXIT
 
 echoerr() { echo "$@" >&2; }
 
-label_on_issue() {
-    local id=$1 search_term=$2 comment=$3 restart=$4
-    local rc=0 grep_output
-    local grep_opts="${grep_opts:-"-qPzo"}"
-    # shellcheck disable=SC2086
-    grep_output=$(timeout "$grep_timeout" grep $grep_opts "$search_term" "$out" 2>&1) || rc=$?
-    if [[ "$rc" == 1 ]]; then
-        return 1
-    elif [[ "$rc" == 124 ]]; then
-        echoerr "grep was killed, possibly timed out: cmd=>grep $grep_opts '$search_term' '$out'< output='$grep_output'"
-        return $rc
-    elif [[ "$rc" != 0 ]]; then
-        # unexpected error, e.g. "exceeded PCRE's backtracking limit"
-        echoerr "grep failed: cmd=>grep $grep_opts '$search_term' '$out'< output='$grep_output'"
-        return $rc
-    fi
-    "${client_call[@]}" -X POST jobs/"$id"/comments text="$comment"
-    if [ "$restart" = "1" ]; then
-        "${client_call[@]}" -X POST jobs/"$id"/restart
-    fi
-}
-
 handle_unreachable_or_no_log() {
     local id=$1
     local testurl=$2
@@ -90,21 +68,23 @@ handle_unreachable_or_no_log() {
 
 label_on_issues_from_issue_tracker() {
     local id=$1
-    # query progress.o.o for all subjects with
-    # 'issue_marker:"<search_term>"[:retry]' with <search_term> being the
-    # perl extended regex to search for and an optional boolean switch
-    # ':retry' after the quoted search term to instruct for retriggering
-    # the according openQA job. The search terms are crosschecked against
-    # the logfiles of the openQA jobs against these issues.
-    #
-    # Detailed explanation:
-    # it is possible to search for issues with a subject search term, e.g.:
-    # curl -s "https://progress.opensuse.org/projects/openqav3/issues.json?subject=~merge%20keys" | jq '.issues | .[] | .id'
-    # this reads out all progress issues that have the search term included and
-    # splice each line with a call to label_on_issue
+    # Iterate over all progress issues that have the search term included
+    # 1. line: issue id
+    # 2. line: subject
     echo "$issues" | (while read -r issue; do
         read -r subject
-        after=${subject#*\"} && search=${after%\"*} && [[ ${#search} -ge $min_search_term ]] && label_on_issue "$id" "$search" "poo#$issue $subject" "${after//*\":retry*/1}" && break; done)
+        after=${subject#*\"}
+        search=${after%\"*}
+        force_result=''
+        label="poo#$issue $subject"
+        if [[ ${#search} -ge $min_search_term ]]; then
+            if [[ $after =~ :force_result:([a-z_]+) ]]; then
+                force_result=${BASH_REMATCH[1]}
+            fi
+            label_on_issue "$id" "$search" "$label" "${after//*\":retry*/1}" "$force_result" && break
+        fi
+        done
+    )
 }
 
 label_on_issues_without_tickets() {
@@ -176,6 +156,7 @@ main() {
             client_call=("$client_prefix" "${client_call[@]}")
         fi
     fi
+    # search for issues with a subject search term
     issues=$(runcurl "${curl_args[@]}" -s "$issue_query" | runjq -r '.issues | .[] | (.id,.subject)')
     # shellcheck disable=SC2013
     for testurl in $(cat - | sed 's/ .*$//'); do

--- a/test/01-label-known-issues.t
+++ b/test/01-label-known-issues.t
@@ -4,7 +4,7 @@ set -e
 
 dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
 
-TEST_MORE_PATH=$dir/../external/test-more-bash
+TEST_MORE_PATH=$dir/../test-more-bash
 BASHLIB="`
     find $TEST_MORE_PATH -type d |
     grep -E '/(bin|lib)$' |

--- a/test/01-label-known-issues.t
+++ b/test/01-label-known-issues.t
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -e
+
+dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
+
+TEST_MORE_PATH=$dir/../external/test-more-bash
+BASHLIB="`
+    find $TEST_MORE_PATH -type d |
+    grep -E '/(bin|lib)$' |
+    xargs -n1 printf "%s:"`"
+PATH=$BASHLIB$PATH
+
+source bash+ :std
+use Test::More
+plan tests 12
+
+source _common
+
+client_output=''
+mock-client() {
+    client_output+="client_call $@"$'\n'
+}
+
+nl=$'\n'
+client_call=(mock-client "${client_call[@]}")
+logfile1=$dir/data/01-os-autoinst.txt.1
+logfile2=$dir/data/01-os-autoinst.txt.2
+
+rc=0
+comment_on_job 123 Label || rc=$?
+is "$rc" 0 'successful comment_on_job'
+is "$client_output" "client_call -X POST jobs/123/comments text=Label$nl" 'comment_on_job works'
+
+rc=0
+search_log 123 'foo.*bar' "$logfile1" || rc=$?
+is "$rc" 0 'successful search_log'
+
+rc=0
+search_log 123 'foo.*bar' "$logfile2" || rc=$?
+is "$rc" 1 'failing search_log'
+
+rc=0
+output=$(search_log 123 'foo [z-a]' "$logfile2" 2>&1) || rc=$?
+is "$rc" 2 'search_log with invalid pattern'
+like "$output" 'range out of order in character class' 'correct error message'
+
+rc=0
+client_output=''
+out=$logfile1
+label_on_issue 123 'foo.*bar' Label 1 softfailed || rc=$?
+expected="client_call -X POST jobs/123/comments text=label:force_result:softfailed:Label
+client_call -X POST jobs/123/restart
+"
+is "$rc" 0 'successful label_on_issue'
+is "$client_output" "$expected" 'label_on_issue with restart and force_result'
+
+rc=0
+client_output=''
+out=$logfile1
+label_on_issue 123 'foo.*bar' Label || rc=$?
+expected="client_call -X POST jobs/123/comments text=Label
+"
+is "$rc" 0 'successful label_on_issue'
+is "$client_output" "$expected" 'label_on_issue with restart and force_result'
+
+rc=0
+client_output=''
+out=$logfile1
+label_on_issue 123 'foo bar' Label || rc=$?
+is "$rc" 1 'label_on_issue did not find search term'
+is "$client_output" "" 'label_on_issue with restart and force_result'
+

--- a/test/data/01-os-autoinst.txt.1
+++ b/test/data/01-os-autoinst.txt.1
@@ -1,0 +1,1 @@
+foo some text bar

--- a/test/data/01-os-autoinst.txt.2
+++ b/test/data/01-os-autoinst.txt.2
@@ -1,0 +1,1 @@
+some text bar


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/102374

Tested with:

* Replace the `issues=` line with:
```
    issues='102374
foo bar auto_review:"Test died: Machine didn.t shut down":retry:force_result:failed'
```
* Call
```
    echo https://openqa.opensuse.org/tests/1990037 | ./openqa-label-known-issues
```

I also added automatic test, so far for label_on_issue and functions below.

I added [Test::More bash](https://github.com/ingydotnet/test-more-bash) as a subrepo, see README