### PR TITLE
Improve openqa-trigger-bisect-jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: |
+          pip install --upgrade pip
+          pip install pytest mocker pytest-mock
+          python --version
+          pytest --version
       - name: unit- and integration tests
         run: |
          make test-unit

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /test-more-bash/
+/tests/__pycache__/
+/__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ test: checkstyle test-unit
 .PHONY: test-unit
 test-unit: test-more-bash
 	prove -r test/
+	py.test
 
 test-more-bash:
 	git clone https://github.com/ingydotnet/test-more-bash.git --depth 1 -b 0.0.5

--- a/openqa-trigger-bisect-jobs
+++ b/openqa-trigger-bisect-jobs
@@ -6,10 +6,13 @@ import re
 import requests
 import subprocess
 import sys
-from urllib.parse import urljoin, urlparse
+import json
+from urllib.parse import urljoin, urlparse, urlunparse
 
 logging.basicConfig()
 log = logging.getLogger(sys.argv[0] if __name__ == '__main__' else __name__)
+GOOD = '-'
+BAD = '+'
 
 
 class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
@@ -47,34 +50,49 @@ def call(cmds, dry_run=False):
 def openqa_clone(cmds, dry_run, default_opts=['--skip-chained-deps', '--within-instance'], default_cmds=['_GROUP=0']):
     return call(['openqa-clone-job'] + default_opts + cmds + default_cmds, dry_run)
 
+def fetch_url(url, request_type='text'):
+    try:
+        content = requests.get(url.geturl())
+        content.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        log.error("Error while fetching %s: %s"% (url.geturl(), str(e)))
+        raise(e)
+    raw = content.content
+    if request_type == 'json':
+        try:
+            content = content.json()
+        except json.decoder.JSONDecodeError as e:
+            log.error("Error while decoding JSON from %s -> >>%s<<: %s" % (url.geturl(), raw, str(e)))
+            raise(e)
+    return content
 
-def main():
-    args = parse_args()
-    investigation_url = urljoin(args.url + '/', 'investigation_ajax')
-    log.debug('Retrieving investigation info from %s' % investigation_url)
-    out = requests.get(investigation_url)
-    log.debug('Received investigation info: %s' % out)
-    investigation = out.json()
-    os_test_issues = [line for line in investigation['diff_to_last_good'].split('\n') if 'OS_TEST_ISSUES' in line]
-    if len(os_test_issues) != 2:
-        return
-    good, bad = [set(re.compile(': "([^"]*)",').search(line).group(1).split(',')) for line in os_test_issues]
-    removed, added = list(good - bad), list(bad - good)
-    log.debug('removed: %s, added: %s' % (removed, added))
+def main(args):
     parsed_url = urlparse(args.url)
-    test_url = urljoin(parsed_url.geturl(), '/api/v1/jobs/' + parsed_url.path.lstrip('/tests/'))
-    log.debug('Retrieving additional job data from %s' % test_url)
-    test_data = requests.get(test_url)
+    investigation_url = urlparse(urlunparse((parsed_url.scheme, parsed_url.netloc, parsed_url.path + '/investigation_ajax', '', '', '')))
+    log.debug('Retrieving investigation info from %s' % investigation_url.geturl())
+    investigation = fetch_url(investigation_url, request_type='json')
+    log.debug('Received investigation info: %s' % investigation)
+    changes = { GOOD: set(), BAD: set() }
+    for line in investigation['diff_to_last_good'].split('\n'):
+        search = re.compile('([+-]) +"OS_TEST_ISSUES" *: "([^"]*)",').search(line)
+        if search:
+            changes[search.group(1)] = set(search.group(2).split(','))
+    if not changes[BAD] or not changes[GOOD]:
+        return
+    removed, added = list(changes[GOOD] - changes[BAD]), list(changes[BAD] - changes[GOOD])
+    log.debug('removed: %s, added: %s' % (removed, added))
+    test_url = urlparse(urlunparse((parsed_url.scheme, parsed_url.netloc, '/api/v1/jobs/' + parsed_url.path.lstrip('/tests/'), '', '', '')))
+    log.debug('Retrieving additional job data from %s' % test_url.geturl())
+    test_data = fetch_url(test_url, request_type='json')
     log.debug('Received job data: %s' % test_data)
