### PR TITLE
Make regex more performant

### DIFF
--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -91,7 +91,7 @@ label_on_issues_from_issue_tracker() {
 }
 
 label_on_issues_without_tickets() {
-    if label_on_issue "$id" '(?s)([dD]ownload.*failed.*404).*Result: setup failure' 'label:non_existing asset, candidate for removal or wrong settings'; then return
+    if label_on_issue "$id" '([dD]ownload.*failed.*404)[\S\s]*Result: setup failure' 'label:non_existing asset, candidate for removal or wrong settings'; then return
     elif label_on_issue "$id" 'File .*\.yaml.* does not exist at .*scheduler.pm' 'label:missing_schedule_file'; then return
     elif label_on_issue "$id" 'Compilation failed in require at .*isotovideo line 28.' 'label:schedule_compilation_error'; then return
     elif label_on_issue "$id" 'qemu-img: Could not open .*: No such file or directory' 'label:missing_asset'; then return

--- a/test/01-label-known-issues.t
+++ b/test/01-label-known-issues.t
@@ -2,7 +2,7 @@
 
 source test/init
 
-plan tests 25
+plan tests 26
 
 source _common
 
@@ -14,6 +14,7 @@ mock-client() {
 client_call=(mock-client "${client_call[@]}")
 logfile1=$dir/data/01-os-autoinst.txt.1
 logfile2=$dir/data/01-os-autoinst.txt.2
+logfile3=$dir/data/01-os-autoinst.txt.3
 
 try-client-output() {
   out=$logfile1
@@ -25,11 +26,14 @@ try-client-output comment_on_job 123 Label
 is "$rc" 0 'successful comment_on_job'
 is "$got" "client_call -X POST jobs/123/comments text=Label" 'comment_on_job works'
 
-try search_log 123 'foo.*bar' "$logfile1"
+try "search_log 123 'foo.*bar'" "$logfile1"
 is "$rc" 0 'successful search_log'
 
-try search_log 123 'foo.*bar' "$logfile2"
+try "search_log 123 'foo.*bar'" "$logfile2"
 is "$rc" 1 'failing search_log'
+
+try "search_log 123 '([dD]ownload.*failed.*404)[\S\s]*Result: setup failure'" "$logfile3"
+is "$rc" 0 'successful search_log'
 
 try "search_log 123 'foo [z-a]' $logfile2"
 is "$rc" 2 'search_log with invalid pattern'

--- a/test/data/01-os-autoinst.txt.3
+++ b/test/data/01-os-autoinst.txt.3
@@ -1,0 +1,6 @@
+test
+aaaaa Download of bbbb failed: 404
+test
+test
+ccc Result: setup failure
+test


### PR DESCRIPTION
Having several `.*` in a regex with the `s` flag can involve a lot of backtracking on a logfile, but in reality only one of the .* must be line spanning.

Looking into the gru logs, this regex was timing out very often. Removing the s flag and replacing the line spanning .* with [\S\s]* will make it faster