### PR TITLE
Replace `is` with `ok` when checking command status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/test-more-bash/
+/bpan/
 /tests/__pycache__/
 /__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ all:
 test: checkstyle test-unit
 
 .PHONY: test-unit
-test-unit: test-more-bash
+test-unit: bpan
 	prove -r test/ xt/
 	py.test
 
-test-more-bash:
-	git clone https://github.com/ingydotnet/test-more-bash.git --depth 1 -b 0.0.5
+bpan:
+	git clone https://github.com/bpan-org/bpan.git --depth 1
 
 .PHONY: test-online
 test-online:

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ requests for consideration or create an issue with a code change proposal.
 
 #### Functional testing
 
-This is done with the [Test::More bash
-library](https://github.com/ingydotnet/test-more-bash).
+This is done with the [test-tap-bash
+library](https://github.com/bpan-org/test-tap-bash).
 It will be automatically cloned.
 
 

--- a/test/01-label-known-issues.t
+++ b/test/01-label-known-issues.t
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+source test/init
 
-dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
-
-TEST_MORE_PATH=$dir/../test-more-bash
-BASHLIB="`
-    find $TEST_MORE_PATH -type d |
-    grep -E '/(bin|lib)$' |
-    xargs -n1 printf "%s:"`"
-PATH=$BASHLIB$PATH
-
-source bash+ :std
-use Test::More
 plan tests 25
 
 source _common

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+source test/init
 
-dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
-
-TEST_MORE_PATH=$dir/../test-more-bash
-BASHLIB="`
-    find $TEST_MORE_PATH -type d |
-    grep -E '/(bin|lib)$' |
-    xargs -n1 printf "%s:"`"
-PATH=$BASHLIB$PATH
-
-source bash+ :std
-use Test::More
 plan tests 27
 
 host=localhost

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -118,19 +118,19 @@ for trace_file in comment_1234_updated comment_for_job_31_created comment_1234_d
 done
 
 # test finalizing investigation comment when no investigation jobs were needed
-rc=0
-out=$(force=true finalize_investigation_comment 31 30 1234 '' 2>&1) || rc=$?
-is "$rc" 0 'success if no investigation jobs needed to be created after all'
-[[ -f comment_1234_deleted ]] && comment_1234_deleted=1 || comment_1234_deleted=0
-[[ -f comment_for_job_31_created ]] && comment_for_job_31_created=1 || comment_for_job_31_created=0
-is "$comment_1234_deleted" 1 'comment on job 30 deleted'
-is "$comment_for_job_31_created" 0 'no comment on job 31 created'
+ok "$(force=true finalize_investigation_comment 31 30 1234 '' 2>&1)" \
+    'success if no investigation jobs needed to be created after all'
+ok "$([[ -f comment_1234_deleted ]])" \
+    'comment on job 30 deleted'
+ok "$([[ ! -f comment_for_job_31_created ]])" \
+    'no comment on job 31 created'
 
 # test finalizing investigation comment when investigation jobs had been created
-rc=0
-out=$(force=true finalize_investigation_comment 31 30 1234 'foo' 2>&1) || rc=$?
-is "$rc" 0 'success if we write an investigation comment'
-[[ -f comment_1234_updated ]] && comment_1234_updated=1 || comment_1234_updated=0
-[[ -f comment_for_job_31_created ]] && comment_for_job_31_created=1 || comment_for_job_31_created=0
-is "$comment_1234_updated" 1 'comment on job 30 updated'
-is "$comment_for_job_31_created" 1 'comment on job 31 created as well'
+ok "$(force=true finalize_investigation_comment 31 30 1234 'foo' 2>&1)" \
+    'success if we write an investigation comment'
+ok "$([[ -f comment_1234_updated ]])" \
+    'comment on job 30 updated'
+ok "$([[ -f comment_for_job_31_created ]])" \
+    'comment on job 31 created as well'
+
+rm -f comment_1234_updated comment_for_job_31_created comment_1234_deleted

--- a/test/03-openqa-label-known-issues-and-investigate-hook.t
+++ b/test/03-openqa-label-known-issues-and-investigate-hook.t
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+source test/init
 
-dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
-
-TEST_MORE_PATH=$dir/../test-more-bash
-BASHLIB="`
-    find $TEST_MORE_PATH -type d |
-    grep -E '/(bin|lib)$' |
-    xargs -n1 printf "%s:"`"
-PATH=$BASHLIB$PATH
-
-source bash+ :std
-use Test::More
 plan tests 5
 
 rc=0

--- a/test/04-common.t
+++ b/test/04-common.t
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+source test/init
 
-dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
-
-TEST_MORE_PATH=$dir/../test-more-bash
-BASHLIB="`
-    find $TEST_MORE_PATH -type d |
-    grep -E '/(bin|lib)$' |
-    xargs -n1 printf "%s:"`"
-PATH=$BASHLIB$PATH
-
-source bash+ :std
-use Test::More
 plan tests 12
 
 source _common

--- a/test/init
+++ b/test/init
@@ -1,0 +1,7 @@
+#!/bash
+
+export BPAN_ROOT=$PWD/bpan
+
+source "$BPAN_ROOT/test/init"
+
+dir=$PWD/test


### PR DESCRIPTION
(based on #194)

The test-tap-bash (and test-more-bash before) supports:

    ok "$(cmd ...)" "label"

for testing whether a command resulted in return status of 0.

This is much cleaner than setting a state variable and then testing it
with `is`.