### PR TITLE
Skip directly chained jobs in openqa-trigger-bisect-jobs

### DIFF
--- a/openqa-trigger-bisect-jobs
+++ b/openqa-trigger-bisect-jobs
@@ -84,6 +84,16 @@ def main(args):
     test_url = urlparse(urlunparse((parsed_url.scheme, parsed_url.netloc, '/api/v1/jobs/' + parsed_url.path.lstrip('/tests/'), '', '', '')))
     log.debug('Retrieving additional job data from %s' % test_url.geturl())
     test_data = fetch_url(test_url, request_type='json')
+
+    job = test_data['job']
+    children = job['children'] if 'children' in job else []
+    parents = job['parents'] if 'parents' in job else []
+    if ('Parallel' in children and len(children['Parallel']) \
+        or 'Directly chained' in children and len(children['Directly chained']) \
+        or 'Parallel' in parents and len(parents['Parallel']) \
+        or 'Directly chained' in parents and len(parents['Directly chained'])):
+        return
+
     log.debug('Received job data: %s' % test_data)
     test = test_data['job']['settings']['TEST']
     log.debug("Found test name '%s'" % test)

--- a/tests/data/python-requests/openqa.opensuse.org/api/v1/jobs/123456
+++ b/tests/data/python-requests/openqa.opensuse.org/api/v1/jobs/123456
@@ -1,0 +1,18 @@
+{
+  "job": {
+    "id": 123456,
+    "priority": 50,
+    "result": "failed",
+    "settings": {
+      "OS_TEST_ISSUES": "21637,21770,21926,21954,22030,22077,22085,22192",
+      "TEST": "foo"
+    },
+    "state": "done",
+    "t_finished": "2021-12-14T02:51:41",
+    "t_started": "2021-12-14T02:36:22",
+    "test": "foo",
+    "children": {
+        "Directly chained": [23456]
+    }
+  }
+}

--- a/tests/data/python-requests/openqa.opensuse.org/tests/123456/investigation_ajax
+++ b/tests/data/python-requests/openqa.opensuse.org/tests/123456/investigation_ajax
@@ -1,0 +1,4 @@
+{
+  "diff_packages_to_last_good": "Diff of packages not available",
+  "diff_to_last_good": "-   \"OS_TEST_ISSUES\" : \"21770,21926,21954,21956,22030,22077\",\n+   \"OS_TEST_ISSUES\" : \"21637,21770,21926,21954,22030,22077,22085,22192\",\n-   \"WORKER_ID\" : 984,\n+   \"WORKER_ID\" : 1800,\n+   \"WORKER_INSTANCE\" : 18,"
+}

--- a/tests/test_trigger_bisect_jobs.py
+++ b/tests/test_trigger_bisect_jobs.py
@@ -11,11 +11,10 @@ import requests
 import json
 
 from argparse import Namespace
-from unittest.mock import call, patch, Mock, MagicMock
+from unittest.mock import call, MagicMock
 from urllib.parse import urljoin, urlparse
 
 rootpath = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-called_commands = []
 
 loader = importlib.machinery.SourceFileLoader('openqa', rootpath + '/openqa-trigger-bisect-jobs')
 spec = importlib.util.spec_from_loader(loader.name, loader)
@@ -44,28 +43,38 @@ def mocked_fetch_url(url, request_type='text'):
     return content
 
 def mocked_call(cmds, dry_run=False):
-    called_commands.append(cmds)
     return 1
 
-def test_trigger(mocker):
+def mocked_openqa_clone(cmds, dry_run, default_opts=['--skip-chained-deps', '--within-instance'], default_cmds=['_GROUP=0']):
+    return 1
+
+cmds = ['https://openqa.opensuse.org/tests/7848818', 'OS_TEST_ISSUES=21770,21926,21954,22030,22077,22085,22192', 'TEST=foo:investigate:bisect_without_21637', 'OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/tests/7848818']
+
+def test_call():
+    openqa.call = MagicMock(side_effect=mocked_call)
+    openqa.openqa_clone(cmds, dry_run=False)
+    args = ['openqa-clone-job', '--skip-chained-deps', '--within-instance', 'https://openqa.opensuse.org/tests/7848818', 'OS_TEST_ISSUES=21770,21926,21954,22030,22077,22085,22192', 'TEST=foo:investigate:bisect_without_21637', 'OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/tests/7848818', '_GROUP=0']
+    openqa.call.assert_called_once_with(args, False)
+
+def test_trigger():
     args = args_factory()
     args.url = 'https://openqa.opensuse.org/tests/7848818'
