### PR TITLE
Replace spurt with Mojo::File::spew

### DIFF
--- a/external/os-autoinst-common/tools/update-deps
+++ b/external/os-autoinst-common/tools/update-deps
@@ -77,7 +77,7 @@ RUN zypper in -y -C \\
 $dep   && zypper clean
 EOM
     $docker =~ s/($begin\n)(.*)($end\n)/$1$run$3/s;
-    path($dockerfile)->spurt($docker);
+    path($dockerfile)->spew($docker);
     say "Updated $dockerfile";
 }
 
@@ -111,7 +111,7 @@ sub update_spec {
         }
     }
 
-    path($specfile)->spurt($spec);
+    path($specfile)->spew($spec);
     say "Updated $specfile";
 }
 
@@ -186,7 +186,7 @@ $cover_requires
 };
 EOM
 
-    path($cpanfile)->spurt($cpan);
+    path($cpanfile)->spew($cpan);
     say "Updated $cpanfile";
 }
 


### PR DESCRIPTION
Pipeline shows a warning on xt/01-make-update-deps.t for deprecate use of Mojo::File::spurt. Fix it replacing with Mojo::File::spew