### PR TITLE
Add error-handling for openqa-investigate

### DIFF
--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -14,9 +14,12 @@ dirname=$(dirname "$0")
 script_dir=${script_dir:-$dirname}
 
 investigate-and-bisect() {
+    local rc=0 test
     read -r test
-    echo "$test" | "$script_dir/openqa-investigate"
-    "$script_dir/openqa-trigger-bisect-jobs" --url "$test"
+    echo "$test" | "$script_dir/openqa-investigate" || rc=$?
+    [[ "$rc" -eq 142 ]] && return "$rc"
+    "$script_dir/openqa-trigger-bisect-jobs" --url "$test" || rc=$?
+    return "$rc"
 }
 
 echo "$host_url/tests/$id" | "$script_dir/openqa-label-known-issues" | sed -n 's/\[\([^]]*\)\].*Unknown issue, to be reviewed.*/\1/p' | investigate-and-bisect

--- a/test/03-openqa-label-known-issues-and-investigate-hook.t
+++ b/test/03-openqa-label-known-issues-and-investigate-hook.t
@@ -13,7 +13,7 @@ PATH=$BASHLIB$PATH
 
 source bash+ :std
 use Test::More
-plan tests 3
+plan tests 5
 
 rc=0
 output=$(script_dir=$dir/scripts ./openqa-label-known-issues-and-investigate-hook 123 2>&1) || rc=$?
@@ -22,3 +22,13 @@ is "$rc" 0 'successful hook'
 like "$output" 'https://openqa.opensuse.org/tests/123 | openqa-investigate' 'correct output 1'
 like "$output" 'openqa-trigger-bisect-jobs .--url https://openqa.opensuse.org/tests/123.' 'correct output 2'
 
+export INVESTIGATE_FAIL=true
+rc=0
+output=$(script_dir=$dir/scripts ./openqa-label-known-issues-and-investigate-hook 123 2>&1) || rc=$?
+is "$rc" 1 'openqa-investigate failed'
+
+export INVESTIGATE_FAIL=false
+export INVESTIGATE_RETRIGGER_HOOK=true
+rc=0
+output=$(script_dir=$dir/scripts ./openqa-label-known-issues-and-investigate-hook 123 2>&1) || rc=$?
+is "$rc" 142 'openqa-investigate exit code for retriggering hook script'

--- a/test/scripts/openqa-investigate
+++ b/test/scripts/openqa-investigate
@@ -1,4 +1,6 @@
 #!/bin/bash
+"$INVESTIGATE_FAIL" && exit 1
+"$INVESTIGATE_RETRIGGER_HOOK" && exit 142
 for testurl in $(cat - | sed 's/ .*$//'); do
     echo "$testurl | openqa-investigate"
 done


### PR DESCRIPTION
In case of exit code 142 we want to exit early because the hook script will
be retriggered.
In case of another non-zero exit code we can still execute openqa-trigger-bisect-jobs

Issue: https://progress.opensuse.org/issues/115178