### PR TITLE
Consistently use the term unreviewed issue in all contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ expensive when `(?s)` is used. Every `.*` can span over multiple lines and
 that involves a lot of backtracking and might not be needed. Use `[^\n]*` over
 `.*` where possible or use line spanning matches like `[\S\s]*`.
 
-### Unknown issues
+### Unreviewed issues
 
 If none of your configured searches above are matching, you can configure a
 notification for those failed jobs, for example to an email address or a
@@ -85,7 +85,7 @@ Just put the following into the description of the Job Group:
 Each Slack channel has its own email address which you can find out by clicking
 on the title and then on "Integrations".
 
-The email will have the subject "Unknown test issue to be reviewed (Group 123)".
+The email will have the subject "Unreviewed issue (Group 123 Foobar)".
 It will contain the link to the job and a small log excerpt, possibly
 already pointing to the error. The sender email address can be
 [configured](#Configuration).
@@ -111,9 +111,9 @@ there is no carry-over and no automatic ticket assignment by auto-review.
 
 ### Combine auto-review and openqa-investigate
 
-A possible approach to combine handling known issues and unknown issues is to
+A possible approach to combine handling known issues and unreviewed issues is to
 run "openqa-label-known-issues-multi" against all "investigation candidates" and
-pass all unknown issues to "openqa-investigate-multi":
+pass all unreviewed issues to "openqa-investigate-multi":
 
 ```
 ./openqa-review-failed
@@ -146,7 +146,7 @@ following scripts are provided:
 
 `openqa-label-known-issues-and-investigate-hook` recognizes the following
 environment variables:
-* `notification_address` - If set, unknown issues will be sent to this address
+* `notification_address` - If set, unreviewed issues will be sent to this address
    unless a job group has an address configured
 * `from_email` - The From address for notification emails
 * `force_result` - If set to `1` tickets in the [tracker openqa-force-result](https://progress.opensuse.org/projects/openqav3/issues?query_id=700) can override job results

--- a/_common
+++ b/_common
@@ -128,7 +128,7 @@ label-on-issue() {
 
 snip_start="    # --- 8< ---"$'\n'
 snip_end="    # --- >8 ---"
-handle_unknown() {
+handle_unreviewed() {
     local testurl=$1 out=$2 reason=$3 group_id=$4 email_unreviewed=$5 from_email=$6 notification_address=${7:-} job_data=${8:-} dry_run=${9:-}
     local group_data group_name group_description group_mailto header email excerpt=$snip_start
     local job_name job_result info

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -140,7 +140,7 @@ investigate_issue() {
     # subject line
     elif label_on_issues_without_tickets "$id"; then return
     else
-        handle_unknown "$testurl" "$out" "$reason" "$group_id" "$email_unreviewed" "$from_email" "$notification_address" "$job_data" "$dry_run"
+        handle_unreviewed "$testurl" "$out" "$reason" "$group_id" "$email_unreviewed" "$from_email" "$notification_address" "$job_data" "$dry_run"
     fi
 }
 

--- a/test/01-label-known-issues.t
+++ b/test/01-label-known-issues.t
@@ -74,7 +74,7 @@ client_args=(api --host http://localhost)
 testurl=https://openqa.opensuse.org/api/v1/jobs/2291399
 group_id=24
 job_data='{"job": {"name": "foo", "result": "failed"}}'
-out=$(handle_unknown "$testurl" "$logfile1" "no reason" "$group_id" true "$from_email" "" "$job_data" 2>&1 >/dev/null) || true
+out=$(handle_unreviewed "$testurl" "$logfile1" "no reason" "$group_id" true "$from_email" "" "$job_data" 2>&1 >/dev/null) || true
 has "$out" 'Subject: Unreviewed issue (Group 24 openQA)' "send-email subject like expected"
 has "$out" 'From: openqa-label-known-issues <foo@bar>' "send-email from called like expected"
 has "$out" 'To: dummy@example.com.dummy' "send-email to like expected"
@@ -83,15 +83,15 @@ has "$out" 'Content-Type: text/html' 'mail has text part'
 has "$out" 'Content-Type: text/plain' 'mail has HTML part'
 has "$out" '<li>Name: foo' 'mail contains job name'
 
-out=$(handle_unknown "$testurl" "$logfile1" "no reason" "null" true "$from_email" 2>&1 >/dev/null) || true
+out=$(handle_unreviewed "$testurl" "$logfile1" "no reason" "null" true "$from_email" 2>&1 >/dev/null) || true
 is "$out" '' "send-email not called for group_id null"
 
 group_id=25
-out=$(handle_unknown "$testurl" "$logfile1" "no reason" "$group_id" true "$from_email" 2>&1 >/dev/null) || true
+out=$(handle_unreviewed "$testurl" "$logfile1" "no reason" "$group_id" true "$from_email" 2>&1 >/dev/null) || true
 is "$out" '' "send-email not called for no email address and no fallback address"
 
 notification_address=fallback@example.com
-out=$(handle_unknown "$testurl" "$logfile1" "no reason" "$group_id" true "$from_email" "$notification_address" "$job_data" 2>&1 >/dev/null) || true
+out=$(handle_unreviewed "$testurl" "$logfile1" "no reason" "$group_id" true "$from_email" "$notification_address" "$job_data" 2>&1 >/dev/null) || true
 has "$out" 'To: fallback@example.com' "send-email to like expected"
 has "$out" 'Subject: Unreviewed issue (Group 25 Lala)' "send-email subject like expected"
 
@@ -100,5 +100,5 @@ send-email() {
     echo "$mailto" >&2
     echo "$email" >&2
 }
-out=$(handle_unknown "$testurl" "$logfile1" "no reason" "$group_id" true "" "" "$job_data" ) || true
+out=$(handle_unreviewed "$testurl" "$logfile1" "no reason" "$group_id" true "" "" "$job_data" ) || true
 like "$out" "\[$testurl\].*Unknown test issue, to be reviewed"


### PR DESCRIPTION
We should not talk about unknown and unreviewed issues in different places to mean the same thing.

The docs also don't explain the actual email subject.

See: https://progress.opensuse.org/issues/132437