### PR TITLE
iPXE: Clear screen before booting

### DIFF
--- a/ipxe/menu.ipxe
+++ b/ipxe/menu.ipxe
@@ -99,6 +99,13 @@ echo -n Kernel cmdline: ${}
 read cmdline
 echo -n Initrd: ${}
 read initrd
+
+# clear the screen to prevent lost chars (eg in ipmi openqa tests)
+set esc:hex 1b            # ANSI escape character - "^["
+set cls ${esc:string}[2J  # ANSI clear screen sequence - "^[[2J"
+echo ${cls}
+sleep 1 # clearing the screen may take a second
+
 kernel ${kernel} ${cmdline}
 initrd ${initrd}
 boot


### PR DESCRIPTION
This prevents lost chars from the multiline input prompts

Ticket: https://progress.opensuse.org/issues/133490