### PR TITLE
Indent log excerpt

### DIFF
--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -105,10 +105,10 @@ handle_unknown() {
     local testurl=$1 out=$2 reason=$3
     to_review+=("$testurl ${reason:0:50}")
     echoerr "$testurl : Unknown issue, to be reviewed -> $testurl/file/autoinst-log.txt"
-    echoerr -e "Likely the error is within this log excerpt, last lines before shutdown:\n---"
+    echoerr -e "Likely the error is within this log excerpt, last lines before shutdown:\n  # --- 8< ---"
     # Look for different termination points with likely context
-    (grep -A 12 'Backend process died, backend errors are reported below in the following lines' "$out" || grep -B 10 'sending magic and exit' "$out" || grep -B 5 'killing command server.*because test execution ended through exception' "$out" || grep -B 5 'EXIT 1' "$out" || grep -B 10 '\(Result: died\|isotovideo failed\)' "$out" || echo '(No log excerpt found)') | head -n -1 >&2
-    echoerr "---"
+    (grep -A 12 'Backend process died, backend errors are reported below in the following lines' "$out" || grep -B 10 'sending magic and exit' "$out" || grep -B 5 'killing command server.*because test execution ended through exception' "$out" || grep -B 5 'EXIT 1' "$out" || grep -B 10 '\(Result: died\|isotovideo failed\)' "$out" || echo '(No log excerpt found)') | sed 's/^/  # /' | head -n -1 >&2
+    echoerr "  # --- >8 ---"
 }
 
 investigate_issue() {


### PR DESCRIPTION
It can be difficult to look for actual errors in the gru log, as
log excerpts are not really marked except for a starting and
ending '---' line.

This commit indents the log lines and also adds a comment sign.

Issue: https://progress.opensuse.org/issues/97034

Before:

    Mar 02 00:01:04 openqa openqa-gru[19218]: Likely the error is within this log excerpt, last lines before shutdown:
    Mar 02 00:01:04 openqa openqa-gru[19218]: ---
    Mar 02 00:01:04 openqa openqa-gru[19474]: [3.4K blob data]
    Mar 02 00:01:04 openqa openqa-gru[19474]:
    Mar 02 00:01:04 openqa openqa-gru[19474]: [2022-03-02T00:01:01.773526+01:00] [debug] git fetch: remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
    Mar 02 00:01:04 openqa openqa-gru[19474]:
    Mar 02 00:01:04 openqa openqa-gru[19474]: Could not find 'abc123' in complete history in cloned Git repository 'https://github.com/foo/bar' at /usr/...
    Mar 02 00:01:04 openqa openqa-gru[19218]: ---
    Mar 02 00:01:04 openqa openqa-gru[19218]: 1 unknown issues to be reviewed:
    Mar 02 00:01:04 openqa openqa-gru[19218]:  - https://openqa.example.org/tests/123 isotovideo died: Could not find 'abc123

After:

    Mar 02 00:01:04 openqa openqa-gru[19218]: Likely the error is within this log excerpt, last lines before shutdown:
    Mar 02 00:01:04 openqa openqa-gru[19218]:   # --- 8< ---
    Mar 02 00:01:04 openqa openqa-gru[19474]:   # [3.4K blob data]
    Mar 02 00:01:04 openqa openqa-gru[19474]:   #
    Mar 02 00:01:04 openqa openqa-gru[19474]:   # [2022-03-02T00:01:01.773526+01:00] [debug] git fetch: remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
    Mar 02 00:01:04 openqa openqa-gru[19474]:   #
    Mar 02 00:01:04 openqa openqa-gru[19474]:   # Could not find 'abc123' in complete history in cloned Git repository 'https://github.com/foo/bar' at /usr/...
    Mar 02 00:01:04 openqa openqa-gru[19218]:   # --- >8 ---
    Mar 02 00:01:04 openqa openqa-gru[19218]: 1 unknown issues to be reviewed:
    Mar 02 00:01:04 openqa openqa-gru[19218]:  - https://openqa.example.org/tests/123 isotovideo died: Could not find 'abc123