### PR TITLE
Do not send E-Mail notifications for restarted jobs

### DIFF
--- a/_common
+++ b/_common
@@ -131,7 +131,9 @@ handle_unknown() {
         group_description=$(echo "$group_data" | runjq -r '.[0].description' ) || true
         group_mailto=$(echo "$group_description" | perl -n -wE'm/.*MAILTO: (\S+).*/ and say $1' | head -1)
         group_mailto=${group_mailto:-$notification_address}
-        if [[ -n "$group_mailto" ]]; then
+        # Avoid sending notifications for jobs that were restarted
+        clone_id="$(echo "$job_data" | runjq -r '.job.clone_id')"
+        if [[ -n "$group_mailto" && "$clone_id" == 'null' ]]; then
             group_name=$(echo "$group_data" | runjq -r '.[0].name')
             job_name=$(echo "$job_data" | runjq -r '.job.name')
             job_result=$(echo "$job_data" | runjq -r '.job.result')

--- a/test/01-label-known-issues.t
+++ b/test/01-label-known-issues.t
@@ -114,6 +114,6 @@ out=$(handle_unknown "$testurl" "$logfile1" "no reason" "$group_id" true "$from_
 like "$out" '' "send-email not called for no email address and no fallback address"
 
 notification_address=fallback@example.com
-out=$(handle_unknown "$testurl" "$logfile1" "no reason" "$group_id" true "$from_email" "$notification_address" 2>&1 >/dev/null) || true
+out=$(handle_unknown "$testurl" "$logfile1" "no reason" "$group_id" true "$from_email" "$notification_address" "$job_data" 2>&1 >/dev/null) || true
 like "$out" 'To: fallback@example.com' "send-email to like expected"
 like "$out" 'Subject: Unreviewed issue .Group 25 Lala.' "send-email subject like expected"


### PR DESCRIPTION
Proposal: avoid sending E-Mail notifications for jobs that were automatically restarted (for example, via **RETRY** setting) by checking if the job has been cloned.