### PR TITLE
Include job ID in error/skip messages of investigate script

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -195,14 +195,14 @@ investigate() {
         # gracefully
         out=$("${client_call[@]}" -X POST jobs/"$origin_job_id"/comments text="Investigate retry job: $host_url/t$id failed, likely not a sporadic failure" 2>/dev/null) || \
             if [[ $(echo "$out" | runjq .error_status) != "404" ]]; then
-                echoerr "Unexpected error encountered when posting comments: '$out'"
+                echoerr "Unexpected error encountered when posting comments on job $origin_job_id after investigation job $id failed: '$out'"
                 return 2
             fi
         return 0
     fi
     clone="$(echo "$job_data" | runjq -r '.job.clone_id')" || return $?
     if ! "$force" && [[ "$clone" != "null" ]]; then
-        echoerr "Job already has a clone, skipping investigation. Use the env variable 'force=true' to trigger investigation jobs"
+        echoerr "Job $id already has a clone, skipping investigation. Use the env variable 'force=true' to trigger investigation jobs"
         return 0
     fi
 

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -83,7 +83,7 @@ is "$out" "* **$testlabel**: " "Expected markdown output of job urls for unsuppo
 rc=0
 out=$(investigate 27 2>&1) || rc=$?
 is "$rc" 0 'success regardless of actually triggered jobs'
-is "$out" "Job already has a clone, skipping investigation. Use the env variable 'force=true' to trigger investigation jobs"
+is "$out" "Job 27 already has a clone, skipping investigation. Use the env variable 'force=true' to trigger investigation jobs"
 
 rc=0
 out=$(force=true investigate 28 2>&1) || rc=$?


### PR DESCRIPTION
When checking the GRU log these messages are without context and therefore
quite meaningless without the related job ID.