### PR TITLE
Add openqa-powermanagement.py script

### DIFF
--- a/openqa-powermanagement.py
+++ b/openqa-powermanagement.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python3
+
+# TODO:
+#  * Add return values checks to avoid crashes/traces (no connection to openQA server, etc.)
+#  * The host name of machines may not be unique
+
+import configparser
+import argparse
+import json
+import os
+import requests
+import subprocess
+
+machine_list_idle = []
+machine_list_offline = []
+machine_list_busy= []
+machines_to_power_on = []
+
+jobs_worker_classes = []
+
+config_file = os.path.join(os.environ.get("OPENQA_CONFIG", "/etc/openqa"), "openqa.ini")
+config = configparser.ConfigParser()
+config.read(config_file)
+
+openqa_server = "http://localhost"
+
+# Manage cmdline options
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config')
+    parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--host')
+    parser.add_argument('--osd', action='store_true')
+    parser.add_argument('--o3', action='store_true')
+    args = parser.parse_args()
+    if args.config is not None and len(args.config):
+        config_file = args.config
+    if args.host is not None and len(args.host):
+        openqa_server = args.host
+    elif args.osd:
+        openqa_server = "https://openqa.suse.de"
+    elif args.o3:
+        openqa_server = "https://openqa.opensuse.org"
+
+print("Using openQA server: " + openqa_server)
+print("Using config file: " + config_file)
+if args.dry_run:
+    print("Dry run mode")
+print("")
+
+# Scheduled/blocked jobs
+scheduled_list_file = requests.get(openqa_server + '/tests/list_scheduled_ajax').content
+scheduled_list_data = json.loads(scheduled_list_file)
+print("Processing " + str(len(scheduled_list_data['data'])) + " job(s) in scheduled/blocked state... (will take about " + str(int(len(scheduled_list_data['data']) * 0.2)) + " seconds)")
+  
+# Create list of WORKER_CLASS needed
+for job in scheduled_list_data['data']:
+    response = requests.get(openqa_server + '/api/v1/jobs/' + str(job['id']))
+    job_data = json.loads(response.content)
+    jobs_worker_classes.append(job_data['job']['settings']['WORKER_CLASS'])
+
+jobs_worker_classes = sorted(set(jobs_worker_classes))
+print("Found " + str(len(jobs_worker_classes)) + " different WORKER_CLASS in scheduled jobs: " + str(jobs_worker_classes))
+
+
+
+# Workers
+workers_list_file = requests.get(openqa_server + '/api/v1/workers').content
+workers_list_data = json.loads(workers_list_file)
+
+# Create list of hosts which may need to powered up/down
+for worker in workers_list_data['workers']:
+    if worker['status'] in ['idle']:
+        machine_list_idle.append(worker['host'])
+    elif worker['status'] in ['dead']: # Looks like 'dead' means 'offline'
+        machine_list_offline.append(worker['host'])
+    else: # worker['status'] in ['running', 'broken']: # Looks like 'running' means 'working'
+        machine_list_busy.append(worker['host'])
+
+# Clean-up the lists
+machine_list_idle = sorted(set(machine_list_idle))
+machine_list_offline = sorted(set(machine_list_offline))
+machine_list_busy = sorted(set(machine_list_busy))
+
+# Remove the machine from idle/offline lists if at least 1 worker is busy
+for machine in machine_list_busy:
+    if machine in machine_list_idle:
+        machine_list_idle.remove(machine)
+    if machine in machine_list_offline:
+        machine_list_offline.remove(machine)
+# Remove the machine from offline list if at least 1 worker is idle
+for machine in machine_list_idle:
+    if machine in machine_list_offline:
+        machine_list_offline.remove(machine)
+
+# Print an overview
+print(str(len(machine_list_idle)) + " workers listed fully idle: " + str(machine_list_idle))
+print(str(len(machine_list_offline)) + " workers listed offline/dead: " + str(machine_list_offline))
+print(str(len(machine_list_busy)) + " workers listed busy: " + str(machine_list_busy))
+
+# Get WORKER_CLASS for each workers of each machines (idle and offline) and compare to WORKER_CLASS required by scheduled/blocked jobs
+for worker in workers_list_data['workers']:
+    if worker['host'] in machine_list_offline:
+        for classes in jobs_worker_classes:
+            if set(classes.split(',')).issubset(worker['properties']['WORKER_CLASS'].split(',')):
+                machines_to_power_on.append(worker['host'])
+    
+    if worker['host'] in machine_list_idle:
+        if worker['properties']['WORKER_CLASS'] in jobs_worker_classes:
+            # Warning: scheduled (blocked?) job could be run on idle machine!
+            print("Warning: scheduled (blocked?) job could be run on idle machine!")
+
+# Power on machines which can run scheduled jobs
+for machine in sorted(set(machines_to_power_on)):
+    if args.dry_run:
+        print("Would power ON '" + machine + "' - Dry run mode")
+    elif 'power_management' in config and config['power_management'].get(machine + "_POWER_ON"):
+        print("Powering ON: " + machine)
+        subprocess.call(config['power_management'][machine + "_POWER_ON"])
+    else:
+        print("Unable to power ON '" + machine + "' - No command for that")
+
+# Power off machines which are idle (TODO: add a threshold, e.g. idle since more than 15 minutes. Does API provide this information?)
+for machine in machine_list_idle:
+    if args.dry_run:
+        print("Would power OFF '" + machine + "' - Dry run mode")
+    elif 'power_management' in config and config['power_management'].get(machine + "_POWER_OFF"):
+        print("Powering OFF: " + machine)
+        subprocess.call(config['power_management'][machine + "_POWER_OFF"])
+    else:
+        print("Unable to power OFF '" + machine + "' - No command for that")


