### PR TITLE
Require at least two approvals for automatic merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@
 pull_request_rules:
   - name: automatic merge
     conditions:
-      - "#approved-reviews-by>=1"
+      - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
       - "#review-requested=0"


### PR DESCRIPTION
Otherwise, when an external contributor creates a PR, it might be merged by only having one person from the team having a look at it.