### PR TITLE
Add test for checking make update-deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 ---
 name: ci
-# yamllint disable-line rule:truthy
 on: [push, pull_request]
 jobs:
   test:
@@ -12,6 +11,9 @@ jobs:
           pip install pytest mocker pytest-mock
           python --version
           pytest --version
+      - run: |
+          sudo apt-get install cpanminus
+          sudo cpanm -n -M https://cpan.metacpan.org --installdeps .
       - name: unit- and integration tests
         run: |
          make test-unit

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,21 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 160
+  indentation:
+    indent-sequences: whatever
+
+  # Allows aligning subsequent lines with [] sequences
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: -1
+  commas:
+    max-spaces-after: -1
+  # Allows aligning key value pairs
+  colons:
+    max-spaces-after: -1
+
+  # don't warn about using yes/no etc.
+  truthy: disable
+

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test: checkstyle test-unit
 
 .PHONY: test-unit
 test-unit: test-more-bash
-	prove -r test/
+	prove -r test/ xt/
 	py.test
 
 test-more-bash:

--- a/cpanfile
+++ b/cpanfile
@@ -12,6 +12,8 @@ requires 'Text::Markdown';
 requires 'YAML::PP';
 
 on 'test' => sub {
+    requires 'Test::Most';
+    requires 'Test::Warnings';
 
 };
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,8 +8,11 @@
 #######################################################
 ---
 targets:
-  cpanfile: [main]
-  spec: [main]
+  cpanfile: [main, test]
+  spec:     [main, test]
+  cpanfile-targets:
+    # target: cpanfile target type (default main)
+    test: test
 main_requires:
   bash:
   coreutils:  # date, ln, tail
@@ -30,3 +33,6 @@ main_requires:
   perl(YAML::PP):
   html-xml-utils:
   xmlstarlet:
+test_requires:
+  perl(Test::Warnings):
+  perl(Test::Most):

--- a/dist/rpm/os-autoinst-scripts-deps.spec
+++ b/dist/rpm/os-autoinst-scripts-deps.spec
@@ -26,6 +26,8 @@ BuildArch:      noarch
 Url:            https://github.com/os-autoinst/scripts
 # The following line is generated from dependencies.yaml
 %define main_requires bash coreutils curl grep html-xml-utils jq openQA-client openssh-clients osc perl >= 5.010 perl(Data::Dumper) perl(FindBin) perl(Getopt::Long) perl(Mojo::File) perl(Text::Markdown) perl(YAML::PP) sed sudo xmlstarlet
+# The following line is generated from dependencies.yaml
+%define test_requires perl(Test::Most) perl(Test::Warnings)
 Requires:       %main_requires
 Suggests:       salt
 Suggests:       postgresql

--- a/external/os-autoinst-common/.gitrepo
+++ b/external/os-autoinst-common/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:os-autoinst/os-autoinst-common.git
 	branch = master
-	commit = 0ed83c703bcf3d7dc9f2d8a600ee20ab407ca19f
-	parent = 8058588f98edc203ae1fd66264f5848e3057f059
+	commit = a62482b1461da31d436e6ccaf838604ababe0b2c
+	parent = 5a9f2d23546689931d8ee90db08a95c6aa77fc6d
 	method = merge
 	cmdver = 0.4.3

--- a/external/os-autoinst-common/lib/OpenQA/Test/PatchDeparse.pm
+++ b/external/os-autoinst-common/lib/OpenQA/Test/PatchDeparse.pm
@@ -1,0 +1,66 @@
+package OpenQA::Test::PatchDeparse;
+use Test::Most;
+
+# Monkeypatch B::Deparse
+# https://progress.opensuse.org/issues/40895
+# related: https://github.com/pjcj/Devel--Cover/issues/142
+# http://perlpunks.de/corelist/mversion?module=B::Deparse
+
+
+# This might be fixed in newer versions of perl/B::Deparse
+# We only see a warning when running with Devel::Cover
+if (
+    $B::Deparse::VERSION
+    and ($B::Deparse::VERSION >= '1.40' and ($B::Deparse::VERSION <= '1.54'))
+  )
+{
+
+#<<<  do not let perltidy touch this
+# This is not our code, and formatting should stay the same for
+# better comparison with new versions of B::Deparse
+# <---- PATCH
+package B::Deparse;
+no warnings 'redefine';
+no strict 'refs';
+
+*{"B::Deparse::walk_lineseq"} = sub {
+
+    my ($self, $op, $kids, $callback) = @_;
+    my @kids = @$kids;
+    for (my $i = 0; $i < @kids; $i++) {
+	my $expr = "";
+	if (is_state $kids[$i]) {
+        # Patch for:
+        # Use of uninitialized value $expr in concatenation (.) or string at /usr/lib/perl5/5.26.1/B/Deparse.pm line 1794.
+	    $expr = $self->deparse($kids[$i++], 0) // ''; # prevent undef $expr
+	    if ($i > $#kids) {
+		$callback->($expr, $i);
+		last;
+	    }
+	}
+	if (is_for_loop($kids[$i])) {
+	    $callback->($expr . $self->for_loop($kids[$i], 0),
+		$i += $kids[$i]->sibling->name eq "unstack" ? 2 : 1);
+	    next;
+	}
+	my $expr2 = $self->deparse($kids[$i], (@kids != 1)/2) // ''; # prevent undef $expr2
+	$expr2 =~ s/^sub :(?!:)/+sub :/; # statement label otherwise
+	$expr .= $expr2;
+	$callback->($expr, $i);
+    }
+
+};
+# ----> PATCH
+#>>>
+
+}
+elsif ($B::Deparse::VERSION) {
+    # when we update to a new perl version, this will remind us about checking
+    # if the bug is still there
+    diag
+      "Using B::Deparse v$B::Deparse::VERSION. If you see 'uninitialized' warnings, update patch in t/lib/OpenQA/Test/PatchDeparse.pm";
+}
+
+1;
+
+

