### PR TITLE
Adapt to new openqa-clone-job output

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -62,9 +62,12 @@ clone() {
     out=$($clone_call "$host_url/tests/$id" "${clone_settings[@]}")
     [[ $dry_run = 1 ]] && echo "$out"
     # output is in $out, should change that text to a markdown list entry
-    url=$(echo "$out" | sed -n 's/^Created job.*-> //p')
+    # Remove any text before the url
+    url=${out/*http:/http:}
+    # Change /tests/123 to /t123
+    url=${url/\/tests\//\/t}
     echo "* **$name**: $url"
-    clone_id=${out/:*/}; clone_id=${clone_id/*#/}
+    clone_id=${url/*\/t/}
     "${client_call[@]}" --json --data "{\"priority\": $((base_prio + prio_add))}" -X PUT jobs/"$clone_id" >/dev/null
 }
 


### PR DESCRIPTION
The output now looks like this:

    1 job has been created:
      - openqa-Tumbleweed-dev-x86_64-Build:TW.20280-openqa_install+publish@64bit-2G -> http://openqa.opensuse.org/tests/3264873

The code can now deal with short /t123 urls as well as long urls.

Issue: https://progress.opensuse.org/issues/128405