### PR TITLE
Fix submission of openQA package after node module changes

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -62,7 +62,7 @@ update_package() {
         mv -v "$file" "$(echo "$file" | sed -e 's,.*:,,')"
     done
     version=$(sed -n 's/^Version:\s*//p' ./*.spec || sed -n 's/^version:\s*//p' ./*.obsinfo)
-    rm -f ./*rpmlintrc _servicedata
+    rm -f ./*rpmlintrc _servicedata node_modules.sums package-lock.json
     $osc addremove
     sed -i '/rpmlintrc/d' ./*.spec || true
     if [[ "$package" == "os-autoinst-distri-opensuse-deps" || "$package" =~ "container" ]]; then


### PR DESCRIPTION
Fixes problem as observed in https://progress.opensuse.org/issues/153427#note-25

`Attention, "node_modules.sums" is not mentioned in spec files as source or patch.`

Verified by executing locally which created

https://build.opensuse.org/request/show/1146602