-    test = test_data.json()['job']['settings']['TEST']
+    test = test_data['job']['settings']['TEST']
     log.debug("Found test name '%s'" % test)
-    for issue in added:
+    for issue in sorted(added):
         log.info("Triggering one bisection job without issue '%s'" % issue)
-        new = ','.join(bad - set([issue]))
+        new = ','.join(sorted(list(changes[BAD] - set([issue]))))
         log.debug("New set of OS_TEST_ISSUES='%s'" % new)
         test_name = test + ':investigate:bisect_without_%s' % issue
         openqa_clone([args.url, 'OS_TEST_ISSUES=' + new, 'TEST=' + test_name, 'OPENQA_INVESTIGATE_ORIGIN=' + args.url], args.dry_run)
 
-
 if __name__ == '__main__':
-    main()
+    main(parse_args())

--- a/tests/data/python-requests/openqa.opensuse.org/api/v1/jobs/7848818
+++ b/tests/data/python-requests/openqa.opensuse.org/api/v1/jobs/7848818
@@ -1,0 +1,15 @@
+{
+  "job": {
+    "id": 7848818,
+    "priority": 50,
+    "result": "failed",
+    "settings": {
+      "OS_TEST_ISSUES": "21637,21770,21926,21954,22030,22077,22085,22192",
+      "TEST": "foo"
+    },
+    "state": "done",
+    "t_finished": "2021-12-14T02:51:41",
+    "t_started": "2021-12-14T02:36:22",
+    "test": "foo"
+  }
+}

--- a/tests/data/python-requests/openqa.opensuse.org/tests/123/investigation_ajax
+++ b/tests/data/python-requests/openqa.opensuse.org/tests/123/investigation_ajax
@@ -1,0 +1,1 @@
+] This is invalid JSON!

--- a/tests/data/python-requests/openqa.opensuse.org/tests/1234/investigation_ajax
+++ b/tests/data/python-requests/openqa.opensuse.org/tests/1234/investigation_ajax
@@ -1,0 +1,4 @@
+{
+  "diff_packages_to_last_good": "Diff of packages not available",
+  "diff_to_last_good": "+   \"OS_TEST_ISSUES\" : \"21637,21770,21926,21954,22030,22077,22085,22192\",\n-   \"WORKER_ID\" : 984,\n+   \"WORKER_ID\" : 1800,\n+   \"WORKER_INSTANCE\" : 18,"
+}

--- a/tests/data/python-requests/openqa.opensuse.org/tests/12345/investigation_ajax
+++ b/tests/data/python-requests/openqa.opensuse.org/tests/12345/investigation_ajax
@@ -1,0 +1,4 @@
+{
+  "diff_packages_to_last_good": "Diff of packages not available",
+  "diff_to_last_good": "-   \"OS_TEST_ISSUES\" : 12345,\n+   \"OS_TEST_ISSUES\" : \"21637,21770,21926,21954,22030,22077,22085,22192\",\n-   \"WORKER_ID\" : 984,\n+   \"WORKER_ID\" : 1800,\n+   \"WORKER_INSTANCE\" : 18,"
+}

--- a/tests/data/python-requests/openqa.opensuse.org/tests/7848818/investigation_ajax
+++ b/tests/data/python-requests/openqa.opensuse.org/tests/7848818/investigation_ajax
@@ -1,0 +1,4 @@
+{
+  "diff_packages_to_last_good": "Diff of packages not available",
+  "diff_to_last_good": "-   \"OS_TEST_ISSUES\" : \"21770,21926,21954,21956,22030,22077\",\n+   \"OS_TEST_ISSUES\" : \"21637,21770,21926,21954,22030,22077,22085,22192\",\n-   \"WORKER_ID\" : 984,\n+   \"WORKER_ID\" : 1800,\n+   \"WORKER_INSTANCE\" : 18,"
+}

