### PR TITLE
Avoid confusing behavior by not combining force-result labels with bugrefs

### DIFF
--- a/_common
+++ b/_common
@@ -83,9 +83,7 @@ openqa-api-get() {
 comment_on_job() {
     local id=$1 comment=$2 force_result=${3:-''}
     if $enable_force_result && [[ -n $force_result ]]; then
-        comment="label:force_result:$force_result:$comment
-
-$comment"
+        comment="label:force_result:$force_result:$comment"
     fi
     "${client_call[@]}" -X POST jobs/"$id"/comments text="$comment"
 }

--- a/test/01-label-known-issues.t
+++ b/test/01-label-known-issues.t
@@ -47,8 +47,6 @@ is "$got" "$expected" 'label-on-issue with restart and disabled force_result'
 
 try-client-output enable_force_result=true label-on-issue 123 'foo.*bar' Label 1 softfailed
 expected="client_call -X POST jobs/123/comments text=label:force_result:softfailed:Label
-
-Label
 client_call -X POST jobs/123/restart"
 is "$rc" 0 'successful label-on-issue'
 is "$got" "$expected" 'label-on-issue with restart and force_result'


### PR DESCRIPTION
* As now stated in the documentation, this is not recommended as the force-result label will not be evaluated on carry-over due to the bugref (which can be confusing).
* This reverts d17bd74b2c9e1ecfa057bbd2e2cd5403b09418b9. The main intention behind this change was to still have a bugref rendered as link (as the one within the label wouldn't be rendered as such). With the openQA change 8fa3634545c132cdc3e8e3b0c55e63ae1b601c98 this is no longer required.
* See https://progress.opensuse.org/issues/123724