### PR TITLE
Fix checking for unknown issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Just put the following into the description of the Job Group:
 Each Slack channel has its own email address which you can find out by clicking
 on the title and then on "Integrations".
 
-The email will have the subject "Unknown issue to be reviewed (Group 123)".
+The email will have the subject "Unknown test issue to be reviewed (Group 123)".
 It will contain the link to the job and a small log excerpt, possibly
 already pointing to the error. The sender email address can be
 [configured](#Configuration).

--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -26,7 +26,7 @@ investigate-and-bisect() {
 
 label() {
     local url=$1
-    openqa-label-known-issues "$url" | sed -n 's/\[\([^]]*\)\].*Unknown issue, to be reviewed.*/\1/p'
+    openqa-label-known-issues "$url" | sed -n 's/\[\([^]]*\)\].*Unknown test issue, to be reviewed.*/\1/p'
 }
 
 hook() {

--- a/openqa-review-failed
+++ b/openqa-review-failed
@@ -1,1 +1,1 @@
-"$(dirname "$0")"/openqa-monitor-investigation-candidates | "$(dirname "$0")"/openqa-label-known-issues-multi 3>&1 1>/dev/null 2>&3- | sed -n 's/\(\S*\) : Unknown issue, to be reviewed.*$/\1/p' | "$(dirname "$0")"/openqa-investigate-multi
+"$(dirname "$0")"/openqa-monitor-investigation-candidates | "$(dirname "$0")"/openqa-label-known-issues-multi 3>&1 1>/dev/null 2>&3- | sed -n 's/\(\S*\) : Unknown test issue, to be reviewed.*$/\1/p' | "$(dirname "$0")"/openqa-investigate-multi

--- a/test/03-openqa-label-known-issues-and-investigate-hook.t
+++ b/test/03-openqa-label-known-issues-and-investigate-hook.t
@@ -18,7 +18,7 @@ openqa-trigger-bisect-jobs() {
 openqa-label-known-issues() {
     testurl=$1
     warn "- openqa-label-known-issues $testurl"
-    echo "[$testurl]($testurl): Unknown issue, to be reviewed -> $testurl/file/autoinst-log.txt"
+    echo "[$testurl]($testurl): Unknown test issue, to be reviewed -> $testurl/file/autoinst-log.txt"
 }
 openqa-investigate() {
     local testurl=$1


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/128405

The output for unown issues was changed to "Unknown test issue", but the test and the READE have never been adapted, mainly because we mock the function in our test, and the mock still uses the old string.

I will think about a way to mock less.