### PR TITLE
Cherry-pick all bash code review commits I consider fine right away

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/bpan/
+/.bpan/
 /tests/__pycache__/
 /__pycache__/

--- a/.setup.mk
+++ b/.setup.mk
@@ -1,3 +1,8 @@
+SHELL := bash
+
+.DELETE_ON_ERROR:
+.SECONDEXPANSION:
+
 ifeq (,$(shell git diff --stat))
 GIT_STATUS_IS_CLEAN := 1
 endif

--- a/.setup.mk
+++ b/.setup.mk
@@ -1,0 +1,3 @@
+ifeq (,$(shell git diff --stat))
+GIT_STATUS_IS_CLEAN := 1
+endif

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,7 @@
-.PHONY: all
 all:
 
-.PHONY: test
 test: checkstyle test-unit
 
-.PHONY: test-unit
 test-unit: bpan
 	prove -r test/ xt/
 	py.test
@@ -12,27 +9,22 @@ test-unit: bpan
 bpan:
 	git clone https://github.com/bpan-org/bpan.git --depth 1
 
-.PHONY: test-online
 test-online:
 	cat ./tests/incompletes | env dry_run=1 bash -ex ./openqa-label-known-issues-multi
 	env dry_run=1 ./trigger-openqa_in_openqa
 	# Invalid JSON causes the job to abort with an error
 	env tw_openqa_host=example.com dry_run=1 ./trigger-openqa_in_openqa | grep -v 'parse error:'
 
-.PHONY: checkstyle
 checkstyle: test-shellcheck test-yaml
 
-.PHONY: test-shellcheck
 test-shellcheck:
 	@which shellcheck >/dev/null 2>&1 || echo "Command 'shellcheck' not found, can not execute shell script checks"
 	shellcheck -x $$(file --mime-type * | sed -n 's/^\(.*\):.*text\/x-shellscript.*$$/\1/p')
 
-.PHONY: test-yaml
 test-yaml:
 	@which yamllint >/dev/null 2>&1 || echo "Command 'yamllint' not found, can not execute YAML syntax checks"
 	yamllint --strict $$(git ls-files "*.yml" "*.yaml" ":!external/")
 
-.PHONY: update-deps
 update-deps:
 	tools/update-deps --specfile dist/rpm/os-autoinst-scripts-deps.spec
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+include .setup.mk
+
+ifndef test
+test := test/
+ifdef GIT_STATUS_IS_CLEAN
+test += xt/
+endif
+endif
 
 BPAN := .bpan
 
@@ -10,7 +18,7 @@ default:
 test: checkstyle test-unit
 
 test-unit: $(BPAN)
-	prove -r test/ xt/
+	prove -r $(if $v,-v )$(test)
 	py.test
 
 

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ update-deps:
 	tools/update-deps --specfile dist/rpm/os-autoinst-scripts-deps.spec
 
 clean:
+	$(RM) job_post_response
 	$(RM) -r $(BPAN)
 	$(RM) -r .pytest_cache/
 	find . -name __pycache__ | xargs -r $(RM) -r

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
-all:
+
+BPAN := .bpan
+
+
+#------------------------------------------------------------------------------
+# User targets
+#------------------------------------------------------------------------------
+default:
 
 test: checkstyle test-unit
 
-test-unit: bpan
+test-unit: $(BPAN)
 	prove -r test/ xt/
 	py.test
 
-bpan:
-	git clone https://github.com/bpan-org/bpan.git --depth 1
 
 test-online:
 	cat ./tests/incompletes | env dry_run=1 bash -ex ./openqa-label-known-issues-multi
@@ -29,4 +34,12 @@ update-deps:
 	tools/update-deps --specfile dist/rpm/os-autoinst-scripts-deps.spec
 
 clean:
-	$(RM) -r bpan
+	$(RM) -r $(BPAN)
+	$(RM) -r .pytest_cache/
+	find . -name __pycache__ | xargs -r $(RM) -r
+
+#------------------------------------------------------------------------------
+# Internal targets
+#------------------------------------------------------------------------------
+$(BPAN):
+	git clone https://github.com/bpan-org/bpan.git --depth 1 $@

--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,6 @@ test-yaml:
 .PHONY: update-deps
 update-deps:
 	tools/update-deps --specfile dist/rpm/os-autoinst-scripts-deps.spec
+
+clean:
+	$(RM) -r bpan

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,13 @@ default:
 
 test: checkstyle test-unit
 
-test-unit: $(BPAN)
-	prove -r $(if $v,-v )$(test)
-	py.test
+test-unit: test-bash test-python
 
+test-bash: $(BPAN)
+	prove -r $(if $v,-v )$(test)
+
+test-python:
+	py.test tests
 
 test-online:
 	cat ./tests/incompletes | env dry_run=1 bash -ex ./openqa-label-known-issues-multi

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ test-python:
 	py.test tests
 
 test-online:
