### PR TITLE
Avoid conflict with GitHub syntax in `openqa-clone-…-job-from-pr`

### DIFF
--- a/openqa-clone-and-monitor-job-from-pr
+++ b/openqa-clone-and-monitor-job-from-pr
@@ -67,12 +67,12 @@ my @vars = ("BUILD=$gh_repo.git#$gh_ref", "_GROUP_ID=$group_id", "CASEDIR=$gh_sr
 
 sub _parse_urls ($text) {
     my @urls;
-    while ($text =~ /(\@openqa:?\s+Clone\s+(https?:[^\s]+))/ig) {
+    while ($text =~ /(openqa:\s+Clone\s+(https?:[^\s]+))/ig) {
         push @urls, $2 if index($2, $expected_url) == 0;
     }
     return \@urls if @urls;
     print 'No test cloned; the PR description does not contain ';    # uncoverable statement
-    print "a command like '\@openqa: Clone $expected_url/tests/<JOB_ID>'.\n";    # uncoverable statement
+    print "a command like 'openqa: Clone $expected_url/tests/<JOB_ID>'.\n";    # uncoverable statement
     exit 0;
 }
 

--- a/test/05-clone-and-monitor.t
+++ b/test/05-clone-and-monitor.t
@@ -14,8 +14,8 @@ $ENV{OPENQA_API_KEY} = 'key';
 $ENV{OPENQA_API_SECRET} = 'secret';
 $ENV{GITHUB_SERVER_URL} = 'gh-srv-url';
 $ENV{GH_PR_BODY} = 'Merge my changes
-@openqa: Clone http://127.0.0.1:9526/tests/4240
-@openqa: Clone http://127.0.0.1:9526/tests/4239
+openqa: Clone http://127.0.0.1:9526/tests/4240
+openqa: Clone http://127.0.0.1:9526/tests/4239
 footnote';
 
 require "$FindBin::RealBin/../openqa-clone-and-monitor-job-from-pr";


### PR DESCRIPTION
* Avoid using `@` so one does not have to mention the unrelated `openqa` organization
* Make the `:` mandatory so the pattern is still hard enough to put in accidentally