### PR TITLE
Disable force_result feature by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ where it makes sense.
 For this the subject line of a ticket must include text following the format
 `auto_review:"<search_term>"[:retry][:force_result:<result>]`
 
+Note that the `force_result` feature is disabled by default.
+
 * `<search_term>`: the perl extended regex to search for
 * `:retry`: (optional) boolean switch after the quoted search term to instruct
    for retriggering the according openQA job.

--- a/_common
+++ b/_common
@@ -3,6 +3,8 @@
 # Common shell script snippets to be used when interacting with openQA
 # instances, for example over openqa-cli.
 
+enable_force_result=${enable_force_result:-false}
+
 client_call=()
 
 warn() { echo "$@" >&2; }
@@ -57,7 +59,7 @@ runcurl() {
 
 comment_on_job() {
     local id=$1 comment=$2 force_result=${3:-''}
-    if [[ -n $force_result ]]; then
+    if $enable_force_result && [[ -n $force_result ]]; then
         comment="label:force_result:$force_result:$comment"
     fi
     "${client_call[@]}" -X POST jobs/"$id"/comments text="$comment"

--- a/test/01-label-known-issues.t
+++ b/test/01-label-known-issues.t
@@ -13,7 +13,7 @@ PATH=$BASHLIB$PATH
 
 source bash+ :std
 use Test::More
-plan tests 12
+plan tests 14
 
 source _common
 
@@ -49,6 +49,16 @@ rc=0
 client_output=''
 out=$logfile1
 label_on_issue 123 'foo.*bar' Label 1 softfailed || rc=$?
+expected="client_call -X POST jobs/123/comments text=Label
+client_call -X POST jobs/123/restart
+"
+is "$rc" 0 'successful label_on_issue'
+is "$client_output" "$expected" 'label_on_issue with restart and disabled force_result'
+
+rc=0
+client_output=''
+out=$logfile1
+enable_force_result=true label_on_issue 123 'foo.*bar' Label 1 softfailed || rc=$?
 expected="client_call -X POST jobs/123/comments text=label:force_result:softfailed:Label
 client_call -X POST jobs/123/restart
 "


### PR DESCRIPTION
Has to be enabled like this:

    enable_force_result=true openqa-label-known-issues

Issue: https://progress.opensuse.org/issues/104923