### PR TITLE
Ensure any bugref in force_result labels to be parsed as a real bugref

### DIFF
--- a/_common
+++ b/_common
@@ -61,7 +61,9 @@ runcurl() {
 comment_on_job() {
     local id=$1 comment=$2 force_result=${3:-''}
     if $enable_force_result && [[ -n $force_result ]]; then
-        comment="label:force_result:$force_result:$comment"
+        comment="label:force_result:$force_result:$comment
+
+$comment"
     fi
     "${client_call[@]}" -X POST jobs/"$id"/comments text="$comment"
 }

--- a/test/01-label-known-issues.t
+++ b/test/01-label-known-issues.t
@@ -60,6 +60,8 @@ client_output=''
 out=$logfile1
 enable_force_result=true label_on_issue 123 'foo.*bar' Label 1 softfailed || rc=$?
 expected="client_call -X POST jobs/123/comments text=label:force_result:softfailed:Label
+
+Label
 client_call -X POST jobs/123/restart
 "
 is "$rc" 0 'successful label_on_issue'


### PR DESCRIPTION
If openQA would detect a label in a line within a comment then only a
label would be referenced however for auto-review using force_result
labels I think we should highlight the actual ticket used as reference.
This commit is putting the comment (duplicated) in a separate line so
that openQA will render the comment with an according bugref link, not
the label per se.

Related progress issue: https://progress.opensuse.org/issues/109857