-    mocker.patch.object(openqa, 'fetch_url', new=mocked_fetch_url)
-    mocker.patch.object(openqa, 'call', new=mocked_call)
+    openqa.openqa_clone = MagicMock(return_value=1, side_effect=mocked_openqa_clone)
+    openqa.fetch_url = MagicMock(side_effect=mocked_fetch_url)
     openqa.main(args)
-    exp = [
-        ['openqa-clone-job', '--skip-chained-deps', '--within-instance', 'https://openqa.opensuse.org/tests/7848818', 'OS_TEST_ISSUES=21770,21926,21954,22030,22077,22085,22192', 'TEST=foo:investigate:bisect_without_21637', 'OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/tests/7848818', '_GROUP=0'],
-        ['openqa-clone-job', '--skip-chained-deps', '--within-instance', 'https://openqa.opensuse.org/tests/7848818', 'OS_TEST_ISSUES=21637,21770,21926,21954,22030,22077,22192', 'TEST=foo:investigate:bisect_without_22085', 'OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/tests/7848818', '_GROUP=0'],
-        ['openqa-clone-job', '--skip-chained-deps', '--within-instance', 'https://openqa.opensuse.org/tests/7848818', 'OS_TEST_ISSUES=21637,21770,21926,21954,22030,22077,22085', 'TEST=foo:investigate:bisect_without_22192', 'OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/tests/7848818', '_GROUP=0'],
+    calls = [
+        call(['https://openqa.opensuse.org/tests/7848818', 'OS_TEST_ISSUES=21770,21926,21954,22030,22077,22085,22192', 'TEST=foo:investigate:bisect_without_21637', 'OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/tests/7848818'], False),
+        call(['https://openqa.opensuse.org/tests/7848818', 'OS_TEST_ISSUES=21637,21770,21926,21954,22030,22077,22192', 'TEST=foo:investigate:bisect_without_22085', 'OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/tests/7848818'], False),
+        call(['https://openqa.opensuse.org/tests/7848818', 'OS_TEST_ISSUES=21637,21770,21926,21954,22030,22077,22085', 'TEST=foo:investigate:bisect_without_22192', 'OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/tests/7848818'], False),
     ]
-    assert(called_commands[0] == exp[0])
-    assert(called_commands[1] == exp[1])
-    assert(called_commands[2] == exp[2])
+    openqa.openqa_clone.assert_has_calls(calls)
 
-def test_problems(mocker):
+orig_fetch_url = openqa.fetch_url
+
+def test_problems():
     args = args_factory()
-    mocker.patch.object(openqa, 'fetch_url', new=mocked_fetch_url)
-    mocker.patch.object(openqa, 'call', new=mocked_call)
+    openqa.openqa_clone = MagicMock(return_value=1, side_effect=mocked_openqa_clone)
+    openqa.fetch_url = MagicMock(side_effect=mocked_fetch_url)
 
     args.url = 'http://openqa.opensuse.org/tests/123'
     try:
@@ -75,22 +84,30 @@ def test_problems(mocker):
         assert(str(e) == 'Expecting value: line 1 column 1 (char 0)')
 
     args.url = 'http://openqa.opensuse.org/tests/1234'
-    called_commands = []
     openqa.main(args)
-    assert(len(called_commands) == 0)
+    openqa.openqa_clone.assert_not_called()
 
     args.url = 'http://openqa.opensuse.org/tests/12345'
-    called_commands = []
     openqa.main(args)
-    assert(len(called_commands) == 0)
+    openqa.openqa_clone.assert_not_called()
 
-def test_network_problems(mocker):
+def test_directly_chained():
+    args = args_factory()
+    openqa.openqa_clone = MagicMock(return_value=1, side_effect=mocked_openqa_clone)
+    openqa.fetch_url = MagicMock(side_effect=mocked_fetch_url)
+
+    args.url = 'http://openqa.opensuse.org/tests/123456'
+    openqa.main(args)
+    openqa.openqa_clone.assert_not_called()
+
+def test_network_problems():
     args = args_factory()
     args.url = 'http://doesnotexist.openqa.opensuse.org/tests/12345'
-    called_commands = []
-    mocker.patch.object(openqa, 'call', new=mocked_call)
+    openqa.openqa_clone = MagicMock(return_value=1, side_effect=mocked_openqa_clone)
+    openqa.fetch_url = MagicMock(side_effect=orig_fetch_url)
     try:
         openqa.main(args)
         assert(False)
     except requests.exceptions.ConnectionError as e:
         assert(True)
+


### PR DESCRIPTION
Related issue: https://progress.opensuse.org/issues/107014

https://github.com/os-autoinst/scripts/pull/141#pullrequestreview-933412150

Note that I needed to do these big changes to the testing code, because adding another test made me realize that filling the `called_commands` array works only once. seems like global variables are broken with mocked functions.

🐪++
🐍--