### PR TITLE
openqa-investigate: Fix dry-run depending on presence of comments

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -65,7 +65,10 @@ clone() {
     clone_settings+=($(echo "$clone_job_data" | runjq -r '.job.settings | keys[] | select (startswith("PUBLISH_")) | . + "="')) || return $?
     clone_settings+=("OPENQA_INVESTIGATE_ORIGIN=$host_url/t$origin")
     out=$($clone_call "$host_url/tests/$id" "${clone_settings[@]}")
-    [[ $dry_run = 1 ]] && echo "$out"
+    if [[ $dry_run = 1 ]]; then
+        echo "$out"
+        out="{ \"$origin\": 42}"
+    fi
 
     # output: { "$id": $clone_id }
     clone_id=$(echo "$out" | runjq -r ".\"$id\"")
@@ -159,6 +162,7 @@ query_dependency_data_or_postpone() {
 sync_via_investigation_comment() {
     local id=$1 first_cluster_job_id=$2
 
+    [[ $dry_run = 1 ]] && return 255
     comment_id=$("${client_call[@]}" -X POST jobs/"$first_cluster_job_id"/comments text="Starting investigation for job $id" | runjq -r '.id') || return $?
     first_comment_id=$("${client_call[@]}" -X GET jobs/"$first_cluster_job_id"/comments | runjq -r '[.[] | select(.text | contains("investigation"))] | min_by(.id) | .id') || return $?
 
@@ -198,6 +202,7 @@ fetch-investigation-results() {
     local origin_job_id=$1
     local state job investigate_type other_id result investigate_comment output comment_lines
 
+    [[ $dry_run = 1 ]] && return 0
     investigate_comment=$("${client_call[@]}" -X GET jobs/"$origin_job_id"/comments | runjq -r '[.[] | select(.text | contains("Automatic investigation jobs for job") and contains(":investigate:retry*:"))] | min_by(.id)') || return $?
     [[ $investigate_comment == 'null' ]] && return
     output=$(echo "$investigate_comment" | runjq -r '.text') || return $?


### PR DESCRIPTION
This fixes the dry-run mode by returning from functions early or
simulating the output of "openqa-clone-job" when we would call
openqa-clone-job and parse its output.

Before:

```
$ dry_run=1 ./openqa-investigate 3876947
jq (161 ./openqa-investigate): jq: parse error: Invalid numeric literal at line 1, column 11 (rc: 5 Input: >>>openqa-cli api --header User-Agent: openqa-investigate (https://github.com/os-autoinst/scripts) --host https://aquarius.suse.cz --retries=3 -X POST jobs/20047/comments text=Starting investigation for job 20047<<<)
```

After:

```
$ dry_run=1 ./openqa-investigate 3876947
openqa-cli api --header User-Agent: openqa-investigate (https://github.com/os-autoinst/scripts) --host https://openqa.opensuse.org -X PUT jobs/3876947/comments/ text=Automatic investigation jobs for job 3876947:

openqa-clone-job --json-output --skip-chained-deps --max-depth 0 --parental-inheritance --within-instance https://openqa.opensuse.org/tests/3876947 TEST+=:investigate:retry _TRIGGER_JOB_DONE_HOOK=1 _GROUP_ID=0 BUILD= OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/t3876947
* **krypton-live:investigate:retry**: https://openqa.opensuse.org/tnull
openqa-clone-job --json-output --skip-chained-deps --max-depth 0 --parental-inheritance --within-instance https://openqa.opensuse.org/tests/3876947 TEST+=:investigate:last_good_tests:b1712f3140cbe7ab8f30cf0647e54aa433e3c401 _TRIGGER_JOB_DONE_HOOK=1 _GROUP_ID=0 BUILD= CASEDIR=https://github.com/os-autoinst/os-autoinst-distri-opensuse.git#b1712f3140cbe7ab8f30cf0647e54aa433e3c401 OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/t3876947
* **krypton-live:investigate:last_good_tests:b1712f3140cbe7ab8f30cf0647e54aa433e3c401**: https://openqa.opensuse.org/tnull
openqa-clone-job --json-output --skip-chained-deps --max-depth 0 --parental-inheritance --within-instance https://openqa.opensuse.org/tests/3836309 TEST+=:investigate:last_good_build:10.44 _TRIGGER_JOB_DONE_HOOK=1 _GROUP_ID=0 BUILD= OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/t3876947
* **krypton-live:investigate:last_good_build:10.44**: https://openqa.opensuse.org/tnull
openqa-clone-job --json-output --skip-chained-deps --max-depth 0 --parental-inheritance --within-instance https://openqa.opensuse.org/tests/3836309 TEST+=:investigate:last_good_tests_and_build:b1712f3140cbe7ab8f30cf0647e54aa433e3c401+10.44 _TRIGGER_JOB_DONE_HOOK=1 _GROUP_ID=0 BUILD= CASEDIR=https://github.com/os-autoinst/os-autoinst-distri-opensuse.git#b1712f3140cbe7ab8f30cf0647e54aa433e3c401 OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/t3876947
* **krypton-live:investigate:last_good_tests_and_build:b1712f3140cbe7ab8f30cf0647e54aa433e3c401+10.44**: https://openqa.opensuse.org/tnull

[*Detailed explanation of this comment*](https://github.com/os-autoinst/scripts#More-details-and-examples-about-openqa-investigate-comments)
```

Related progress issue: https://progress.opensuse.org/issues/153763