### PR TITLE
Skip unnecessary investigation when there are clones already

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=/dev/null
-. "$(dirname "$0")"/_common
+. "$(dirname "${BASH_SOURCE[0]}")"/_common
 
 host="${host:-"openqa.opensuse.org"}"
 scheme="${scheme:-"https"}"
@@ -183,4 +183,4 @@ main() {
     exit "$error_count"
 }
 
-main "$@"
+caller 0 >/dev/null || main "$@"

--- a/openqa-investigate
+++ b/openqa-investigate
@@ -19,6 +19,7 @@ exclude_name_regex="${exclude_name_regex:-":investigate:"}"
 exclude_no_group="${exclude_no_group:-"true"}"
 # exclude_group_regex checks a combined string "<parent job group name> / <job group name>"
 exclude_group_regex="${exclude_group_regex:-"Development.*/ "}"
+force=${force:-false}
 client_args=(api --header 'User-Agent: openqa-investigate (https://github.com/os-autoinst/scripts)' --host "$host_url")
 jq_output_limit="${jq_output_limit:-15}"
 curl_args=(--user-agent "openqa-investigate")
@@ -143,6 +144,11 @@ investigate() {
                 echoerr "Unexpected error encountered when posting comments: '$out'"
                 return 2
             fi
+        return 0
+    fi
+    clone="$(echo "$job_data" | runjq -r '.job.clone_id')" || return $?
+    if ! "$force" && [[ "$clone" != "null" ]]; then
+        echoerr "Job already has a clone, skipping investigation. Use the env variable 'force=true' to trigger investigation jobs"
         return 0
     fi
     [[ "$old_name" =~ $exclude_name_regex ]] && echo "Job name '$old_name' matches \$exclude_name_regex '$exclude_name_regex', skipping investigation" && return 0

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -13,7 +13,7 @@ PATH=$BASHLIB$PATH
 
 source bash+ :std
 use Test::More
-plan tests 6
+plan tests 10
 
 host=localhost
 url=https://localhost
@@ -41,6 +41,8 @@ is "$out" "unable to clone job 42: it is part of a parallel or directly chained 
 openqa-cli() {
     if [[ "$1 $2" == "--json jobs/24" ]]; then
         echo '{"job": { "test": "vim", "priority": 50, "settings" : {} } }'
+    elif [[ "$1 $2" == "--json jobs/27" ]]; then
+        echo '{"job": { "test": "vim", "clone_id" : 28 } }'
     else
         echo '{"result": [{ "25": "foo", "26": "bar" }], "test_url": [{"25": "/tests/25", "26": "/tests/26"}] } '
     fi
@@ -53,3 +55,12 @@ is "$rc" 0 "Successful clone"
 testlabel="vim:investigate"
 is "$out" "* **$testlabel**: " "Expected markdown output of job urls for unsupported clusters"
 
+rc=0
+out=$(investigate 27 2>&1) || rc=$?
+is "$rc" 0 'success regardless of actually triggered jobs'
+is "$out" "Job already has a clone, skipping investigation. Use the env variable 'force=true' to trigger investigation jobs"
+
+rc=0
+out=$(force=true investigate 27 2>&1) || rc=$?
+is "$rc" 0 'still success'
+like "$out" "exclude_no_group is set, skipping investigation"

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -e
+
+dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
+
+TEST_MORE_PATH=$dir/../test-more-bash
+BASHLIB="`
+    find $TEST_MORE_PATH -type d |
+    grep -E '/(bin|lib)$' |
+    xargs -n1 printf "%s:"`"
+PATH=$BASHLIB$PATH
+
+source bash+ :std
+use Test::More
+plan tests 6
+
+host=localhost
+url=https://localhost
+
+source openqa-investigate
+
+client_args=()
+cli_rc=1
+openqa-cli() {
+    return $cli_rc
+}
+client_call=(openqa-cli)
+
+rc=0
+out=$(clone 41 42  2>&1 > /dev/null) || rc=$?
+is "$rc" 1 'fails when unable to query job data'
+is "$out" "unable to query job data for 42: " 'query error on stderr'
+
+cli_rc=0
+consider_parallel_and_directly_chained_clusters=1
+out=$(clone 41 42 2>&1 > /dev/null) || rc=$?
+is "$rc" 2 'fails when no jobs could be restarted'
+is "$out" "unable to clone job 42: it is part of a parallel or directly chained cluster (not supported)" 'restart error on stderr'
+
+openqa-cli() {
+    if [[ "$1 $2" == "--json jobs/24" ]]; then
+        echo '{"job": { "test": "vim", "priority": 50, "settings" : {} } }'
+    else
+        echo '{"result": [{ "25": "foo", "26": "bar" }], "test_url": [{"25": "/tests/25", "26": "/tests/26"}] } '
+    fi
+}
+
+rc=0
+clone_call=echo
+out=$(clone 23 24 2>&1 ) || rc=$?
+is "$rc" 0 "Successful clone"
+testlabel="vim:investigate"
+is "$out" "* **$testlabel**: " "Expected markdown output of job urls for unsupported clusters"
+


### PR DESCRIPTION
Within openqa-investigate if a job already has any clone then normally
no investigation is required by users. One can still force the
triggering of investigation jobs with the "force" environment variable.

Related progress issue: https://progress.opensuse.org/issues/110911