### PR TITLE
Ensure writable homedir when calling mutt

### DIFF
--- a/_common
+++ b/_common
@@ -110,7 +110,7 @@ handle_unknown() {
         group_description=$(echo "$group_data" | runjq -r '.[0].description' ) || true
         group_mailto=$(echo "$group_description" | perl -n -wE'm/.*MAILTO: (\S+).*/ and say $1' | head -1)
         if [[ -n "$group_mailto" ]]; then
-            echo "$header"$'\n'"Reason: $reason" | mutt -s "Unknown issue to be reviewed (Group $group_id)" -e "my_hdr From: openqa-label-known-issues <$from_email>" "$group_mailto"
+            echo "$header"$'\n'"Reason: $reason" | HOME=/tmp mutt -s "Unknown issue to be reviewed (Group $group_id)" -e "my_hdr From: openqa-label-known-issues <$from_email>" "$group_mailto"
         fi
     fi
 }


### PR DESCRIPTION
Sometimes we run as a user with a readonly homedir, and mutt
wants to create a 'sent' file. Haven't found an easy way to tell
mutt not to create that file.

Issue: https://progress.opensuse.org/issues/91605