### PR TITLE
Convert Bash tests to use bpan-org/test-tap-bash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/test-more-bash/
+/bpan/
 /tests/__pycache__/
 /__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ all:
 test: checkstyle test-unit
 
 .PHONY: test-unit
-test-unit: test-more-bash
+test-unit: bpan
 	prove -r test/ xt/
 	py.test
 
-test-more-bash:
-	git clone https://github.com/ingydotnet/test-more-bash.git --depth 1 -b 0.0.5
+bpan:
+	git clone https://github.com/bpan-org/bpan.git --depth 1
 
 .PHONY: test-online
 test-online:

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ requests for consideration or create an issue with a code change proposal.
 
 #### Functional testing
 
-This is done with the [Test::More bash
-library](https://github.com/ingydotnet/test-more-bash).
+This is done with the [test-tap-bash
+library](https://github.com/bpan-org/test-tap-bash).
 It will be automatically cloned.
 
 

--- a/test/01-label-known-issues.t
+++ b/test/01-label-known-issues.t
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+source test/init
 
-dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
-
-TEST_MORE_PATH=$dir/../test-more-bash
-BASHLIB="`
-    find $TEST_MORE_PATH -type d |
-    grep -E '/(bin|lib)$' |
-    xargs -n1 printf "%s:"`"
-PATH=$BASHLIB$PATH
-
-source bash+ :std
-use Test::More
 plan tests 25
 
 source _common

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+source test/init
 
-dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
-
-TEST_MORE_PATH=$dir/../test-more-bash
-BASHLIB="`
-    find $TEST_MORE_PATH -type d |
-    grep -E '/(bin|lib)$' |
-    xargs -n1 printf "%s:"`"
-PATH=$BASHLIB$PATH
-
-source bash+ :std
-use Test::More
 plan tests 27
 
 host=localhost

--- a/test/03-openqa-label-known-issues-and-investigate-hook.t
+++ b/test/03-openqa-label-known-issues-and-investigate-hook.t
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+source test/init
 
-dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
-
-TEST_MORE_PATH=$dir/../test-more-bash
-BASHLIB="`
-    find $TEST_MORE_PATH -type d |
-    grep -E '/(bin|lib)$' |
-    xargs -n1 printf "%s:"`"
-PATH=$BASHLIB$PATH
-
-source bash+ :std
-use Test::More
 plan tests 5
 
 rc=0

--- a/test/04-common.t
+++ b/test/04-common.t
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+source test/init
 
-dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
-
-TEST_MORE_PATH=$dir/../test-more-bash
-BASHLIB="`
-    find $TEST_MORE_PATH -type d |
-    grep -E '/(bin|lib)$' |
-    xargs -n1 printf "%s:"`"
-PATH=$BASHLIB$PATH
-
-source bash+ :std
-use Test::More
 plan tests 12
 
 source _common

--- a/test/init
+++ b/test/init
@@ -1,0 +1,7 @@
+#!/bash
+
+export BPAN_ROOT=$PWD/bpan
+
+source "$BPAN_ROOT/test/init"
+
+dir=$PWD/test


### PR DESCRIPTION
The ingydotnet/test-more-bash and bash+ libraries are deprecated in favor of the https://github.com/bpan-org versions.

None of the test logic needed changing at all.
The test bootstrap code in each test was replaced with a single line that does the same thing with the newer libraries.

The bpan-org/test-tap-bash library does everything test-more-bash did and more.

The test-tap-bash library is packaged in the `bpan` repo itself, so the Makefile now clones the bpan-org/bpan repo locally and the tests use these bundled libraries.