### PR TITLE
Fix postponing the investigation

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -243,12 +243,12 @@ main() {
     fi
     set -u
     clone_call="${clone_call:-"$client_prefix openqa-clone-job --skip-chained-deps --max-depth 0 --parental-inheritance --within-instance"}"
-    error_count=0
+    local rc=0
     # shellcheck disable=SC2013
     for i in $(cat - | sed 's/ .*$//'); do
-        investigate "$i" "$@" || ((error_count++)) ||:
+        investigate "$i" "$@" || rc=$?
     done
-    exit "$error_count"
+    exit $rc
 }
 
 caller 0 >/dev/null || main "$@"

--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
 
-set -o pipefail
+set -eo pipefail
 
 # "hook script" intended to be called by openQA instances taking a job ID as
 # parameter and forwarding a complete job URL to "openqa-label-known-issues"

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -13,7 +13,7 @@ PATH=$BASHLIB$PATH
 
 source bash+ :std
 use Test::More
-plan tests 24
+plan tests 26
 
 host=localhost
 url=https://localhost
@@ -94,6 +94,11 @@ rc=0
 out=$(investigate 30 2>&1) || rc=$?
 is "$rc" 142 'investigation postponed because other job in cluster is not done'
 like "$out" "Postponing to investigate job 30: waiting until pending dependencies have finished"
+
+rc=0
+out=$(echo 30 | main 2>&1) || rc=$?
+is "$rc" 142 'return code (for postponing) passed by main function'
+like "$out" "Postponing to investigate job 30: waiting until pending dependencies have finished" 'output passed by main function'
 
 rc=0
 out=$(force=true investigate 31 2>&1) || rc=$?


### PR DESCRIPTION
* Ensure the `main()` function of `openqa-investigate` actually passes the
  return code of the `investigate()` call
    * Only returns the return code of the last `investigate()` call but
      that should be ok since we're only investigating one job at a time
      in `openqa-label-known-issues-and-investigate-hook`
* Add `set -e` to `openqa-label-known-issues-and-investigate-hook` for
  consistent behavior regardless whether the script is called via shebang
  or not
* Tested against my local instance to see whether
  `openqa-label-known-issues` and
  `openqa-label-known-issues-and-investigate-hook` will actually return 142
* See https://progress.opensuse.org/issues/95783