### PR TITLE
Let curl output an error message on error

### DIFF
--- a/_common
+++ b/_common
@@ -215,7 +215,7 @@ $body
 
 latest_published_tw_builds() {
     local latest_builds group_id=$1
-    latest_builds=("$(runcurl -s "$tw_openqa_host/group_overview/$group_id.json" \
+    latest_builds=("$(runcurl -sS "$tw_openqa_host/group_overview/$group_id.json" \
         | jq -r '([.build_results[] | select(.tag.description=="published") | select(.version=="Tumbleweed") | .build] | sort | reverse)[]')")
     echo "${latest_builds[@]}"
 }

--- a/backlog-set-due-date
+++ b/backlog-set-due-date
@@ -24,7 +24,7 @@ if [ $# -eq 1 ] && [ -f "$1" ] && [ "$dry_run" = "1" ]; then
   jq -r "$jquery" "$1" >"$issues"
 else
   redmine_api_key="${redmine_api_key:?"Need redmine API key"}"
-  curl -s -H "X-Redmine-API-Key: $redmine_api_key" "$host/issues.json?query_id=$query_id&limit=$ticket_limit" | jq -r "$jquery" >"$issues"
+  curl -sS -H "X-Redmine-API-Key: $redmine_api_key" "$host/issues.json?query_id=$query_id&limit=$ticket_limit" | jq -r "$jquery" >"$issues"
 fi
 
 [ "$dry_run" = "1" ] && prefix="echo"

--- a/openqa-investigate
+++ b/openqa-investigate
@@ -76,7 +76,7 @@ trigger_jobs() {
     clone "$id" "$id" 'retry' '' "${@:2}"
 
     job_url="$host_url/tests/$id"
-    investigation=$(runcurl "${curl_args[@]}" -s "$job_url"/investigation_ajax) || return $?
+    investigation=$(runcurl "${curl_args[@]}" -sS "$job_url"/investigation_ajax) || return $?
     last_good_exists=$(echo "$investigation" | runjq -r '.last_good') || return $?
     if [[ "$last_good_exists" = "null" || "$last_good_exists" = "not found" ]]; then
         echo "No last good recorded, skipping regression investigation jobs" && return 0
@@ -91,7 +91,7 @@ trigger_jobs() {
         echo "$test_log. Skipping test regression investigation job."
         last_good_tests=''
     else
-        vars_last_good=$(runcurl "${curl_args[@]}" -s "$host_url/tests/$last_good"/file/vars.json) || return $?
+        vars_last_good=$(runcurl "${curl_args[@]}" -sS "$host_url/tests/$last_good"/file/vars.json) || return $?
         last_good_tests=$(echo "$vars_last_good" | runjq -r '.TEST_GIT_HASH') || return $?
         # here we could apply the same approach for needles, not only tests
         # With https://github.com/os-autoinst/os-autoinst/pull/1358 we could
@@ -110,7 +110,7 @@ trigger_jobs() {
         echo "Current job has same build as last good, product regression unlikely. Skipping product regression investigation job."
         last_good_build=''
     else
-        vars_last_good=${vars_last_good:-$(runcurl "${curl_args[@]}" -s "$host_url/tests/$last_good"/file/vars.json)} || return $?
+        vars_last_good=${vars_last_good:-$(runcurl "${curl_args[@]}" -sS "$host_url/tests/$last_good"/file/vars.json)} || return $?
         last_good_build=$(echo "$vars_last_good" | runjq -r '.BUILD') || return $?
         # here we clone with unspecified test refspec, i.e. this could be a
         # more recent tests version. As an alternative we could explicitly

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -117,7 +117,7 @@ investigate_issue() {
     fi
     reason=$(echo "$job_data" | runjq -r '.job.reason')
     group_id=$(echo "$job_data" | runjq -r '.job.group_id')
-    curl_output=$(curl "${curl_args[@]}" -s -w "%{http_code}" "$testurl/file/autoinst-log.txt" -o "$out")
+    curl_output=$(curl "${curl_args[@]}" -sS -w "%{http_code}" "$testurl/file/autoinst-log.txt" -o "$out")
     # combine both the reason and autoinst-log.txt to check known issues
     # against even in case when autoinst-log.txt is missing the details, e.g.
     # see https://progress.opensuse.org/issues/69178
@@ -149,7 +149,7 @@ label_issue() {
         fi
     fi
     # search for issues with a subject search term
-    issues=${issues:-$(runcurl "${curl_args[@]}" -s "$issue_query" | runjq -r '.issues | .[] | (.id,.subject,.tracker.name)')}
+    issues=${issues:-$(runcurl "${curl_args[@]}" -sS "$issue_query" | runjq -r '.issues | .[] | (.id,.subject,.tracker.name)')}
     investigate_issue "$testurl"
 }
 

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -30,7 +30,7 @@ wait_for_package_build() {
     local wip_states='\(unknown\|blocked\|scheduled\|dispatching\|building\|signing\|finished\)'
     local bad_states='\(failed\|unresolvable\|broken\)'
     local attempts="$osc_build_start_poll_tries"
-    while ! curl -s  "$osc_query" | grep -e "$wip_states" ; do
+    while ! curl -sS  "$osc_query" | grep -e "$wip_states" ; do
         if [[ $attempts -le 0 ]]; then
             echo "warning: Re-build of $package has not been considered in time (or package has been re-built so fast that we've missed it)"
             break
@@ -39,11 +39,11 @@ wait_for_package_build() {
         sleep "$osc_poll_interval"
         attempts=$((attempts - 1))
     done
-    while curl -s "$osc_query" | grep -e "$wip_states" ; do
+    while curl -sS "$osc_query" | grep -e "$wip_states" ; do
         echo "Waiting while $package is in progress"
         sleep "$osc_poll_interval"
     done
-    if curl -s "$osc_query" | grep -e "$bad_states" ; then
+    if curl -sS "$osc_query" | grep -e "$bad_states" ; then
         echo "Building $package has failed, skipping submission"
         return 1
     fi


### PR DESCRIPTION
Normally we want it to be silent to not have any informational output we don't need, but in error cases, for example the host is not reachable, we want to see the error message.

Issue: https://progress.opensuse.org/issues/132665