### PR TITLE
trigger-openqa_in_openqa: Fix lookup of latest Tumbleweed qcow

### DIFF
--- a/trigger-openqa_in_openqa
+++ b/trigger-openqa_in_openqa
@@ -37,7 +37,7 @@ find_latest_published_tumbleweed_image() {
     qcow=null
     for latest_published_tw_build in $latest_published_tw_builds; do
         qcow=$(${openqa_cli} api --host "${tw_openqa_host}" assets \
-            | jq -r "[.assets[] | select(.name | test(\"Tumbleweed-$arch-$latest_published_tw_build-Tumbleweed\\\\@$machine.qcow\")) | select(.size != null)] | .[0] | .name")
+            | jq -r "[.assets[] | select(.name | test(\"Tumbleweed-$arch-$latest_published_tw_build-Tumbleweed\\\\@$machine.*.qcow\")) | select(.size != null)] | .[0] | .name")
         # This published build has an image available
         if [[ "$qcow" != "null" ]]; then
             break


### PR DESCRIPTION
We can generalize the search for assets by looking for any machine
suffix. Lately the qcow generating test scenario was changed to run on
the machine variant "64bit-3G" so our lookup did not match anymore.

Tested manually locally by calling

```
openqa-cli api --host https://openqa.opensuse.org assets | jq -r '[.assets[] | select(.name | test("Tumbleweed-x86_64-20220801-Tumbleweed\\@64bit.*.qcow")) | select(.size != null)] | .[0] | .name'
```

which yields "opensuse-Tumbleweed-x86_64-20220801-Tumbleweed@64bit-3G.qcow2

Related progress issue: https://progress.opensuse.org/issues/114944