### PR TITLE
Check if we get passed a job id before investigating

### DIFF
--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -17,7 +17,9 @@ host_url="$scheme://$host"
 
 investigate-and-bisect() {
     local rc=0 test
-    read -r test
+    read -r test || rc=$?
+    [[ -n "$test" ]] || return 0
+    rc=0
     openqa-investigate "$test" || rc=$?
     [[ "$rc" -eq 142 ]] && return "$rc"
     openqa-trigger-bisect-jobs --url "$test" || rc=$?

--- a/test/03-openqa-label-known-issues-and-investigate-hook.t
+++ b/test/03-openqa-label-known-issues-and-investigate-hook.t
@@ -2,7 +2,7 @@
 
 source test/init
 
-plan tests 18
+plan tests 22
 dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
 
 source "$dir/../openqa-label-known-issues-and-investigate-hook"
@@ -75,3 +75,15 @@ export INVESTIGATE_FAIL=false
 export INVESTIGATE_RETRIGGER_HOOK=true
 try hook 123
 is "$rc" 142 'openqa-investigate exit code for retriggering hook script'
+
+openqa-label-known-issues() {
+    testurl=$1
+    warn "- openqa-label-known-issues $testurl"
+    echo "nothing"
+}
+export INVESTIGATE_RETRIGGER_HOOK=false
+try hook 123
+is "$rc" 0 'successful hook (no unknown issue) (123)'
+has "$got" "- openqa-label-known-issues"
+hasnt "$got" "- openqa-investigate"
+hasnt "$got" "- openqa-trigger-bisect-jobs"


### PR DESCRIPTION
If label() returns nothing, the 'test' variable might be empty, or the `read` call actually fails if it run under `-e` and result in an exit code 1.

Issue: https://progress.opensuse.org/issues/128405