### PR TITLE
label-known-issues: Skip passed tests

### DIFF
--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -110,6 +110,12 @@ investigate_issue() {
     local reason
     local curl_output
     job_data=$(openqa-cli "${client_args[@]}" jobs/"$id")
+    state="$(echo "$job_data" | runjq -r '.job.state')"
+    result="$(echo "$job_data" | runjq -r '.job.result')"
+    # Skip all unfinished or passed jobs for now
+    if [[ "$state" != 'done' || "$result" == passed ]]; then
+        return
+    fi
     reason=$(echo "$job_data" | runjq -r '.job.reason')
     group_id=$(echo "$job_data" | runjq -r '.job.group_id')
     curl_output=$(curl "${curl_args[@]}" -s -w "%{http_code}" "$testurl/file/autoinst-log.txt" -o "$out")


### PR DESCRIPTION
In order to enable _TRIGGER_JOB_DONE_HOOK=1 for investigate jobs we first have to make sure it exits early for passed jobs.

Later we can add the requested comment logic.

Issue: https://progress.opensuse.org/issues/98862