-	cat ./tests/incompletes | env dry_run=1 bash -ex ./openqa-label-known-issues-multi
-	env dry_run=1 ./trigger-openqa_in_openqa
+	dry_run=1 bash -x ./openqa-label-known-issues-multi < ./tests/incompletes
+	dry_run=1 ./trigger-openqa_in_openqa
 	# Invalid JSON causes the job to abort with an error
-	env tw_openqa_host=example.com dry_run=1 ./trigger-openqa_in_openqa | grep -v 'parse error:'
+	-tw_openqa_host=example.com dry_run=1 ./trigger-openqa_in_openqa
 
 checkstyle: test-shellcheck test-yaml
 

--- a/_common
+++ b/_common
@@ -3,21 +3,21 @@
 # Common shell script snippets to be used when interacting with openQA
 # instances, for example over openqa-cli.
 
+warn() { printf '%s\n' "$@" >&2; }
+
 enable_force_result=${enable_force_result:-false}
 
 client_call=()
 client_args=()
 markdown_cmd=$(command -v Markdown.pl) || markdown_cmd=$(command -v markdown) \
-    || echo "+++ (Markdown.pl|markdown) not found, please install Text::Markdown +++" >&2
+    || warn "+++ (Markdown.pl|markdown) not found, please install Text::Markdown +++"
 openqa_cli="${openqa_cli:-""}"
-
-warn() { echo "$@" >&2; }
 
 error-handler() {
     local line=$1
     # shellcheck disable=SC2207
     local c=($(caller))
-    echo "${c[1]}: ERROR: line $line" >&2
+    warn "${c[1]}: ERROR: line $line"
 }
 
 # From openqa-cli JSON output filter and return the id/ids of jobs,
@@ -53,7 +53,7 @@ runjq() {
     set -e
     [[ "$rc" == 0 ]] && echo "$output" && return
     output=$(echo "$output" | head -"$jq_output_limit")
-    echo "jq ($(caller)): $output (rc: $rc Input: >>>$input<<<)" >&2
+    warn "jq ($(caller)): $output (rc: $rc Input: >>>$input<<<)"
     return $rc
 }
 
