### PR TITLE
Replace deprecated load_module with exec_module

### DIFF
--- a/tests/test_trigger_bisect_jobs.py
+++ b/tests/test_trigger_bisect_jobs.py
@@ -6,6 +6,7 @@ import sys
 import os.path
 import pytest
 import importlib.machinery
+import importlib.util
 import requests
 import json
 
@@ -17,7 +18,9 @@ rootpath = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 called_commands = []
 
 loader = importlib.machinery.SourceFileLoader('openqa', rootpath + '/openqa-trigger-bisect-jobs')
-openqa = loader.load_module()
+spec = importlib.util.spec_from_loader(loader.name, loader)
+openqa = importlib.util.module_from_spec(spec)
+loader.exec_module(openqa)
 
 def args_factory():
     args = Namespace()
@@ -47,8 +50,8 @@ def mocked_call(cmds, dry_run=False):
 def test_trigger(mocker):
     args = args_factory()
     args.url = 'https://openqa.opensuse.org/tests/7848818'
-    mocker.patch('openqa.fetch_url', new=mocked_fetch_url)
-    mocker.patch('openqa.call', new=mocked_call)
+    mocker.patch.object(openqa, 'fetch_url', new=mocked_fetch_url)
+    mocker.patch.object(openqa, 'call', new=mocked_call)
     openqa.main(args)
     exp = [
         ['openqa-clone-job', '--skip-chained-deps', '--within-instance', 'https://openqa.opensuse.org/tests/7848818', 'OS_TEST_ISSUES=21770,21926,21954,22030,22077,22085,22192', 'TEST=foo:investigate:bisect_without_21637', 'OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/tests/7848818', '_GROUP=0'],
@@ -61,8 +64,8 @@ def test_trigger(mocker):
 
 def test_problems(mocker):
     args = args_factory()
-    mocker.patch('openqa.fetch_url', new=mocked_fetch_url)
-    mocker.patch('openqa.call', new=mocked_call)
+    mocker.patch.object(openqa, 'fetch_url', new=mocked_fetch_url)
+    mocker.patch.object(openqa, 'call', new=mocked_call)
 
     args.url = 'http://openqa.opensuse.org/tests/123'
     try:
@@ -85,7 +88,7 @@ def test_network_problems(mocker):
     args = args_factory()
     args.url = 'http://doesnotexist.openqa.opensuse.org/tests/12345'
     called_commands = []
-    mocker.patch('openqa.call', new=mocked_call)
+    mocker.patch.object(openqa, 'call', new=mocked_call)
     try:
         openqa.main(args)
         assert(False)


### PR DESCRIPTION
Related issue: https://progress.opensuse.org/issues/107014