### PR TITLE
Bisect only failed jobs with diff_to_last_good

### DIFF
--- a/openqa-trigger-bisect-jobs
+++ b/openqa-trigger-bisect-jobs
@@ -76,6 +76,8 @@ def main(args):
     investigation = fetch_url(investigation_url, request_type='json')
     log.debug('Received investigation info: %s' % investigation)
     changes = { GOOD: set(), BAD: set() }
+    if 'diff_to_last_good' not in investigation:
+        return
     for line in investigation['diff_to_last_good'].split('\n'):
         search = re.compile('([+-]) +"OS_TEST_ISSUES" *: "([^"]*)",').search(line)
         if search:

--- a/tests/data/python-requests/openqa.opensuse.org/tests/100/investigation_ajax
+++ b/tests/data/python-requests/openqa.opensuse.org/tests/100/investigation_ajax
@@ -1,0 +1,3 @@
+{
+  "diff_packages_to_last_good": "Diff of packages not available"
+}

--- a/tests/test_trigger_bisect_jobs.py
+++ b/tests/test_trigger_bisect_jobs.py
@@ -103,6 +103,10 @@ def test_problems():
     openqa.main(args)
     openqa.openqa_clone.assert_not_called()
 
+    args.url = 'http://openqa.opensuse.org/tests/100'
+    openqa.main(args)
+    openqa.openqa_clone.assert_not_called()
+
 def test_directly_chained():
     args = args_factory()
     openqa.openqa_clone = MagicMock(return_value='')


### PR DESCRIPTION
But I saw this in our logs:

    Traceback (most recent call last):
      File "/opt/os-autoinst-scripts/openqa-trigger-bisect-jobs", line 120, in <module>
        main(parse_args())
      File "/opt/os-autoinst-scripts/openqa-trigger-bisect-jobs", line 79, in main
        for line in investigation['diff_to_last_good'].split('\n'):
    KeyError: 'diff_to_last_good'

Jobs might not have a diff_to_last_good entry.

Issue: https://progress.opensuse.org/issues/107014