@@ -62,14 +62,14 @@ runjq() {
 runcurl() {
     local rc status_code body response
     local verbose="${verbose:-"false"}"
-    $verbose && echo "[debug] curl: Fetching ($*)" >&2
+    $verbose && warn "[debug] curl: Fetching ($*)"
     set +e
     response=$(curl -w "\n%{http_code}\n" "$@" 2>&1)
     rc=$?
     set -e
-    [[ "$rc" != 0 ]] && echo "curl ($(caller)): Error fetching ($*): $response" >&2 && return 1
+    [[ "$rc" != 0 ]] && warn "curl ($(caller)): Error fetching ($*): $response" && return 1
     status_code=$(echo "$response" | tail -1)
-    [[ "$status_code" != 200 ]] && echo "curl ($(caller)): Error fetching url ($*): Got Status $status_code" >&2 && return 1
+    [[ "$status_code" != 200 ]] && warn "curl ($(caller)): Error fetching url ($*): Got Status $status_code" && return 1
     # remove last line
     body=$(echo "$response" | tac | tail -n+2 | tac)
     echo "$body"

--- a/_common
+++ b/_common
@@ -108,7 +108,7 @@ search_log() {
     fi
 }
 
-label_on_issue() {
+label-on-issue() {
     local id=$1 search_term=$2 label=$3 restart=${4:-''} force_result=${5:-''}
     local out=${out:?}
     search_log "$id" "$search_term" "$out" || return

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -84,22 +84,22 @@ label_on_issues_from_issue_tracker() {
             if [[ $tracker == 'openqa-force-result' && $after =~ :force_result:([a-z_]+) ]]; then
                 force_result=${BASH_REMATCH[1]}
             fi
-            label_on_issue "$id" "$search" "$label" "${after//*\":retry*/1}" "$force_result" && break
+            label-on-issue "$id" "$search" "$label" "${after//*\":retry*/1}" "$force_result" && break
         fi
         done
     )
 }
 
 label_on_issues_without_tickets() {
-    if label_on_issue "$id" '([dD]ownload.*failed.*404)[\S\s]*Result: setup failure' 'label:non_existing asset, candidate for removal or wrong settings'; then return
-    elif label_on_issue "$id" 'File .*\.yaml.* does not exist at .*scheduler.pm' 'label:missing_schedule_file'; then return
-    elif label_on_issue "$id" 'Compilation failed in require at .*isotovideo line 28.' 'label:schedule_compilation_error'; then return
-    elif label_on_issue "$id" 'qemu-img: Could not open .*: No such file or directory' 'label:missing_asset'; then return
-    elif label_on_issue "$id" 'fatal: Remote branch .* not found' 'label:remote_branch_not_found, probably wrong custom git URL specified with branch'; then return
-    elif label_on_issue "$id" 'fatal: repository not found' 'label:remote_repo_not_found, probably wrong custom git URL specified'; then return
-    elif label_on_issue "$id" '(?s)Cloning git URL.*to use as test distribution.*(No scripts in|needledir not found)' 'label:remote_repo_invalid, probably wrong custom git URL specified'; then return
-    elif label_on_issue "$id" '(?s)Cloning git URL.*to use as test distribution.*(SCHEDULE.*not set|loadtest needs a script below)' 'label:remote_repo_schedule_not_found, probably wrong custom git URL + PRODUCTDIR specified'; then return
-    elif label_on_issue "$id" '\[error\] Failed to download' 'label:download_error potentially out-of-space worker?' 1; then return
+    if label-on-issue "$id" '([dD]ownload.*failed.*404)[\S\s]*Result: setup failure' 'label:non_existing asset, candidate for removal or wrong settings'; then return
+    elif label-on-issue "$id" 'File .*\.yaml.* does not exist at .*scheduler.pm' 'label:missing_schedule_file'; then return
+    elif label-on-issue "$id" 'Compilation failed in require at .*isotovideo line 28.' 'label:schedule_compilation_error'; then return
+    elif label-on-issue "$id" 'qemu-img: Could not open .*: No such file or directory' 'label:missing_asset'; then return
+    elif label-on-issue "$id" 'fatal: Remote branch .* not found' 'label:remote_branch_not_found, probably wrong custom git URL specified with branch'; then return
+    elif label-on-issue "$id" 'fatal: repository not found' 'label:remote_repo_not_found, probably wrong custom git URL specified'; then return
+    elif label-on-issue "$id" '(?s)Cloning git URL.*to use as test distribution.*(No scripts in|needledir not found)' 'label:remote_repo_invalid, probably wrong custom git URL specified'; then return
+    elif label-on-issue "$id" '(?s)Cloning git URL.*to use as test distribution.*(SCHEDULE.*not set|loadtest needs a script below)' 'label:remote_repo_schedule_not_found, probably wrong custom git URL + PRODUCTDIR specified'; then return
+    elif label-on-issue "$id" '\[error\] Failed to download' 'label:download_error potentially out-of-space worker?' 1; then return
     fi
     false
 }

--- a/test/01-label-known-issues.t
+++ b/test/01-label-known-issues.t
@@ -39,28 +39,28 @@ try "search_log 123 'foo [z-a]' $logfile2"
 is "$rc" 2 'search_log with invalid pattern'
 has "$got" 'range out of order in character class' 'correct error message'
 
-try-client-output label_on_issue 123 'foo.*bar' Label 1 softfailed
+try-client-output label-on-issue 123 'foo.*bar' Label 1 softfailed
 expected="client_call -X POST jobs/123/comments text=Label
 client_call -X POST jobs/123/restart"
-is "$rc" 0 'successful label_on_issue'
-is "$got" "$expected" 'label_on_issue with restart and disabled force_result'
+is "$rc" 0 'successful label-on-issue'
+is "$got" "$expected" 'label-on-issue with restart and disabled force_result'
 
-try-client-output enable_force_result=true label_on_issue 123 'foo.*bar' Label 1 softfailed
+try-client-output enable_force_result=true label-on-issue 123 'foo.*bar' Label 1 softfailed
 expected="client_call -X POST jobs/123/comments text=label:force_result:softfailed:Label
 
 Label
 client_call -X POST jobs/123/restart"
-is "$rc" 0 'successful label_on_issue'
-is "$got" "$expected" 'label_on_issue with restart and force_result'
+is "$rc" 0 'successful label-on-issue'
+is "$got" "$expected" 'label-on-issue with restart and force_result'
 
-try-client-output label_on_issue 123 "foo.*bar" Label
+try-client-output label-on-issue 123 "foo.*bar" Label
 expected="client_call -X POST jobs/123/comments text=Label"
-is "$rc" 0 'successful label_on_issue'
-is "$got" "$expected" 'label_on_issue with restart and force_result'
+is "$rc" 0 'successful label-on-issue'
+is "$got" "$expected" 'label-on-issue with restart and force_result'
 
-try-client-output "label_on_issue 123 'foo bar' Label"
-is "$rc" 1 'label_on_issue did not find search term'
-is "$got" "" 'label_on_issue with restart and force_result'
+try-client-output "label-on-issue 123 'foo bar' Label"
+is "$rc" 1 'label-on-issue did not find search term'
+is "$got" "" 'label-on-issue with restart and force_result'
 
 send-email() {
     local mailto=$1 email=$2

--- a/test/init
+++ b/test/init
@@ -1,6 +1,6 @@
 #!/bash
 
-export BPAN_ROOT=$PWD/bpan
+export BPAN_ROOT=$PWD/.bpan
 
 source "$BPAN_ROOT/test/init"
 


### PR DESCRIPTION
I cherry-picked the following commits from #209
that I consider right away to merge if others agree as well. Other not included commits can still be discussed:

* Rename a function using - instead of _
* Use `warn` in _common
* Add job_post_response file to 'make clean'
* Remove usage of `env` from Makefile rules
* Split `test-unit` Makefile rule into 2 rules
* Add some standard settings to .setup.mk
* Allow user to select which files to prove
* Change bpan/ to .bpan/
* Remove unneeded .PHONY lines
* Add a 'clean' target to the Makefile
* README.md: Add notes regarding line-spanning regex