### PR TITLE
Reuse job_data in openqa-investigate

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -31,20 +31,25 @@ clone() {
     id=${2:?"Need 'id'"}
     name_suffix=${3+":$3"}
     refspec=${4+$4}
-    job_data=$(openqa-cli "${client_args[@]}" --json jobs/"$id")
+    local clone_job_data
+    if [[ "$origin" == "$id" ]]; then
+        clone_job_data=$job_data
+    else
+        clone_job_data=$(openqa-cli "${client_args[@]}" --json jobs/"$id")
+    fi
     # shellcheck disable=SC2181
-    [[ $? != 0 ]] && echoerr "unable to query job data for $id: $job_data" && return 1
+    [[ $? != 0 ]] && echoerr "unable to query job data for $id: $clone_job_data" && return 1
 
     # fail on jobs with directly chained dependencies (not supported)
-    unsupported_cluster_jobs=$(echo "$job_data" | runjq -r '(.job.children["Directly chained"] | length) + (.job.parents["Directly chained"] | length)') || return $?
+    unsupported_cluster_jobs=$(echo "$clone_job_data" | runjq -r '(.job.children["Directly chained"] | length) + (.job.parents["Directly chained"] | length)') || return $?
     [[ $unsupported_cluster_jobs != 0 ]] \
         && echoerr "Unable to clone job $id: it is part of a directly chained cluster (not supported)" && return 2
 
-    name="$(echo "$job_data" | runjq -r '.job.test'):investigate$name_suffix" || return $?
-    base_prio=$(echo "$job_data" | runjq -r '.job.priority') || return $?
+    name="$(echo "$clone_job_data" | runjq -r '.job.test'):investigate$name_suffix" || return $?
+    base_prio=$(echo "$clone_job_data" | runjq -r '.job.priority') || return $?
     clone_settings=("TEST+=:investigate$name_suffix" '_GROUP_ID=0' 'BUILD=')
     if [[ $refspec ]]; then
-        casedir=$(echo "$job_data" | runjq -r '.job.settings.CASEDIR') || return $?
+        casedir=$(echo "$clone_job_data" | runjq -r '.job.settings.CASEDIR') || return $?
         [[ $casedir == null ]] && casedir=''
         repo=${casedir:-'https://github.com/os-autoinst/os-autoinst-distri-opensuse.git'}
         clone_settings+=("CASEDIR=${repo%#*}#${refspec}")
@@ -52,7 +57,7 @@ clone() {
     [[ -n ${*:5} ]] && clone_settings+=("${@:5}")
     # clear "PUBLISH_" settings to avoid overriding production assets
     # shellcheck disable=SC2207
-    clone_settings+=($(echo "$job_data" | runjq -r '.job.settings | keys[] | select (startswith("PUBLISH_")) | . + "="')) || return $?
+    clone_settings+=($(echo "$clone_job_data" | runjq -r '.job.settings | keys[] | select (startswith("PUBLISH_")) | . + "="')) || return $?
     clone_settings+=("OPENQA_INVESTIGATE_ORIGIN=$host_url/t$origin")
     out=$($clone_call "$host_url/tests/$id" "${clone_settings[@]}")
     [[ $dry_run = 1 ]] && echo "$out"


### PR DESCRIPTION
Most of the times origin and id are the same, so better not query the data everytime we call clone.

Also rename the variable to make it clear it might be different from the outer job_data variable.

Related issue: https://progress.opensuse.org/issues/98862