### PR TITLE
Fix empty openqa-cli call in monitor-openqa_job

### DIFF
--- a/_common
+++ b/_common
@@ -8,7 +8,7 @@ enable_force_result=${enable_force_result:-false}
 client_call=()
 client_args=()
 markdown_cmd=$(command -v Markdown.pl) || markdown_cmd=$(command -v markdown)
-openqa_cli=""
+openqa_cli="${openqa_cli:-""}"
 
 warn() { echo "$@" >&2; }
 


### PR DESCRIPTION
This fixes a regression introduced by 1845c6d which unconditionally
overwrites the openqa_cli variable in _common which causes other scripts
setting the configuration variable before to break. This was noticed as
http://jenkins.qa.suse.de/job/monitor-openQA_in_openQA-TW/ using
monitor-openqa_job failed to call openqa-cli.