### PR TITLE
Email notifications for unreviewed issues

### DIFF
--- a/_common
+++ b/_common
@@ -6,6 +6,7 @@
 enable_force_result=${enable_force_result:-false}
 
 client_call=()
+client_args=()
 
 warn() { echo "$@" >&2; }
 
@@ -92,3 +93,25 @@ label_on_issue() {
         "${client_call[@]}" -X POST jobs/"$id"/restart
     fi
 }
+
+handle_unknown() {
+    local testurl=$1 out=$2 reason=$3 group_id=$4 email_unreviewed=$5 from_email=$6
+    local group_data group_description group_mailto header
+    to_review+=("$testurl ${reason:0:50}")
+    header="$testurl : Unknown issue, to be reviewed -> $testurl/file/autoinst-log.txt"
+    warn "$header"
+    warn -e "Likely the error is within this log excerpt, last lines before shutdown:\n  # --- 8< ---"
+    # Look for different termination points with likely context
+    (grep -A 12 'Backend process died, backend errors are reported below in the following lines' "$out" || grep -B 10 'sending magic and exit' "$out" || grep -B 5 'killing command server.*because test execution ended through exception' "$out" || grep -B 5 'EXIT 1' "$out" || grep -B 10 '\(Result: died\|isotovideo failed\)' "$out" || echo '(No log excerpt found)') | sed 's/^/  # /' | head -n -1 >&2
+    warn "  # --- >8 ---"
+
+    if "$email_unreviewed"; then
+        group_data=$(openqa-cli "${client_args[@]}" "job_groups/$group_id")
+        group_description=$(echo "$group_data" | runjq -r '.[0].description' ) || true
+        group_mailto=$(echo "$group_description" | perl -n -wE'm/.*MAILTO: (\S+).*/ and say $1' | head -1)
+        if [[ -n "$group_mailto" ]]; then
+            echo "$header"$'\n'"Reason: $reason" | mutt -s "Unknown issue to be reviewed (Group $group_id)" -e "my_hdr From: openqa-label-known-issues <$from_email>" "$group_mailto"
+        fi
+    fi
+}
+

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -17,6 +17,8 @@ issue_marker="${issue_marker:-"auto_review%3A"}"
 issue_query="${issue_query:-"https://progress.opensuse.org/projects/openqav3/issues.json?limit=200&subproject_id=*&subject=~${issue_marker}"}"
 reason_min_length="${reason_min_length:-"8"}"
 grep_timeout="${grep_timeout:-5}"
+email_unreviewed=${email_unreviewed:-true}
+from_email=${from_email:-openqa-label-known-issues@open.qa}
 to_review=()
 curl_args=(--user-agent "openqa-label-known-issues")
 client_args=(api --header 'User-Agent: openqa-label-known-issues (https://github.com/os-autoinst/scripts)' --host "$host_url")
@@ -101,21 +103,13 @@ label_on_issues_without_tickets() {
     false
 }
 
-handle_unknown() {
-    local testurl=$1 out=$2 reason=$3
-    to_review+=("$testurl ${reason:0:50}")
-    echoerr "$testurl : Unknown issue, to be reviewed -> $testurl/file/autoinst-log.txt"
-    echoerr -e "Likely the error is within this log excerpt, last lines before shutdown:\n  # --- 8< ---"
-    # Look for different termination points with likely context
-    (grep -A 12 'Backend process died, backend errors are reported below in the following lines' "$out" || grep -B 10 'sending magic and exit' "$out" || grep -B 5 'killing command server.*because test execution ended through exception' "$out" || grep -B 5 'EXIT 1' "$out" || grep -B 10 '\(Result: died\|isotovideo failed\)' "$out" || echo '(No log excerpt found)') | sed 's/^/  # /' | head -n -1 >&2
-    echoerr "  # --- >8 ---"
-}
-
 investigate_issue() {
     local id="${1##*/}"
     local reason
     local curl_output
-    reason=$(openqa-cli "${client_args[@]}" jobs/"$id" | runjq -r '.job.reason')
+    job_data=$(openqa-cli "${client_args[@]}" jobs/"$id")
+    reason=$(echo "$job_data" | runjq -r '.job.reason')
+    group_id=$(echo "$job_data" | runjq -r '.job.group_id')
     curl_output=$(curl "${curl_args[@]}" -s -w "%{http_code}" "$testurl/file/autoinst-log.txt" -o "$out")
     # combine both the reason and autoinst-log.txt to check known issues
     # against even in case when autoinst-log.txt is missing the details, e.g.
@@ -134,7 +128,7 @@ investigate_issue() {
     # subject line
     elif label_on_issues_without_tickets "$id"; then return
     else
-        handle_unknown "$testurl" "$out" "$reason"
+        handle_unknown "$testurl" "$out" "$reason" "$group_id" "$email_unreviewed" "$from_email"
     fi
 }
 

--- a/test/01-label-known-issues.t
+++ b/test/01-label-known-issues.t
@@ -13,7 +13,7 @@ PATH=$BASHLIB$PATH
 
 source bash+ :std
 use Test::More
-plan tests 14
+plan tests 15
 
 source _common
 
@@ -81,3 +81,16 @@ label_on_issue 123 'foo bar' Label || rc=$?
 is "$rc" 1 'label_on_issue did not find search term'
 is "$client_output" "" 'label_on_issue with restart and force_result'
 
+mutt() {
+    local s=$1 subject=$2 e=$3 header=$4 recv=$5
+    echo "$subject,$header,$recv"
+}
+openqa-cli() {
+    cat "$dir/data/group24.json"
+}
+from_email=foo@bar
+client_args=(api --host http://localhost)
+testurl=https://openqa.opensuse.org/api/v1/jobs/2291399
+group_id=24
+out=$(handle_unknown "$testurl" "$logfile1" "no reason" "$group_id" true "$from_email" 2>/dev/null) || true
+is "$out" 'Unknown issue to be reviewed (Group 24),my_hdr From: openqa-label-known-issues <foo@bar>,dummy@example.com.dummy' "mutt called like expected"

--- a/test/data/group24.json
+++ b/test/data/group24.json
@@ -1,0 +1,8 @@
+[
+  {
+    "default_priority": 50,
+    "description": "Responsible maintainer, MAILTO: dummy@example.com.dummy end of line\r\n\r\nTests for openQA within openQA using the test repository [os-autoinst-distri-openQA](https://github.com/os-autoinst/os-autoinst-distri-openQA)\r\n\r\nTesting the packages as provided by [devel:openQA](https://build.opensuse.org/project/show/devel:openQA)",
+    "id": 24,
+    "name": "openQA"
+  }
+]


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/91605

I tested it on o3 with
```
echo http://openqa.opensuse.org/tests/2270756 | host=openqa.opensuse.org scheme=http ./openqa-label-known-issues
```
The email looks like:
```
Subject: Unknown issue to be reviewed (Group 24)                                                                    

http://openqa.opensuse.org/tests/2270756 : Unknown issue, to be reviewed ->
http://openqa.opensuse.org/tests/2270756/file/autoinst-log.txt
Reason: null
```