### PR TITLE
Don't attempt to notify for empty group_id

### DIFF
--- a/_common
+++ b/_common
@@ -105,7 +105,7 @@ handle_unknown() {
     (grep -A 12 'Backend process died, backend errors are reported below in the following lines' "$out" || grep -B 10 'sending magic and exit' "$out" || grep -B 5 'killing command server.*because test execution ended through exception' "$out" || grep -B 5 'EXIT 1' "$out" || grep -B 10 '\(Result: died\|isotovideo failed\)' "$out" || echo '(No log excerpt found)') | sed 's/^/  # /' | head -n -1 >&2
     warn "  # --- >8 ---"
 
-    if "$email_unreviewed"; then
+    if "$email_unreviewed" && [[ "$group_id" != 'null' ]]; then
         group_data=$(openqa-cli "${client_args[@]}" "job_groups/$group_id")
         group_description=$(echo "$group_data" | runjq -r '.[0].description' ) || true
         group_mailto=$(echo "$group_description" | perl -n -wE'm/.*MAILTO: (\S+).*/ and say $1' | head -1)

--- a/test/01-label-known-issues.t
+++ b/test/01-label-known-issues.t
@@ -13,7 +13,7 @@ PATH=$BASHLIB$PATH
 
 source bash+ :std
 use Test::More
-plan tests 15
+plan tests 16
 
 source _common
 
@@ -94,3 +94,5 @@ testurl=https://openqa.opensuse.org/api/v1/jobs/2291399
 group_id=24
 out=$(handle_unknown "$testurl" "$logfile1" "no reason" "$group_id" true "$from_email" 2>/dev/null) || true
 is "$out" 'Unknown issue to be reviewed (Group 24),my_hdr From: openqa-label-known-issues <foo@bar>,dummy@example.com.dummy' "mutt called like expected"
+out=$(handle_unknown "$testurl" "$logfile1" "no reason" "null" true "$from_email" 2>/dev/null) || true
+is "$out" '' "mutt not called for group_id null"


### PR DESCRIPTION
If a job has an unknown group_id, the

    openqa-cli "${client_args[@]}" "job_groups/$group_id"

was causing an error in the log.

Issue: https://progress.opensuse.org/issues/91605