### PR TITLE
Assign correct CASEDIR based on TEST_GIT_URL on clone function

### DIFF
--- a/_common
+++ b/_common
@@ -11,6 +11,7 @@ enable_force_result=${enable_force_result:-false}
 
 client_call=()
 client_args=()
+curl_args=()
 markdown_cmd=$(command -v Markdown.pl) || markdown_cmd=$(command -v markdown) \
     || warn "+++ (Markdown.pl|markdown) not found, please install Text::Markdown +++"
 openqa_cli="${openqa_cli:-""}"
@@ -255,3 +256,7 @@ find_latest_published_tumbleweed_image() {
     echo "$image"
 }
 
+fetch-vars-json() {
+    local tid=$1
+    runcurl "${curl_args[@]}" -sS "$host_url/tests/$tid"/file/vars.json || return $?
+}

--- a/openqa-investigate
+++ b/openqa-investigate
@@ -51,7 +51,10 @@ clone() {
     base_prio=$(echo "$clone_job_data" | runjq -r '.job.priority') || return $?
     clone_settings=("TEST+=:investigate$name_suffix" '_TRIGGER_JOB_DONE_HOOK=1' '_GROUP_ID=0' 'BUILD=')
     if [[ $refspec ]]; then
+	vars_json=$(fetch-vars-json "$origin")
+        testgiturl=$(echo "$vars_json" | runjq -r '.TEST_GIT_URL')
         casedir=$(echo "$clone_job_data" | runjq -r '.job.settings.CASEDIR') || return $?
+        [[ $testgiturl != null ]] && casedir=$testgiturl
         [[ $casedir == null ]] && casedir=''
         repo=${casedir:-'https://github.com/os-autoinst/os-autoinst-distri-opensuse.git'}
         clone_settings+=("CASEDIR=${repo%#*}#${refspec}")


### PR DESCRIPTION
When TEST_GIT_URL is used the CASEDIR should assign the repo based on this variable. As such the investigation uses the correct test repo to clone jobs. 