### PR TITLE
Localize return code in openqa-investigate

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -184,6 +184,7 @@ $comment_text"
 #    sources, e.g. infrastructure
 investigate() {
     id="${1##*/}"
+    local rc=0
 
     job_data=$(openqa-cli "${client_args[@]}" --json jobs/"$id")
     # shellcheck disable=SC2181


### PR DESCRIPTION
rc is set inside of investigate(), and 255 is actually used for
success, and if investigate() returns successfully, rc will keep
the value from inside.
So we need to localize it at the beginning of investigate()