### PR TITLE
Fix warnings about empty variables

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -236,9 +236,9 @@ identify-issue-type() {
             fi
         fi
     done
-    if ([[ -z "$pass_lgtb" ]] || "$pass_lgtb") && ([[ -z "$pass_lgt" ]] || ! "$pass_lgt") && "$pass_lgb"; then
+    if ([[ -z "$pass_lgtb" ]] || "$pass_lgtb") && ([[ -z "$pass_lgt" ]] || ! "$pass_lgt") && [[ -n "$pass_lgb" ]] && "$pass_lgb"; then
         product_issue=true
-    elif ([[ -z "$pass_lgtb" ]] || "$pass_lgtb") && "$pass_lgt" && ([[ -z "$pass_lgb" ]] || ! "$pass_lgb"); then
+    elif ([[ -z "$pass_lgtb" ]] || "$pass_lgtb") && [[ -n "$pass_lgt" ]] && "$pass_lgt" && ([[ -z "$pass_lgb" ]] || ! "$pass_lgb"); then
         test_issue=true
     fi
 }

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -3,7 +3,7 @@
 source test/init
 bpan:source bashplus +err +fs +sym
 
-plan tests 69
+plan tests 73
 
 host=localhost
 url=https://localhost
@@ -271,6 +271,23 @@ last_good_tests_and_build|4|$t4"
     identify-issue-type 999
     is "$product_issue" "false" "$t1+$t2+$t3+$t4 -> false"
     is "$test_issue" "false" "$t1+$t2+$t3+$t4 -> false"
+
+    # test when last good tests or build do not exist
+    fetch-investigation-results() {
+        echo "retry|1|failed
+last_good_build|3|passed"
+    }
+    identify-issue-type 999
+    is "$product_issue" "true" "failed+n/a+failed+n/a -> true"
+    is "$test_issue" "false" "failed+n/a+failed+n/a -> false"
+
+    fetch-investigation-results() {
+        echo "retry|1|failed
+last_good_tests|2|passed"
+    }
+    identify-issue-type 999
+    is "$product_issue" "false" "failed+failed+n/a+n/a -> false"
+    is "$test_issue" "true" "failed+failed+n/a+n/a -> true"
 }
 
 test-post-investigate


### PR DESCRIPTION
We saw warnings in the logs:

    /opt/os-autoinst-scripts/openqa-investigate: line 239: : command not found
    /opt/os-autoinst-scripts/openqa-investigate: line 241: : command not found

By testing if the variables have content this can be fixed. Not sure how I would make such warnings fatal in our tests.

Issue: https://progress.opensuse.org/issues/132272