### PR TITLE
openqa-investigate: Provide support for multi-machine scenarios

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -42,7 +42,7 @@ clone() {
 
     name="$(echo "$job_data" | runjq -r '.job.test'):investigate$name_suffix" || return $?
     base_prio=$(echo "$job_data" | runjq -r '.job.priority') || return $?
-    clone_settings=("TEST=$name" '_GROUP_ID=0' 'BUILD=')
+    clone_settings=("TEST+=:investigate$name_suffix" '_GROUP_ID=0' 'BUILD=')
     if [[ $refspec ]]; then
         casedir=$(echo "$job_data" | runjq -r '.job.settings.CASEDIR') || return $?
         [[ $casedir == null ]] && casedir=''
@@ -242,7 +242,7 @@ main() {
         fi
     fi
     set -u
-    clone_call="${clone_call:-"$client_prefix openqa-clone-job --skip-chained-deps --max-depth 0 --within-instance"}"
+    clone_call="${clone_call:-"$client_prefix openqa-clone-job --skip-chained-deps --max-depth 0 --parental-inheritance --within-instance"}"
     error_count=0
     # shellcheck disable=SC2013
     for i in $(cat - | sed 's/ .*$//'); do

--- a/openqa-investigate
+++ b/openqa-investigate
@@ -26,7 +26,7 @@ curl_args=(--user-agent "openqa-investigate")
 echoerr() { echo "$@" >&2; }
 
 clone() {
-    local origin id name_suffix refspec job_data unsupported_cluster_jobs name base_prio clone_settings casedir repo out url clone_id
+    local origin id name_suffix refspec job_data unsupported_cluster_jobs parallel_parents pending_cluster_jobs name base_prio clone_settings casedir repo out url clone_id
     origin=${1:?"Need 'origin'"}
     id=${2:?"Need 'id'"}
     name_suffix=${3+":$3"}
@@ -34,9 +34,19 @@ clone() {
     job_data=$(openqa-cli "${client_args[@]}" --json jobs/"$id")
     # shellcheck disable=SC2181
     [[ $? != 0 ]] && echoerr "unable to query job data for $id: $job_data" && return 1
-    unsupported_cluster_jobs=$(echo "$job_data" | runjq -r '(.job.children["Parallel"] | length) + (.job.parents["Parallel"] | length) + (.job.children["Directly chained"] | length) + (.job.parents["Directly chained"] | length)') || return $?
+
+    # fail on jobs with directly chained dependencies (not supported)
+    unsupported_cluster_jobs=$(echo "$job_data" | runjq -r '(.job.children["Directly chained"] | length) + (.job.parents["Directly chained"] | length)') || return $?
     [[ $unsupported_cluster_jobs != 0 ]] \
-        && echoerr "unable to clone job $id: it is part of a parallel or directly chained cluster (not supported)" && return 2
+        && echoerr "Unable to clone job $id: it is part of a directly chained cluster (not supported)" && return 2
+
+    # fail on parallel children (not supported)
+    # note: We already skip the investigation for parallel children to handle it together with the parent. However, the last good job
+    #       of the parallel parent might be a parallel child so we still need to check whether we have a parallel child.
+    parallel_parents=$(echo "$job_data" | runjq -r '(.job.parents["Parallel"] | length)') || return $?
+    [[ $parallel_parents != 0 ]] \
+        && echoerr "Unable to clone job $id: it is a parallel child; the structure of the parallel cluster might have changed since the last good (not supported)" && return 2
+
     name="$(echo "$job_data" | runjq -r '.job.test'):investigate$name_suffix" || return $?
     base_prio=$(echo "$job_data" | runjq -r '.job.priority') || return $?
     clone_settings=("TEST=$name" '_GROUP_ID=0' 'BUILD=')
@@ -119,6 +129,37 @@ trigger_jobs() {
     fi
 }
 
+check_dependencies_to_determine_whether_to_skip_or_postpone() {
+    local id=$1 job_data=$2 parallel_parents dependency_data pending_cluster_jobs cluster_jobs relevant_cluster_results
+
+    # skip parallel children (will be handled together with parallel parent)
+    # note: For this to work, this script needs to be executed for all job results (so we won't miss the investigation in case the parallel parent has passed).
+    parallel_parents=$(echo "$job_data" | runjq -r '(.job.parents["Parallel"] | length)') || return $?
+    [[ $parallel_parents != 0 ]] \
+        && echoerr "Skipping investigation of job $id: Investigation will be done on the parallel parent" && return 0
+
+    # postpone if not all dependencies are done/cancelled
+    # note: This "AJAX" route is normally used to render the dependencies tab in the web UI.
+    dependency_data=$(openqa-cli "${client_args[@]}" --apibase '' --json tests/"$id"/dependencies_ajax)
+    pending_cluster_jobs=$(echo "$dependency_data" | runjq -r '[.nodes[] | select(.state != "done" and .state != "cancelled")] | length') || return $?
+    [[ $pending_cluster_jobs != 0 ]] \
+        && echoerr "Postponing to investigate job $id: waiting until pending dependencies have finished" && return 142
+
+    # determine number of jobs in cluster with relevant result
+    # note: The "$id, …" is to always also consider the job itself (even if it is just a single job and therefore not in a cluster).
+    cluster_jobs=$(echo "$dependency_data" | runjq -r "[$id, [.cluster[] | select(contains([$id]))]] | flatten | unique") || return $?
+    # shellcheck disable=SC2016
+    relevant_cluster_results=$(echo "$dependency_data" | runjq --argjson cluster_jobs "$cluster_jobs" -r '[.nodes[] | select([.id] | inside($cluster_jobs)) | .result | select(inside("failed", "incomplete", "timeout_exceeded"))] | length') || return $?
+
+    # skip investigation if no jobs with relevant results are part of the cluster
+    # note: We need to run the investigate script for all jobs (see note from before) and therefore rely on checking the job/cluster result here.
+    [[ $relevant_cluster_results == 0 ]] \
+        && echoerr "Skip investigation of job $id: job is not failed/incomplete/timeout_exceeded, same counts for whole job cluster" && return 0
+
+    # do not skip the job
+    return 255
+}
+
 # crosscheck
 # 1. current job/build + current test -> check if reproducible/sporadic
 # 2. current job/build + last good test (+ last good needles) -> check for
@@ -151,6 +192,10 @@ investigate() {
         echoerr "Job already has a clone, skipping investigation. Use the env variable 'force=true' to trigger investigation jobs"
         return 0
     fi
+
+    check_dependencies_to_determine_whether_to_skip_or_postpone "$id" "$job_data"; rc=$?
+    [[ $rc != 255 ]] && return $rc
+
     [[ "$old_name" =~ $exclude_name_regex ]] && echo "Job name '$old_name' matches \$exclude_name_regex '$exclude_name_regex', skipping investigation" && return 0
     group="$(echo "$job_data" | runjq -r '.job.parent_group + " / " + .job.group')" || return $?
     [[ "$group" = " / " ]] && [[ "$exclude_no_group" = "true" ]] && echo "Job w/o job group, \$exclude_no_group is set, skipping investigation" && return 0

--- a/openqa-investigate
+++ b/openqa-investigate
@@ -149,7 +149,7 @@ check_dependencies_to_determine_whether_to_skip_or_postpone() {
     # note: The "$id, …" is to always also consider the job itself (even if it is just a single job and therefore not in a cluster).
     cluster_jobs=$(echo "$dependency_data" | runjq -r "[$id, [.cluster[] | select(contains([$id]))]] | flatten | unique") || return $?
     # shellcheck disable=SC2016
-    relevant_cluster_results=$(echo "$dependency_data" | runjq --argjson cluster_jobs "$cluster_jobs" -r '[.nodes[] | select([.id] | inside($cluster_jobs)) | .result | select(inside("failed", "incomplete", "timeout_exceeded"))] | length') || return $?
+    relevant_cluster_results=$(echo "$dependency_data" | runjq --argjson cluster_jobs "$cluster_jobs" -r '[.nodes[] | select([.id] | inside($cluster_jobs)) | .result | select(inside("failed"))] | length') || return $?
 
     # skip investigation if no jobs with relevant results are part of the cluster
     # note: We need to run the investigate script for all jobs (see note from before) and therefore rely on checking the job/cluster result here.

--- a/openqa-investigate
+++ b/openqa-investigate
@@ -26,7 +26,7 @@ curl_args=(--user-agent "openqa-investigate")
 echoerr() { echo "$@" >&2; }
 
 clone() {
-    local origin id name_suffix refspec job_data unsupported_cluster_jobs parallel_parents pending_cluster_jobs name base_prio clone_settings casedir repo out url clone_id
+    local origin id name_suffix refspec job_data unsupported_cluster_jobs pending_cluster_jobs name base_prio clone_settings casedir repo out url clone_id
     origin=${1:?"Need 'origin'"}
     id=${2:?"Need 'id'"}
     name_suffix=${3+":$3"}
@@ -39,13 +39,6 @@ clone() {
     unsupported_cluster_jobs=$(echo "$job_data" | runjq -r '(.job.children["Directly chained"] | length) + (.job.parents["Directly chained"] | length)') || return $?
     [[ $unsupported_cluster_jobs != 0 ]] \
         && echoerr "Unable to clone job $id: it is part of a directly chained cluster (not supported)" && return 2
-
-    # fail on parallel children (not supported)
-    # note: We already skip the investigation for parallel children to handle it together with the parent. However, the last good job
-    #       of the parallel parent might be a parallel child so we still need to check whether we have a parallel child.
-    parallel_parents=$(echo "$job_data" | runjq -r '(.job.parents["Parallel"] | length)') || return $?
-    [[ $parallel_parents != 0 ]] \
-        && echoerr "Unable to clone job $id: it is a parallel child; the structure of the parallel cluster might have changed since the last good (not supported)" && return 2
 
     name="$(echo "$job_data" | runjq -r '.job.test'):investigate$name_suffix" || return $?
     base_prio=$(echo "$job_data" | runjq -r '.job.priority') || return $?
@@ -129,14 +122,8 @@ trigger_jobs() {
     fi
 }
 
-check_dependencies_to_determine_whether_to_skip_or_postpone() {
-    local id=$1 job_data=$2 parallel_parents dependency_data pending_cluster_jobs cluster_jobs relevant_cluster_results
-
-    # skip parallel children (will be handled together with parallel parent)
-    # note: For this to work, this script needs to be executed for all job results (so we won't miss the investigation in case the parallel parent has passed).
-    parallel_parents=$(echo "$job_data" | runjq -r '(.job.parents["Parallel"] | length)') || return $?
-    [[ $parallel_parents != 0 ]] \
-        && echoerr "Skipping investigation of job $id: Investigation will be done on the parallel parent" && return 0
+query_dependency_data_or_postpone() {
+    local id=$1 job_data=$2 dependency_data pending_cluster_jobs
 
     # postpone if not all dependencies are done/cancelled
     # note: This "AJAX" route is normally used to render the dependencies tab in the web UI.
@@ -145,19 +132,45 @@ check_dependencies_to_determine_whether_to_skip_or_postpone() {
     [[ $pending_cluster_jobs != 0 ]] \
         && echoerr "Postponing to investigate job $id: waiting until pending dependencies have finished" && return 142
 
-    # determine number of jobs in cluster with relevant result
-    # note: The "$id, …" is to always also consider the job itself (even if it is just a single job and therefore not in a cluster).
-    cluster_jobs=$(echo "$dependency_data" | runjq -r "[$id, [.cluster[] | select(contains([$id]))]] | flatten | unique") || return $?
-    # shellcheck disable=SC2016
-    relevant_cluster_results=$(echo "$dependency_data" | runjq --argjson cluster_jobs "$cluster_jobs" -r '[.nodes[] | select([.id] | inside($cluster_jobs)) | .result | select(inside("failed"))] | length') || return $?
-
-    # skip investigation if no jobs with relevant results are part of the cluster
-    # note: We need to run the investigate script for all jobs (see note from before) and therefore rely on checking the job/cluster result here.
-    [[ $relevant_cluster_results == 0 ]] \
-        && echoerr "Skip investigation of job $id: job is not failed/incomplete/timeout_exceeded, same counts for whole job cluster" && return 0
-
     # do not skip the job
+    echo "$dependency_data"
     return 255
+}
+
+sync_via_investigation_comment() {
+    local id=$1 first_cluster_job_id=$2
+
+    comment_id=$("${client_call[@]}" -X POST jobs/"$first_cluster_job_id"/comments text="Starting investigation for job $id" | runjq -r '.id') || return $?
+    first_comment_id=$("${client_call[@]}" -X GET jobs/"$first_cluster_job_id"/comments | runjq -r '[.[] | select(.text | contains("investigation"))] | sort_by(.id) | first | .id') || return $?
+
+    # delete comment again in case a concurrent job could start the investigation before us
+    if [[ $comment_id != "$first_comment_id" ]]; then
+        echoerr "Skipping investigation of job $id: job cluster is already being investigated, see comment on job $first_cluster_job_id"
+        "${client_call[@]}" -X DELETE jobs/"$first_cluster_job_id"/comments/"$comment_id" && return 0
+    fi
+
+    echo "$comment_id"
+    return 255
+}
+
+finalize_investigation_comment() {
+    local id=$1 first_cluster_job_id=$2 comment_id=$3 comment_text=$4
+
+    # delete comment again if there were no investigation jobs needed after all
+    if ! [[ $comment_text ]]; then
+        "${client_call[@]}" -X DELETE jobs/"$first_cluster_job_id"/comments/"$comment_id"
+        return 0
+    fi
+
+    local comment="Automatic investigation jobs for job $id:
+
+$comment_text"
+    "${client_call[@]}" -X PUT jobs/"$first_cluster_job_id"/comments/"$comment_id" text="$comment"
+
+    # also write a comment on the job we're actually investigating
+    if [[ $first_cluster_job_id != "$id" ]]; then
+        "${client_call[@]}" -X POST jobs/"$id"/comments text="$comment"
+    fi
 }
 
 # crosscheck
@@ -193,8 +206,12 @@ investigate() {
         return 0
     fi
 
-    check_dependencies_to_determine_whether_to_skip_or_postpone "$id" "$job_data"; rc=$?
+    # determine dependency data or postpone if cluster not done
+    dependency_data=$(query_dependency_data_or_postpone "$id" "$job_data"); rc=$?
     [[ $rc != 255 ]] && return $rc
+
+    # determine the job in the cluster with the lowest ID to use that for commenting/synchronization
+    first_cluster_job_id=$(echo "$dependency_data" | runjq -r "[$id, [.cluster[] | select(contains([$id]))]] | flatten | sort | first") || return $?
 
     [[ "$old_name" =~ $exclude_name_regex ]] && echo "Job name '$old_name' matches \$exclude_name_regex '$exclude_name_regex', skipping investigation" && return 0
     group="$(echo "$job_data" | runjq -r '.job.parent_group + " / " + .job.group')" || return $?
@@ -205,13 +222,13 @@ investigate() {
     # method instead for we are just working based on supplied job which can
     # have more, ambiguous potential changes that we need to bisect on
 
+    # sync by writing initial investigation comment (edited later)
+    comment_id=$(sync_via_investigation_comment "$id" "$first_cluster_job_id"); rc=$?
+    [[ $rc != 255 ]] && return $rc
+
     out=$(trigger_jobs "$id" "${@:2}")
     $verbose && echo "$0, id: '$id', out: '$out'"
-    [[ $out ]] || return 0
-    comment="Automatic investigation jobs:
-
-$out"
-    "${client_call[@]}" -X POST jobs/"$id"/comments text="$comment"
+    finalize_investigation_comment "$id" "$first_cluster_job_id" "$comment_id" "$out"
 }
 
 main() {
@@ -225,7 +242,7 @@ main() {
         fi
     fi
     set -u
-    clone_call="${clone_call:-"$client_prefix openqa-clone-job --skip-chained-deps --within-instance"}"
+    clone_call="${clone_call:-"$client_prefix openqa-clone-job --skip-chained-deps --max-depth 0 --within-instance"}"
     error_count=0
     # shellcheck disable=SC2013
     for i in $(cat - | sed 's/ .*$//'); do

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -52,8 +52,8 @@ openqa-cli() {
     elif [[ $@ == '--apibase  --json tests/30/dependencies_ajax' ]]; then
         echo '{"cluster":{"cluster_foo":[28,30],"cluster_bar":[29]}, "edges":[], "nodes":[{"id":28,"state":"uploading","result":"none"},{"id":30,"state":"done","result":"passed"}]}'
     elif [[ $@ == '--apibase  --json tests/31/dependencies_ajax' ]]; then
-        # job with cancelled job in the cluster (should be treated like a done job) that is incomplete (should be treated like failed)
-        echo '{"cluster":{"cluster_foo":[28,31],"cluster_bar":[29]}, "edges":[], "nodes":[{"id":28,"state":"cancelled","result":"none"},{"id":31,"state":"done","result":"incomplete"}]}'
+        # job with cancelled job in the cluster (should be treated like a done job)
+        echo '{"cluster":{"cluster_foo":[28,31],"cluster_bar":[29]}, "edges":[], "nodes":[{"id":28,"state":"cancelled","result":"none"},{"id":31,"state":"done","result":"failed"}]}'
     else
         echo '{"result": [{ "25": "foo", "26": "bar" }], "test_url": [{"25": "/tests/25", "26": "/tests/26"}] } '
     fi


### PR DESCRIPTION
Latest commit: Sync investigation of parallel clusters via openQA comment

* Instead of only considering parallel parents, just do the investigation
  for any job with parallel dependencies
    * Avoid having to run the investigation script for all job results
    * Sync via an openQA comment instead (to avoid running the same
      investigation twice; abort if a concurrent job already does the
      investigation of the cluster)
    * Use `--max-depth 0` to clone all jobs in the parallel cluster,
      regardless whether we're starting from a parallel parent or child
        * Has no effect on other dependency types since we're
            * using `--skip-chained-deps` anyways
            * *not* using `--clone-children`
            * still excluding directly chained dependencies
* Write an investigation comment on the job we're actually investigating
  and on the first job in the cluster (for the synchronization)
* See https://progress.opensuse.org/issues/95783#note-58