### PR DESCRIPTION
to power on/off on-demand the machines running openQA workers.


This script is being tested with machine `siodtw01` (SoftIron Overdrive 1000, behind a smartplug TP-Link HS100) connected to o3 and running Raspberry Pi 2/3/4 tests.

# Limitations
Currently, only a single openQA server is supported, so workers connected to multiple openQA servers should not be managed by this script yet.

# Usage
Run `openqa-powermanagement.py` with one of the following options: `--o3`, `--osd` or `--host http://myhost`.

Without configuration file, or with `--dry-run` option, it will only check if some machines running openQA workers could be switched OFF or ON, without any action.

With appropriate configuration file (`/etc/openqa/openqa.ini`), it will power ON/OFF some machines, depending on the scheduled jobs and current state of workers running on the machines.

Example of output with a config file for `siodtw01` machine:
```
Using openQA server: https://openqa.opensuse.org
Using config file: /etc/openqa/openqa.ini

Processing 358 job(s) in scheduled/blocked state... (will take about 71 seconds)
Found 15 different WORKER_CLASS in scheduled jobs: ['generalhw_RPi2B', 'heavyload,qemu_aarch64', 'heavyload,qemu_ppc64', 'heavyload,qemu_ppc64le', 'heavyload,qemu_x86_64', 'openqaworker1,qemu_x86_64', 'openqaworker1,windows', 'qemu_aarch64', 'qemu_ppc64', 'qemu_ppc64le', 'qemu_x86_64', 'qemu_x86_64,tap', 's390x-zVM-vswitch-l2', 's390x-zVM-vswitch-l2,tap', 'windows']
1 workers listed fully idle: ['rebel']
8 workers listed offline/dead: ['hctw01', 'imagetester', 'n1sdp', 'openqaworker1_container', 'openqaworker20', 'openqaworker7_container', 'power8', 'siodtw01']
8 workers listed busy: ['ip-10-252-32-90', 'ip-10-252-32-98', 'openqa-aarch64', 'openqaworker1', 'openqaworker19', 'openqaworker4', 'openqaworker7', 'oss-cobbler-03']
Unable to power ON 'imagetester' - No command for that
Unable to power ON 'openqaworker1_container' - No command for that
Unable to power ON 'openqaworker20' - No command for that
Unable to power ON 'power8' - No command for that
Powering ON: siodtw01
Unable to power OFF 'rebel' - No command for that
```

# Config

Edit `/etc/openqa/openqa.ini` to add a `power_management` section. In this section adds 2 parameters _<machine_name\>_\_POWER_ON and _<machine_name\>_\_POWER_OFF. The values are path to executable scripts to power on/off the machine.
For instance, for the machine named `siodtw01`, we could have:

```
[power_management]
siodtw01_POWER_ON = /home/guillaume/openqa-powermanagement/siodtw01_power_on.sh
siodtw01_POWER_OFF = /home/guillaume/openqa-powermanagement/siodtw01_power_off.sh
```

You have a range of smartplug devcies supported by scripts in `/var/lib/openqa/share/tests/opensuse/data/generalhw_scripts/` folder (from [https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/data/generalhw_scripts](https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/data/generalhw_scripts)) but you could also use BMC/ipmi interfaces.
