### PR TITLE
Make sure exit code gets propagated to caller

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -184,11 +184,12 @@ $comment_text"
 
 fetch-investigation-results() {
     local origin_job_id=$1
-    local state job investigate_type other_id result investigate_comment comment_lines
+    local state job investigate_type other_id result investigate_comment output comment_lines
 
     investigate_comment=$("${client_call[@]}" -X GET jobs/"$origin_job_id"/comments | runjq -r '[.[] | select(.text | contains("Automatic investigation jobs for job") and contains(":investigate:retry**:"))] | min_by(.id)') || return $?
     [[ $investigate_comment == 'null' ]] && return
-    readarray -t comment_lines < <(echo "$investigate_comment" | runjq -r '.text') || return $?
+    output=$(echo "$investigate_comment" | runjq -r '.text') || return $?
+    mapfile -t comment_lines <<<"$output"
 
     for line in "${comment_lines[@]}"; do
         if [[ $line =~ :investigate:([^:*]+).*\/t([0-9]+) ]]; then
@@ -210,12 +211,15 @@ is-ok() {
 }
 
 is-product-issue() {
+    # Fetch job data for all 4 investigation jobs. If one is not yet finished,
+    # return special 142 to retrigger this hook later again.
     local origin_job_id=$1
-    local state result investigate_type passed result_lines
+    local state result investigate_type passed output result_lines
     local pass_lgt='' pass_lgb='' pass_lgtb=''
     product_issue=false
 
-    readarray -t result_lines < <(fetch-investigation-results "$origin_job_id") || return $?
+    output=$(fetch-investigation-results "$origin_job_id") || return $?
+    mapfile -t result_lines <<<"$output"
 
     for line in "${result_lines[@]}"; do
         if [[ $line =~ ^([^|]+)\|([^|]+)\|([^|]+) ]]; then
@@ -240,7 +244,8 @@ post-investigate() {
     local id=$1 old_name=$2
     local rc=0 status
     [[ ! "$old_name" =~ investigate:retry$ ]] && echo "Job is ':investigate:' already, skipping investigation" && return 0
-    # We are in the investigate:retry job now
+    # We are in the investigate:retry job now. From here we will check the
+    # results of the other investigation jobs, if necessary
     retry_result="$(echo "$job_data" | runjq -r '.job.result')" || return $?
     investigate_origin="$(echo "$job_data" | runjq -r '.job.settings.OPENQA_INVESTIGATE_ORIGIN')" || return 1
     origin_job_id=${investigate_origin#"$host_url/t"}

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -3,7 +3,7 @@
 source test/init
 bpan:source bashplus +err +fs +sym
 
-plan tests 46
+plan tests 47
 
 host=localhost
 url=https://localhost
@@ -45,6 +45,10 @@ openqa-cli() {
         echo '{ "state": "done", "test": "vim:investigate:retry", "result": "failed" }'
     elif [[ "$2" =~ experimental/jobs/3400[34]/status ]]; then
         echo '{ "state": "done", "test": "vim:investigate:retry", "result": "passed" }'
+    elif [[ "$2" =~ experimental/jobs/3401[01]/status ]]; then
+        echo '{ "state": "done", "test": "vim:investigate:retry", "result": "failed" }'
+    elif [[ "$2" =~ experimental/jobs/3401[12]/status ]]; then
+        echo '{ "state": "running", "test": "vim:investigate:retry", "result": "none" }'
     elif [[ $@ == "-X POST jobs/30/comments text=Starting investigation for job 31" ]]; then
         echo '{"id": 1234}'
     elif [[ $@ == $'-X PUT jobs/30/comments/1234 text=Automatic investigation jobs for job 31:\n\nfoo' ]]; then
@@ -61,6 +65,8 @@ openqa-cli() {
         echo '[{"id": 1236, "text":"Starting investigation for job 32"},{"id": 1237, "text":"Starting investigation for job 32"}]'
     elif [[ $@ == "-X GET jobs/35/comments" ]]; then
         echo '[{"id": 1236, "text":"Automatic investigation jobs for job\n**a:investigate:retry**:url/t34001\n**a:investigate:last_good_tests:coffee**:url/t34002\n**a:investigate:last_good_build:2001**:url/t34003\n**a:investigate:last_good_tests_and_build:coffee+2001**:url/t34004"}]'
+    elif [[ $@ == "-X GET jobs/36/comments" ]]; then
+        echo '[{"id": 1236, "text":"Automatic investigation jobs for job\n**a:investigate:retry**:url/t34010\n**a:investigate:last_good_tests:coffee**:url/t34011\n**a:investigate:last_good_build:2001**:url/t34012\n**a:investigate:last_good_tests_and_build:coffee+2001**:url/t34013"}]'
     elif [[ $@ =~ "-X POST jobs/35/comments" ]]; then
         warn "Commenting 35 ($@)"
         exit 99
@@ -130,6 +136,10 @@ has "$got" "likely not a sporadic" "not sporadic (34)"
 has "$got" "product issue" "product issue (34)"
 
 test-post-investigate() {
+
+    local job_data='{"job": { "result": "failed", "settings": { "OPENQA_INVESTIGATE_ORIGIN": "https://localhost/t36" } } }'
+    try post-investigate 36 "vim:investigate:retry"
+    is "$rc" 142 'post-investigate returned 142 (not all jobs finished yet) (36)'
 
     t1="fail"
 


### PR DESCRIPTION
    readarray -t foo < <(some command)

will not get the exit code of 'some command'.

Issue: https://progress.opensuse.org/issues/109920