### PR TITLE
Add simple script to check linking reason for package

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -19,6 +19,7 @@ main_requires:
   curl:
   grep:
   jq:
+  yq:
   sed:
   sudo:
   openQA-client:  # openqa-cli

--- a/dist/rpm/os-autoinst-scripts-deps.spec
+++ b/dist/rpm/os-autoinst-scripts-deps.spec
@@ -25,7 +25,7 @@ Group:          Development/Tools/Other
 BuildArch:      noarch
 Url:            https://github.com/os-autoinst/scripts
 # The following line is generated from dependencies.yaml
-%define main_requires bash coreutils curl grep html-xml-utils jq openQA-client openssh-clients osc perl >= 5.010 perl(Data::Dumper) perl(FindBin) perl(Getopt::Long) perl(Mojo::File) perl(Text::Markdown) perl(YAML::PP) sed sudo xmlstarlet
+%define main_requires bash coreutils curl grep html-xml-utils jq openQA-client openssh-clients osc perl >= 5.010 perl(Data::Dumper) perl(FindBin) perl(Getopt::Long) perl(Mojo::File) perl(Text::Markdown) perl(YAML::PP) sed sudo xmlstarlet yq
 # The following line is generated from dependencies.yaml
 %define test_requires perl(Test::Most) perl(Test::Warnings)
 Requires:       %main_requires

--- a/obs-check-devel-openqa-leap-extra-dependencies
+++ b/obs-check-devel-openqa-leap-extra-dependencies
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+osc="osc --apiurl https://api.opensuse.org"
+
+for project in $($osc search --project -s 'devel:openQA:Leap:' | grep -o '^devel:openQA:Leap:.*'); do
+    for package in $($osc list "$project"); do
+        $osc api "/comments/package/$project/$package" | \
+            yq -pxml -oy '.comments.comment |= ([] + .) | .comments.comment[].+content' | \
+            grep -q "Reason for linking:" || \
+            { echo "No reason for $project/$package" >&2; problem=1; }
+    done
+done
+
+test -z "$problem"


### PR DESCRIPTION
Check for comments in each package and look for reason to linking. Outputs the list of packages without a reason.

Reference: https://progress.opensuse.org/issues/128087