### PR TITLE
Prevent execution errors to be swallowed from openqa-label-known-issues

### DIFF
--- a/_common
+++ b/_common
@@ -99,11 +99,11 @@ handle_unknown() {
     local group_data group_description group_mailto header
     to_review+=("$testurl ${reason:0:50}")
     header="$testurl : Unknown issue, to be reviewed -> $testurl/file/autoinst-log.txt"
-    warn "$header"
-    warn -e "Likely the error is within this log excerpt, last lines before shutdown:\n  # --- 8< ---"
+    echo "$header"
+    echo -e "Likely the error is within this log excerpt, last lines before shutdown:\n  # --- 8< ---"
     # Look for different termination points with likely context
     (grep -A 12 'Backend process died, backend errors are reported below in the following lines' "$out" || grep -B 10 'sending magic and exit' "$out" || grep -B 5 'killing command server.*because test execution ended through exception' "$out" || grep -B 5 'EXIT 1' "$out" || grep -B 10 '\(Result: died\|isotovideo failed\)' "$out" || echo '(No log excerpt found)') | sed 's/^/  # /' | head -n -1 >&2
-    warn "  # --- >8 ---"
+    echo "  # --- >8 ---"
 
     if "$email_unreviewed" && [[ "$group_id" != 'null' ]]; then
         group_data=$(openqa-cli "${client_args[@]}" "job_groups/$group_id")

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -37,20 +37,20 @@ handle_unreachable_or_no_log() {
     if ! curl "${curl_args[@]}" -s --head "$testurl" -o /dev/null; then
         # the page might be gone, try the scheme+host we configured (might be different one though)
         if ! grep -q "$host_url" <<< "$testurl"; then
-            echo "'$testurl' is not reachable and 'host_url' parameter does not match '$testurl', can not check further, continuing with next"
+            echoerr "'$testurl' is not reachable and 'host_url' parameter does not match '$testurl', can not check further, continuing with next"
             return
         fi
         if ! curl "${curl_args[@]}" -s --head "$host_url"; then
-            echo "'$host_url' is not reachable, bailing out"
+            echoerr "'$host_url' is not reachable, bailing out"
             curl "${curl_args[@]}" --head "$host_url"
         fi
-        echo "'$testurl' is not reachable, assuming deleted, continuing with next"
+        echoerr "'$testurl' is not reachable, assuming deleted, continuing with next"
         return
     fi
     # resorting to downloading the job details page instead of the
     # log, overwrites $out
     if ! curl "${curl_args[@]}" -s "$testurl" -o "$out"; then
-        echo "'$testurl' can be reached but not downloaded, bailing out"
+        echoerr "'$testurl' can be reached but not downloaded, bailing out"
         curl "${curl_args[@]}" "$testurl"
         exit 2
     fi
@@ -58,7 +58,7 @@ handle_unreachable_or_no_log() {
     # then the job might be too old and logs are already deleted.
     # Checking timestamp
     if [[ $(date -uIs -d '-14days') > $(grep timeago "$out" | hxselect -s '\n' -c '.timeago::attr(title)') ]]; then
-        echo "'$testurl' does not have autoinst-log.txt but is rather old, ignoring"
+        echoerr "'$testurl' does not have autoinst-log.txt but is rather old, ignoring"
         return
     fi
     if hxnormalize -x "$out" | hxselect -s '\n' -c '.links_a .resborder' | grep -qPzo '(?s)Gru job failed.*connection error.*Inactivity timeout'; then
@@ -139,7 +139,7 @@ print_summary() {
     for job in "${to_review[@]}"; do
         msg+="\n - $job"
     done
-    echoerr -e "$msg"
+    echo -e "$msg"
 }
 
 main() {

--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -19,5 +19,5 @@ investigate-and-bisect() {
     "$script_dir/openqa-trigger-bisect-jobs" --url "$test"
 }
 
-echo "$host_url/tests/$id" | "$script_dir/openqa-label-known-issues" 3>&1 1>/dev/null 2>&3- | sed -n 's/\(\S*\) : Unknown issue, to be reviewed.*$/\1/p' | investigate-and-bisect
+echo "$host_url/tests/$id" | "$script_dir/openqa-label-known-issues" | sed -n 's/\(\S*\) : Unknown issue, to be reviewed.*$/\1/p' | investigate-and-bisect
 

--- a/test/01-label-known-issues.t
+++ b/test/01-label-known-issues.t
@@ -83,7 +83,7 @@ is "$client_output" "" 'label_on_issue with restart and force_result'
 
 mailx() {
     local s=$1 subject=$2 e=$3 header=$4 recv=$5
-    echo "$subject,$header,$recv"
+    echo "$subject,$header,$recv" >&2
 }
 openqa-cli() {
     cat "$dir/data/group24.json"
@@ -92,7 +92,7 @@ from_email=foo@bar
 client_args=(api --host http://localhost)
 testurl=https://openqa.opensuse.org/api/v1/jobs/2291399
 group_id=24
-out=$(handle_unknown "$testurl" "$logfile1" "no reason" "$group_id" true "$from_email" 2>/dev/null) || true
+out=$(handle_unknown "$testurl" "$logfile1" "no reason" "$group_id" true "$from_email" 2>&1 >/dev/null) || true
 is "$out" 'Unknown issue to be reviewed (Group 24),openqa-label-known-issues <foo@bar>,dummy@example.com.dummy' "mailx called like expected"
-out=$(handle_unknown "$testurl" "$logfile1" "no reason" "null" true "$from_email" 2>/dev/null) || true
+out=$(handle_unknown "$testurl" "$logfile1" "no reason" "null" true "$from_email" 2>&1 >/dev/null) || true
 is "$out" '' "mailx not called for group_id null"

--- a/test/scripts/openqa-label-known-issues
+++ b/test/scripts/openqa-label-known-issues
@@ -1,4 +1,4 @@
 #!/bin/bash
 for testurl in $(cat - | sed 's/ .*$//'); do
-    echo "$testurl : Unknown issue, to be reviewed -> $testurl/file/autoinst-log.txt" >&2
+    echo "$testurl : Unknown issue, to be reviewed -> $testurl/file/autoinst-log.txt"
 done


### PR DESCRIPTION
Originally I opted to use stdout for diagnostic output in
openqa-label-known-issues and stderr for the relevant left unreviewed
test failures. This causes potential errors to be hidden in particular
when forwarding the output in the hook scripts.

This commit swaps the use of stdout and stderr in
openqa-label-known-issues so that stderr with diagnostic output can
output info as well as error output which can then be read by callers to
investigate problems while the stdout is passed on in the pipe within
the hook scripts.

Related progress issue: https://progress.opensuse.org/issues/91605