### PR TITLE
Add test name to retry job comment

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -254,7 +254,7 @@ post-investigate() {
     # cluster jobs might have the same OPENQA_INVESTIGATE_ORIGIN as the root retry job
     [[ $retry_name != "$origin_name:investigate:retry" ]] && echo "Job $retry_name ($id) is not a retry of $origin_name ($origin_job_id)" && return 0
 
-    comment="Investigate retry job: $host_url/t$id"
+    comment="Investigate retry job **$retry_name**: $host_url/t$id"
     if is-ok "$retry_result"; then
         comment+=" $retry_result, likely a sporadic failure"
     else

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -3,7 +3,7 @@
 source test/init
 bpan:source bashplus +err +fs +sym
 
-plan tests 49
+plan tests 50
 
 host=localhost
 url=https://localhost
@@ -157,6 +157,7 @@ test-post-investigate() {
     try investigate 30001
     is "$rc" 2 'mocked function returned failure (30001)'
     has "$got" "Commenting 3000" "Posting comment on OPENQA_INVESTIGATE_ORIGIN (30001)"
+    has "$got" "Investigate retry job **vim:investigate:retry**" "retry test name appears in comment(30001)"
     has "$got" "likely not a sporadic" "not sporadic (30001)"
     has "$got" "product issue" "product issue (30001)"
 


### PR DESCRIPTION
To make it clear which scenario was tested here. There can be multiple such comments in case some test has a RETRY setting.

Related issue: https://progress.opensuse.org/issues/132332