### PR TITLE
Make wrapper scripts for batch processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ bpan:
 
 .PHONY: test-online
 test-online:
-	cat ./tests/incompletes | env dry_run=1 bash -ex ./openqa-label-known-issues
+	cat ./tests/incompletes | env dry_run=1 bash -ex ./openqa-label-known-issues-multi
 	env dry_run=1 ./trigger-openqa_in_openqa
 	# Invalid JSON causes the job to abort with an error
 	env tw_openqa_host=example.com dry_run=1 ./trigger-openqa_in_openqa | grep -v 'parse error:'

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ false matches of job failures unrelated to the specified ticket.
   output the list of "interesting" incompletes, where "interesting" means not
   all incompletes but the ones likely needing actions by admins, e.g.
   unreviewed, no clones, no obvious "setup failure", etc.
-* [openqa-label-known-issues](https://github.com/os-autoinst/scripts/blob/master/openqa-label-known-issues)
+* [openqa-label-known-issues-multi](https://github.com/os-autoinst/scripts/blob/master/openqa-label-known-issues-multi)
   can take a list of openQA jobs, for example output from
   "openqa-monitor-incompletes" and look for matching "known issues", for
   example from progress.opensuse.org, label the job and retrigger if specified
@@ -107,7 +107,7 @@ there is no carry-over and no automatic ticket assignment by auto-review.
 ### Combine auto-review and openqa-investigate
 
 A possible approach to combine handling known issues and unknown issues is to
-run "openqa-label-known-issues" against all "investigation candidates" and
+run "openqa-label-known-issues-multi" against all "investigation candidates" and
 pass all unknown issues to "openqa-investigate":
 
 ```
@@ -117,7 +117,7 @@ pass all unknown issues to "openqa-investigate":
 which does the equivalent of:
 
 ```
-./openqa-monitor-investigation-candidates | ./openqa-label-known-issues | ./openqa-investigate
+./openqa-monitor-investigation-candidates | ./openqa-label-known-issues-multi | ./openqa-investigate
 ```
 
 with minor changes to the input/output format used between the commands.
@@ -190,7 +190,7 @@ psql \
 
 Perform a dry run on the local instance using the generated job list:
 ```
-cat tests/local_incompletes | env scheme=http host=localhost:9526 dry_run=1 sh -ex ./openqa-label-known-issues
+cat tests/local_incompletes | env scheme=http host=localhost:9526 dry_run=1 sh -ex ./openqa-label-known-issues-multi
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ there is no carry-over and no automatic ticket assignment by auto-review.
   output the list of failed jobs that are suitable for triggering
   investigation jobs on, compare to "openqa-monitor-incompletes"
 
-* [openqa-investigate](https://github.com/os-autoinst/scripts/blob/master/openqa-investigate)
+* [openqa-investigate-multi](https://github.com/os-autoinst/scripts/blob/master/openqa-investigate-multi)
   can take a list of openQA jobs, for example output of
   "openqa-monitor-investigation-candidates" and trigger "investigation jobs",
   e.g. a plain retrigger, using the "last good" tests as well as "last good"
@@ -108,7 +108,7 @@ there is no carry-over and no automatic ticket assignment by auto-review.
 
 A possible approach to combine handling known issues and unknown issues is to
 run "openqa-label-known-issues-multi" against all "investigation candidates" and
-pass all unknown issues to "openqa-investigate":
+pass all unknown issues to "openqa-investigate-multi":
 
 ```
 ./openqa-review-failed
@@ -117,7 +117,7 @@ pass all unknown issues to "openqa-investigate":
 which does the equivalent of:
 
 ```
-./openqa-monitor-investigation-candidates | ./openqa-label-known-issues-multi | ./openqa-investigate
+./openqa-monitor-investigation-candidates | ./openqa-label-known-issues-multi | ./openqa-investigate-multi
 ```
 
 with minor changes to the input/output format used between the commands.

--- a/openqa-investigate
+++ b/openqa-investigate
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Usage
-# echo jobnumber | openqa-investigate
+# echo jobnumber | openqa-investigate-multi
 
 # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 set -euo pipefail
@@ -188,7 +188,7 @@ $comment_text"
 # 4. last good job/build + last good test -> check for other problem
 #    sources, e.g. infrastructure
 investigate() {
-    id="${1##*/}"
+    local id="${1##*/}"
     local rc=0
 
     job_data=$(openqa-cli "${client_args[@]}" --json jobs/"$id")
@@ -250,12 +250,7 @@ main() {
     fi
     set -u
     clone_call="${clone_call:-"$client_prefix openqa-clone-job --skip-chained-deps --max-depth 0 --parental-inheritance --within-instance"}"
-    local rc=0
-    # shellcheck disable=SC2013
-    for i in $(cat - | sed 's/ .*$//'); do
-        investigate "$i" "$@" || rc=$?
-    done
-    exit $rc
+    investigate "$@"
 }
 
 caller 0 >/dev/null || main "$@"

--- a/openqa-investigate-multi
+++ b/openqa-investigate-multi
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Usage
+# echo jobnumber | openqa-investigate
+
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+
+# shellcheck source=/dev/null
+. "$(dirname "${BASH_SOURCE[0]}")"/_common
+
+main() {
+    local rc=0
+    # shellcheck disable=SC2013
+    for i in $(cat - | sed 's/ .*$//'); do
+        openqa-investigate "$i" "$@" || rc=$?
+    done
+    exit $rc
+}
+
+caller 0 >/dev/null || main "$@"

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # Usage
-# echo https://openqahost/tests/1234 | openqa-label-known-issues
+# openqa-label-known-issues https://openqahost/tests/1234
 
 set -o pipefail -o errtrace
 
@@ -20,7 +20,6 @@ grep_timeout="${grep_timeout:-5}"
 email_unreviewed=${email_unreviewed:-true}
 notification_address=${notification_address:-}
 from_email=${from_email:-openqa-label-known-issues@open.qa}
-to_review=()
 curl_args=(--user-agent "openqa-label-known-issues")
 client_args=(api --header 'User-Agent: openqa-label-known-issues (https://github.com/os-autoinst/scripts)' --host "$host_url")
 
@@ -140,17 +139,8 @@ investigate_issue() {
     fi
 }
 
-print_summary() {
-    local to_review_count=${#to_review[@]}
-    [[ $to_review_count -eq 0 ]] && return
-    local msg="\n\e[1m\e[31m$to_review_count unknown issues to be reviewed:\e[0m"
-    for job in "${to_review[@]}"; do
-        msg+="\n - $job"
-    done
-    echo -e "$msg"
-}
-
-main() {
+label_issue() {
+    testurl="${1:?"Need 'testurl'"}"
     [[ "$dry_run" = "1" ]] && client_prefix="echo"
     if [[ -z "$client_call" ]]; then
         client_call=(openqa-cli "${client_args[@]}")
@@ -159,12 +149,8 @@ main() {
         fi
     fi
     # search for issues with a subject search term
-    issues=$(runcurl "${curl_args[@]}" -s "$issue_query" | runjq -r '.issues | .[] | (.id,.subject,.tracker.name)')
-    # shellcheck disable=SC2013
-    for testurl in $(cat - | sed 's/ .*$//'); do
-        investigate_issue "$testurl"
-    done
-    print_summary
+    issues=${issues:-$(runcurl "${curl_args[@]}" -s "$issue_query" | runjq -r '.issues | .[] | (.id,.subject,.tracker.name)')}
+    investigate_issue "$testurl"
 }
 
-main
+caller 0 >/dev/null || label_issue "$@"

--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -15,7 +15,7 @@ host_url="$scheme://$host"
 investigate-and-bisect() {
     local rc=0 test
     read -r test
-    echo "$test" | openqa-investigate || rc=$?
+    openqa-investigate "$test" || rc=$?
     [[ "$rc" -eq 142 ]] && return "$rc"
     openqa-trigger-bisect-jobs --url "$test" || rc=$?
     return "$rc"

--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -23,7 +23,7 @@ investigate-and-bisect() {
 
 hook() {
     local id="${1:?"Need 'job_id'"}"
-    echo "$host_url/tests/$id" | openqa-label-known-issues | sed -n 's/\[\([^]]*\)\].*Unknown issue, to be reviewed.*/\1/p' | investigate-and-bisect
+    openqa-label-known-issues "$host_url/tests/$id" | sed -n 's/\[\([^]]*\)\].*Unknown issue, to be reviewed.*/\1/p' | investigate-and-bisect
 }
 
 caller 0 >/dev/null || hook "$@"

--- a/openqa-label-known-issues-hook
+++ b/openqa-label-known-issues-hook
@@ -3,11 +3,11 @@
 set -o pipefail
 
 # "hook script" intended to be called by openQA instances taking a job ID as
-# parameter and forwarding a complete job URL to "openqa-label-known-issues"
+# parameter and forwarding a complete job URL to "openqa-label-known-issues-multi"
 # on stdin
 
 id="${1:?"Need 'job_id'"}"
 host="${host:-"openqa.opensuse.org"}"
 scheme="${scheme:-"https"}"
 host_url="$scheme://$host"
-echo "$host_url/tests/$id" | "$(dirname "$0")"/openqa-label-known-issues
+echo "$host_url/tests/$id" | "$(dirname "$0")"/openqa-label-known-issues-multi

--- a/openqa-label-known-issues-multi
+++ b/openqa-label-known-issues-multi
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+
+# Usage
+# echo https://openqahost/tests/1234 | openqa-label-known-issues-multi
+
+set -o pipefail -o errtrace
+
+source "$(dirname "$0")"/openqa-label-known-issues
+
+to_review=()
+
+print_summary() {
+    local to_review_count=${#to_review[@]}
+    [[ $to_review_count -eq 0 ]] && return
+    local msg="\n\e[1m\e[31m$to_review_count unknown issues to be reviewed:\e[0m"
+    for job in "${to_review[@]}"; do
+        msg+="\n - $job"
+    done
+    echo -e "$msg"
+}
+
+main() {
+    # shellcheck disable=SC2013
+    for testurl in $(cat - | sed 's/ .*$//'); do
+        label_issue "$testurl"
+    done
+    print_summary
+}
+
+caller 0 >/dev/null || main "$@"

--- a/openqa-review-failed
+++ b/openqa-review-failed
@@ -1,1 +1,1 @@
-"$(dirname "$0")"/openqa-monitor-investigation-candidates | "$(dirname "$0")"/openqa-label-known-issues-multi 3>&1 1>/dev/null 2>&3- | sed -n 's/\(\S*\) : Unknown issue, to be reviewed.*$/\1/p' | "$(dirname "$0")"/openqa-investigate
+"$(dirname "$0")"/openqa-monitor-investigation-candidates | "$(dirname "$0")"/openqa-label-known-issues-multi 3>&1 1>/dev/null 2>&3- | sed -n 's/\(\S*\) : Unknown issue, to be reviewed.*$/\1/p' | "$(dirname "$0")"/openqa-investigate-multi

--- a/openqa-review-failed
+++ b/openqa-review-failed
@@ -1,1 +1,1 @@
-"$(dirname "$0")"/openqa-monitor-investigation-candidates | "$(dirname "$0")"/openqa-label-known-issues 3>&1 1>/dev/null 2>&3- | sed -n 's/\(\S*\) : Unknown issue, to be reviewed.*$/\1/p' | "$(dirname "$0")"/openqa-investigate
+"$(dirname "$0")"/openqa-monitor-investigation-candidates | "$(dirname "$0")"/openqa-label-known-issues-multi 3>&1 1>/dev/null 2>&3- | sed -n 's/\(\S*\) : Unknown issue, to be reviewed.*$/\1/p' | "$(dirname "$0")"/openqa-investigate

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -83,7 +83,7 @@ try investigate 30
 is "$rc" 142 'investigation postponed because other job in cluster is not done'
 is "$got" "Postponing to investigate job 30: waiting until 1 pending parallel job(s) finished"
 
-try 'echo 30 | main'
+try main 30
 is "$rc" 142 'return code (for postponing) passed by main function'
 is "$got" "Postponing to investigate job 30: waiting until 1 pending parallel job(s) finished" 'output passed by main function'
 

--- a/test/03-openqa-label-known-issues-and-investigate-hook.t
+++ b/test/03-openqa-label-known-issues-and-investigate-hook.t
@@ -20,17 +20,16 @@ openqa-label-known-issues() {
     echo "[$testurl]($testurl): Unknown issue, to be reviewed -> $testurl/file/autoinst-log.txt"
 }
 openqa-investigate() {
+    local testurl=$1
     "$INVESTIGATE_FAIL" && return 1
     "$INVESTIGATE_RETRIGGER_HOOK" && return 142
-    for testurl in $(cat - | sed 's/ .*$//'); do
-        echo "$testurl | openqa-investigate"
-    done
+    echo "openqa-investigate $testurl"
 }
 
 try hook 123
 is "$rc" 0 'successful hook'
 
-has "$got" 'https://openqa.opensuse.org/tests/123 | openqa-investigate' 'correct output 1'
+has "$got" 'openqa-investigate https://openqa.opensuse.org/tests/123' 'correct output 1'
 has "$got" 'openqa-trigger-bisect-jobs (--url https://openqa.opensuse.org/tests/123)' 'correct output 2'
 
 export INVESTIGATE_FAIL=true

--- a/test/03-openqa-label-known-issues-and-investigate-hook.t
+++ b/test/03-openqa-label-known-issues-and-investigate-hook.t
@@ -16,9 +16,8 @@ openqa-trigger-bisect-jobs() {
     echo "openqa-trigger-bisect-jobs ($@)"
 }
 openqa-label-known-issues() {
-    for testurl in $(cat - | sed 's/ .*$//'); do
-        echo "[$testurl]($testurl): Unknown issue, to be reviewed -> $testurl/file/autoinst-log.txt"
-    done
+    testurl=$1
+    echo "[$testurl]($testurl): Unknown issue, to be reviewed -> $testurl/file/autoinst-log.txt"
 }
 openqa-investigate() {
     "$INVESTIGATE_FAIL" && return 1


### PR DESCRIPTION

Make openqa-label-known-issues and openqa-investigate take a single url

and provide  wrapper scripts {openqa-label-known-issues,openqa-investigate}-multi for
batch operations.

This makesthe scripts easier to use and test.

We can call a single command for a single url that we pass as a
parameter.
Having to pipe the url makes it harder to use.
Also with a command for a single url we can easier write tests for
this command.
    
Related issue: https://progress.opensuse.org/issues/98862
