### PR TITLE
Skip comments about failing openQA-in-openQA test

### DIFF
--- a/monitor-openqa_job
+++ b/monitor-openqa_job
@@ -16,6 +16,7 @@ host="${host:-"https://openqa.opensuse.org"}"
 openqa_groupid="${openqa_groupid:-"24"}"
 obs_component="${obs_component:-"package"}"
 obs_package_name="${1:-""}"
+comment_on_obs=${comment_on_obs:-}
 
 # shellcheck source=/dev/null
 . "$(dirname "$0")"/_common
@@ -40,6 +41,7 @@ for job_id in $(job_ids job_post_response); do
 done
 
 [[ ${failed_jobs[*]} ]] || exit 0
+[[ $comment_on_obs ]] || exit 1
 
 osc api "/comments/$obs_component/$obs_package_name" | grep id= | sed -n 's/.*id="\([^"]*\)">.*test.* failed.*/\1/p' | while read -r id; do
     osc api -X DELETE /comment/"$id"


### PR DESCRIPTION
Skip commenting about failing openQA-in-openQA tests on OBS by default as those comments are redundant to mails about unreviewed issues sent by the hook script.

The code takes care of cleaning up old comments. However, this does not help with mail notifications leading to
https://progress.opensuse.org/issues/124694. So to fix this, it is the easiest to simply avoid creating those comments.