### PR TITLE
Fix matching of urls

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -63,7 +63,7 @@ clone() {
     [[ $dry_run = 1 ]] && echo "$out"
     # output is in $out, should change that text to a markdown list entry
     # Remove any text before the url
-    url=${out/*http:/http:}
+    url=${out/*http/http}
     # Change /tests/123 to /t123
     url=${url/\/tests\//\/t}
     echo "* **$name**: $url"


### PR DESCRIPTION
It might be http or https

Otherwise we might get more unwanted output from the clone command in the
comment.

Issue: https://progress.opensuse.org/issues/128909 , https://progress.opensuse.org/issues/128405