### PR TITLE
Enhance CI with whitespace checks on bash scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,6 @@ jobs:
         run: |
          sudo apt-get install yamllint shellcheck
          make checkstyle
+         tools/tab_checker "$PR_NUMBER"
+        env:
+	 PR_NUMBER: ${{ github.event.number }}

--- a/tools/tab_checker
+++ b/tools/tab_checker
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+pr_id=$1
+files=$(curl https://api.github.com/repos/os-autoinst/scripts/pulls/${pr_id}/files | jq -c '.[].filename' | sed 's/\"//g')
+checker() {
+for n in "$files"; do
+    if head -1 "$n" | grep -q '^#!'; then
+       if [[ $(sed -n '/\t/p' "$n" | wc -l) > 0 ]]; then
+          echo "$n is using TAB"
+       	  return 1
+       fi
+    return 0
+fi
+done
+}
+
+checker "$@"


### PR DESCRIPTION
Implement `tab_checker` to ensure non-tab intentation usage on the bash scripts. The scripts runs only against the committed files of the PR using github REST API.