### PR TITLE
Add pxeboot config for aarch64

### DIFF
--- a/ipxe/boot.ipxe
+++ b/ipxe/boot.ipxe
@@ -4,7 +4,10 @@
 # git clone https://github.com/ipxe/ipxe.git
 # cd ipxe/src
 # make EMBED=boot.ipxe bin/ipxe.pxe bin-x86_64-efi/ipxe.efi
-# make EMBED=boot.ipxe CROSS=/usr/bin/aarch64-suse-linux- bin-arm64-efi/ipxe.efi
+# cp bin/ipxe.pxe bin-x86_64-efi/ipxe.efi /srv/tftpboot/ipxe/
+# zypper -n in cross-aarch64-gcc13
+# make EMBED=/srv/tftpboot/ipxe/boot.ipxe CROSS=aarch64-suse-linux- bin-arm64-efi/ipxe.efi
+# cp bin-arm64-efi/ipxe.efi /srv/tftpboot/ipxe/ipxe-arm64.efi
 
 echo Welcome to o3 iPXE
 

--- a/ipxe/menu.ipxe
+++ b/ipxe/menu.ipxe
@@ -11,6 +11,7 @@ menu iPXE boot menu for openqa.opensuse.org
 
 item --gap --             ------------------------- Operating systems ------------------------------
 item --gap --             ------ (You will be prompted to edit cmdline after selecting an os) ------
+item --gap --             -------------------------------- x86_64 ----------------------------------
 item --key l leapS1       (L)Boot openSUSE Leap15.5 from download.opensuse.org / ttyS1 (http)
 item --key e leapS2       (E)Boot openSUSE Leap15.5 from download.opensuse.org / ttyS2 (http)
 item --key a leapS1auto   (A)Boot openSUSE Leap15.5 / ttyS1 autoyast=https://is.gd/oqaay4
@@ -21,6 +22,8 @@ item --key s tumbleweedS2 (S)Boot openSUSE Tumbleweed from download.opensuse.org
 item --key M memtest64efi (M)Memtest 64 EFI
 item --key N nbxyzbios    (N)Netboot.xyz BIOS
 item --key N nbxyzefi     (N)Netboot.xyz EFI
+item --gap --             -------------------------------- AArch64 ---------------------------------
+item --key o leapS1aarch64auto (O)Boot openSUSE Leap15.5 / ttyS1 autoyast=https://is.gd/oqaay4
 item --gap --             ------------------------- Advanced options -------------------------------
 item --key c config       Configure settings
 item shell                Drop to iPXE shell 
@@ -85,6 +88,12 @@ chain --autofree http://boot.netboot.xyz/ipxe/netboot.xyz.lkrn
 
 :nbxyzefi
 chain --autofree http://boot.netboot.xyz/ipxe/netboot.xyz.efi
+
+:leapS1aarch64auto
+set kernel http://download.opensuse.org/distribution/leap/15.5/repo/oss/boot/aarch64/linux
+set cmdline network=1 install=http://download.opensuse.org/distribution/leap/15.5/repo/oss/ root=/dev/ram0 initrd=initrd textmode=1 console=tty console=ttyS1,115200 autoyast=https://is.gd/oqaay4 rootpassword=opensuse
+set initrd http://download.opensuse.org/distribution/leap/15.5/repo/oss/boot/aarch64/initrd
+goto editandboot
 
 :editandboot
 echo Selected settings:

--- a/ipxe/pxeboot.conf
+++ b/ipxe/pxeboot.conf
@@ -10,8 +10,10 @@ dhcp-no-override
 dhcp-option=option:tftp-server,"10.150.1.11"
 
 # set tags according to client architecture option received in DISCOVER
-# see https://www.rfc-editor.org/rfc/rfc4578#section-2.1 for an incomplete list
+# see https://github.com/wireshark/wireshark/blob/wireshark-4.0.7/epan/dissectors/packet-dhcp.c#L1208
+dhcp-match=set:efi-aarch64-http,option:client-arch,19
 dhcp-match=set:efi-x86_64-http,option:client-arch,16
+dhcp-match=set:efi-aarch64,option:client-arch,11
 dhcp-match=set:efi-x86_64,option:client-arch,9
 dhcp-match=set:efi-x86_64,option:client-arch,7
 dhcp-match=set:efi-x86,option:client-arch,6
@@ -26,5 +28,12 @@ dhcp-option=tag:efi-x86_64,option:bootfile-name,ipxe/ipxe.efi
 # UEFI http boot
 dhcp-option=tag:efi-x86_64-http,option:bootfile-name,http://10.150.1.11/tftpboot/ipxe/ipxe.efi
 dhcp-option=tag:efi-x86_64-http,option:vendor-class,HTTPClient
+
+# UEFI tftp boot aarch64
+dhcp-option=tag:efi-aarch64,option:bootfile-name,ipxe/ipxe-arm64.efi
+
+# UEFI http boot aarch64
+dhcp-option=tag:efi-aarch64-http,option:bootfile-name,http://10.150.1.11/tftpboot/ipxe/ipxe-arm64.efi
+dhcp-option=tag:efi-aarch64-http,option:vendor-class,HTTPClien
 
 #dhcp-boot=grub2.ppc64le.elf


### PR DESCRIPTION
This does not yet contain any entries tailored for aarch64 but machines will boot into the iPXE menu.

Related ticket: https://progress.opensuse.org/issues/134123