### PR TITLE
Retry osc command-line invocations

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -155,7 +155,7 @@ handle_auto_submit() {
 }
 
 [ "$dry_run" = "1" ] && prefix="echo"
-osc="${osc:-"$prefix osc"}"
+osc="${osc:-"$prefix retry -e osc"}"
 
 TMPDIR=${TMPDIR:-$(mktemp -d -t os-autoinst-obs-auto-submit-XXXX)}
 trap 'rm -rf "$TMPDIR"' EXIT


### PR DESCRIPTION
Try again if OBS is unavailable temporarily.

See: https://progress.opensuse.org/issues/157018