### PR TITLE
Make hook script easier to test

### DIFF
--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -5,22 +5,25 @@ set -eo pipefail
 # "hook script" intended to be called by openQA instances taking a job ID as
 # parameter and forwarding a complete job URL to "openqa-label-known-issues"
 # on stdin and all left unknowns to "openqa-investigate"
+dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
+PATH=$dir:$PATH
 
-id="${1:?"Need 'job_id'"}"
 host="${host:-"openqa.opensuse.org"}"
 scheme="${scheme:-"https"}"
 host_url="$scheme://$host"
-dirname=$(dirname "$0")
-script_dir=${script_dir:-$dirname}
 
 investigate-and-bisect() {
     local rc=0 test
     read -r test
-    echo "$test" | "$script_dir/openqa-investigate" || rc=$?
+    echo "$test" | openqa-investigate || rc=$?
     [[ "$rc" -eq 142 ]] && return "$rc"
-    "$script_dir/openqa-trigger-bisect-jobs" --url "$test" || rc=$?
+    openqa-trigger-bisect-jobs --url "$test" || rc=$?
     return "$rc"
 }
 
-echo "$host_url/tests/$id" | "$script_dir/openqa-label-known-issues" | sed -n 's/\[\([^]]*\)\].*Unknown issue, to be reviewed.*/\1/p' | investigate-and-bisect
+hook() {
+    local id="${1:?"Need 'job_id'"}"
+    echo "$host_url/tests/$id" | openqa-label-known-issues | sed -n 's/\[\([^]]*\)\].*Unknown issue, to be reviewed.*/\1/p' | investigate-and-bisect
+}
 
+caller 0 >/dev/null || hook "$@"

--- a/test/03-openqa-label-known-issues-and-investigate-hook.t
+++ b/test/03-openqa-label-known-issues-and-investigate-hook.t
@@ -3,18 +3,42 @@
 source test/init
 
 plan tests 5
+dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
 
-try script_dir=$dir/scripts ./openqa-label-known-issues-and-investigate-hook 123
+source "$dir/../openqa-label-known-issues-and-investigate-hook"
+client_args=(api --host "$host_url")
+
+export INVESTIGATE_FAIL=false
+export INVESTIGATE_RETRIGGER_HOOK=false
+
+# Mocking
+openqa-trigger-bisect-jobs() {
+    echo "openqa-trigger-bisect-jobs ($@)"
+}
+openqa-label-known-issues() {
+    for testurl in $(cat - | sed 's/ .*$//'); do
+        echo "[$testurl]($testurl): Unknown issue, to be reviewed -> $testurl/file/autoinst-log.txt"
+    done
+}
+openqa-investigate() {
+    "$INVESTIGATE_FAIL" && return 1
+    "$INVESTIGATE_RETRIGGER_HOOK" && return 142
+    for testurl in $(cat - | sed 's/ .*$//'); do
+        echo "$testurl | openqa-investigate"
+    done
+}
+
+try hook 123
 is "$rc" 0 'successful hook'
 
 has "$got" 'https://openqa.opensuse.org/tests/123 | openqa-investigate' 'correct output 1'
 has "$got" 'openqa-trigger-bisect-jobs (--url https://openqa.opensuse.org/tests/123)' 'correct output 2'
 
 export INVESTIGATE_FAIL=true
-try script_dir=$dir/scripts ./openqa-label-known-issues-and-investigate-hook 123
+try hook 123
 is "$rc" 1 'openqa-investigate failed'
 
 export INVESTIGATE_FAIL=false
 export INVESTIGATE_RETRIGGER_HOOK=true
-try script_dir=$dir/scripts ./openqa-label-known-issues-and-investigate-hook 123
+try hook 123
 is "$rc" 142 'openqa-investigate exit code for retriggering hook script'

--- a/test/scripts/openqa-investigate
+++ b/test/scripts/openqa-investigate
@@ -1,6 +1,0 @@
-#!/bin/bash
-"$INVESTIGATE_FAIL" && exit 1
-"$INVESTIGATE_RETRIGGER_HOOK" && exit 142
-for testurl in $(cat - | sed 's/ .*$//'); do
-    echo "$testurl | openqa-investigate"
-done

--- a/test/scripts/openqa-label-known-issues
+++ b/test/scripts/openqa-label-known-issues
@@ -1,4 +1,0 @@
-#!/bin/bash
-for testurl in $(cat - | sed 's/ .*$//'); do
-    echo "[$testurl]($testurl): Unknown issue, to be reviewed -> $testurl/file/autoinst-log.txt"
-done

--- a/test/scripts/openqa-trigger-bisect-jobs
+++ b/test/scripts/openqa-trigger-bisect-jobs
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "openqa-trigger-bisect-jobs ($@)"


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/98862

By adding the
    
    caller 0 >/dev/null || hook "$@"
    
line one can source the script and test its functions without having to call
the whole script.
    
By making the calls to the scripts pathless one can mock
it in the test easily with a function.
That's also what a user can do if they want to call the
hook script and use a different openqa-investigate script/function.