--- a/tests/test_trigger_bisect_jobs.py
+++ b/tests/test_trigger_bisect_jobs.py
@@ -1,0 +1,93 @@
+"""
+tests for openqa-trigger-bisect-jobs
+"""
+
+import sys
+import os.path
+import pytest
+import importlib.machinery
+import requests
+import json
+
+from argparse import Namespace
+from unittest.mock import call, patch, Mock, MagicMock
+from urllib.parse import urljoin, urlparse
+
+rootpath = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+called_commands = []
+
+loader = importlib.machinery.SourceFileLoader('openqa', rootpath + '/openqa-trigger-bisect-jobs')
+openqa = loader.load_module()
+
+def args_factory():
+    args = Namespace()
+    args.dry_run = False
+    args.verbose = 1
+    return args
+
+def mocked_fetch_url(url, request_type='text'):
+    content = ''
+    if url.scheme in ["http", "https"]:
+        path = url.geturl()
+        path = path[len(url.scheme)+3:]
+        path = 'tests/data/python-requests/' + path
+        with open(path, "r") as request:
+            raw = content = request.read()
+    if request_type == 'json':
+        try:
+            content = json.loads(content)
+        except json.decoder.JSONDecodeError as e:
+            raise(e)
+    return content
+
+def mocked_call(cmds, dry_run=False):
+    called_commands.append(cmds)
+    return 1
+
+def test_trigger(mocker):
+    args = args_factory()
+    args.url = 'https://openqa.opensuse.org/tests/7848818'
+    mocker.patch('openqa.fetch_url', new=mocked_fetch_url)
+    mocker.patch('openqa.call', new=mocked_call)
+    openqa.main(args)
+    exp = [
+        ['openqa-clone-job', '--skip-chained-deps', '--within-instance', 'https://openqa.opensuse.org/tests/7848818', 'OS_TEST_ISSUES=21770,21926,21954,22030,22077,22085,22192', 'TEST=foo:investigate:bisect_without_21637', 'OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/tests/7848818', '_GROUP=0'],
+        ['openqa-clone-job', '--skip-chained-deps', '--within-instance', 'https://openqa.opensuse.org/tests/7848818', 'OS_TEST_ISSUES=21637,21770,21926,21954,22030,22077,22192', 'TEST=foo:investigate:bisect_without_22085', 'OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/tests/7848818', '_GROUP=0'],
+        ['openqa-clone-job', '--skip-chained-deps', '--within-instance', 'https://openqa.opensuse.org/tests/7848818', 'OS_TEST_ISSUES=21637,21770,21926,21954,22030,22077,22085', 'TEST=foo:investigate:bisect_without_22192', 'OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/tests/7848818', '_GROUP=0'],
+    ]
+    assert(called_commands[0] == exp[0])
+    assert(called_commands[1] == exp[1])
+    assert(called_commands[2] == exp[2])
+
+def test_problems(mocker):
+    args = args_factory()
+    mocker.patch('openqa.fetch_url', new=mocked_fetch_url)
+    mocker.patch('openqa.call', new=mocked_call)
+
+    args.url = 'http://openqa.opensuse.org/tests/123'
+    try:
+        openqa.main(args)
+        assert(False)
+    except json.decoder.JSONDecodeError as e:
+        assert(str(e) == 'Expecting value: line 1 column 1 (char 0)')
+
+    args.url = 'http://openqa.opensuse.org/tests/1234'
+    called_commands = []
+    openqa.main(args)
+    assert(len(called_commands) == 0)
+
+    args.url = 'http://openqa.opensuse.org/tests/12345'
+    called_commands = []
+    openqa.main(args)
+    assert(len(called_commands) == 0)
+
+def test_network_problems(mocker):
+    args = args_factory()
+    args.url = 'http://doesnotexist.openqa.opensuse.org/tests/12345'
+    called_commands = []
+    mocker.patch('openqa.call', new=mocked_call)
+    try:
+        openqa.main(args)
+        assert(False)
+    except requests.exceptions.ConnectionError as e:
+        assert(True)


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/107014

* Return early in case the job does not have (changed) OS_TEST_ISSUES settings
* Print informative error message in case of
  * Invalid JSON
  * Unsuccessful HTTP request
* Add tests

