### PR TITLE
Allow investigation to schedule modules regardless PUBLISH_

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -70,7 +70,7 @@ clone() {
     [[ -n ${*:5} ]] && clone_settings+=("${@:5}")
     # clear "PUBLISH_" settings to avoid overriding production assets
     # shellcheck disable=SC2207
-    clone_settings+=($(echo "$clone_job_data" | runjq -r '.job.settings | keys[] | select (startswith("PUBLISH_")) | . + "="')) || return $?
+    clone_settings+=($(echo "$clone_job_data" | runjq -r '.job.settings | keys[] | select (startswith("PUBLISH_")) | . + "=none"')) || return $?
     clone_settings+=("OPENQA_INVESTIGATE_ORIGIN=$host_url/t$origin")
     out=$($clone_call "$host_url/tests/$id" "${clone_settings[@]}")
     if [[ $dry_run = 1 ]]; then


### PR DESCRIPTION
Due to conditions in main_common PUBLISH_* variable cant be empty. Set to `None` to allow the scheduling.

https://progress.opensuse.org/issues/156394