--- a/external/os-autoinst-common/lib/OpenQA/Test/TimeLimit.pm
+++ b/external/os-autoinst-common/lib/OpenQA/Test/TimeLimit.pm
@@ -61,7 +61,7 @@ respectively.
 
 =head2 Alternatives considered
 
-* Just checking the runtime while not aborting the test – this idea has
+* Just checking the runtime while not aborting the test - this idea has
 not been followed as we want to prevent any external runners to run into
 timeout first which can cause less obvious results
 * https://metacpan.org/pod/Time::Limit - nice syntax that inspired me to

--- a/external/os-autoinst-common/tools/update-deps
+++ b/external/os-autoinst-common/tools/update-deps
@@ -20,16 +20,16 @@ GetOptions(
 usage(0) if $help;
 usage(1) unless $specfile;
 
-my $scriptname   = path(__FILE__)->to_rel("$Bin/..");
-my $yamlfile     = "dependencies.yaml";
-my $file         = "$Bin/../$yamlfile";
-my $cpanfile     = "$Bin/../cpanfile";
+my $scriptname = path(__FILE__)->to_rel("$Bin/..");
+my $yamlfile = "dependencies.yaml";
+my $file = "$Bin/../$yamlfile";
+my $cpanfile = "$Bin/../cpanfile";
 
-my $data     = YAML::PP->new->load_file($file);
-my $spec     = path($specfile)->slurp;
+my $data = YAML::PP->new->load_file($file);
+my $spec = path($specfile)->slurp;
 
-my $spectargets   = $data->{targets}->{spec};
-my $cpantargets   = $data->{targets}->{cpanfile};
+my $spectargets = $data->{targets}->{spec};
+my $cpantargets = $data->{targets}->{cpanfile};
 my $dockertargets = $data->{targets}->{docker};
 my $cpantarget_mapping = $data->{targets}->{'cpanfile-targets'};
 
@@ -46,7 +46,7 @@ sub update_dockerfile {
     my @pkg;
     for my $target (@$dockertargets) {
         my $name = $target . '_requires';
-        my $deps     = $data->{$name};
+        my $deps = $data->{$name};
         for my $key (sort keys %$deps) {
             next if $key =~ m/^%/;
             my $line = '       ';
@@ -66,7 +66,8 @@ sub update_dockerfile {
     }
     @perl = sort @perl;
     @pkg = sort @pkg;
-    my $dep = join '', @pkg, @perl;
+    my %seen;
+    my $dep = join '', grep { not $seen{$_}++ } @pkg, @perl;
     my $begin = '# AUTODEPS START';
     my $end = '# AUTODEPS END';
     my $run = <<"EOM";
@@ -84,8 +85,8 @@ sub update_spec {
 
     for my $target (@$spectargets) {
         my $name = $target . '_requires';
-        my $deps     = $data->{$name};
-        my $prefix   = "%define $name";
+        my $deps = $data->{$name};
+        my $prefix = "%define $name";
         my $specline = $prefix;
         for my $key (sort keys %$deps) {
             my $version = $deps->{$key};
@@ -139,7 +140,7 @@ sub _requires_line {
     # requires 'Archive::Extract', '> 0.7';
     my ($hash, $module) = @_;
     my $version = $hash->{$module};
-    my $line    = "requires '$module'";
+    my $line = "requires '$module'";
     $line .= qq{, '$version'} if $version;
     $line .= ";\n";
     return $line;

--- a/external/os-autoinst-common/xt/01-make-update-deps.t
+++ b/external/os-autoinst-common/xt/01-make-update-deps.t
@@ -1,0 +1,28 @@
+#!/usr/bin/env perl
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Test::Warnings;
+use FindBin '$Bin';
+
+if (not -e "$Bin/../.git") {
+    pass("Skipping all tests, not in a git repository");
+    done_testing;
+    exit;
+}
+
+my $build_dir = $ENV{OS_AUTOINST_BUILD_DIRECTORY} || "$Bin/..";
+my $make_tool = $ENV{OS_AUTOINST_MAKE_TOOL} || 'make';
+my $make_cmd = "$make_tool update-deps";
+
+chdir $build_dir;
+my @out = qx{$make_cmd};
+my $rc = $?;
+die "Could not run $make_cmd: rc=$rc, out: @out" if $rc;
+
+my @status = grep { not m/^\?/ } qx{git -C "$Bin/.." status --porcelain};
+ok(!@status, "No changed files after '$make_cmd'") or diag @status;
+
+done_testing;
+

--- a/xt/01-make-update-deps.t
+++ b/xt/01-make-update-deps.t
@@ -1,0 +1,1 @@
+../external/os-autoinst-common/xt/01-make-update-deps.t


### PR DESCRIPTION
I added the test to https://github.com/os-autoinst/os-autoinst-common/pull/21

In this PR I add a symlink to the test.
I also added a `.yamllint` file.

I had to reclone the subrepo because the commits listed in the `.gitrepo` file didn't exist.
Not sure how the original subrepo clone was done. Maybe it was done on a local branch and the commit cherry-picked or so. That can't work.

Issue: https://progress.opensuse.org/issues/111215