### PR TITLE
Wait longer and sleep longer

### DIFF
--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -23,6 +23,8 @@ notification_address=${notification_address:-}
 from_email=${from_email:-openqa-label-known-issues@open.qa}
 curl_args=(-L --user-agent "openqa-label-known-issues")
 retries="${retries:-"3"}"
+OPENQA_CLI_RETRY_SLEEP_TIME_S=${OPENQA_CLI_RETRY_SLEEP_TIME_S:-20}
+MOJO_CONNECT_TIMEOUT=${MOJO_CONNECT_TIMEOUT:-30}
 client_args=(api --header 'User-Agent: openqa-label-known-issues (https://github.com/os-autoinst/scripts)' --host "$host_url" --retries="$retries")
 
 out="${REPORT_FILE:-$(mktemp -t openqa-label-known-issues--output-XXXX)}"


### PR DESCRIPTION
When making openqa-cli requests, we try to be more patient.

https://github.com/os-autoinst/openQA/pull/5359 Will make sure also connection timeouts will be retried.

Issue: https://progress.opensuse.org/issues/138545