### PR TITLE
Revert "Retry osc command-line invocations"

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -155,7 +155,7 @@ handle_auto_submit() {
 }
 
 [ "$dry_run" = "1" ] && prefix="echo"
-osc="${osc:-"$prefix retry -e osc"}"
+osc="${osc:-"$prefix osc"}"
 
 TMPDIR=${TMPDIR:-$(mktemp -d -t os-autoinst-obs-auto-submit-XXXX)}
 trap 'rm -rf "$TMPDIR"' EXIT


### PR DESCRIPTION
Reverts os-autoinst/scripts#300

The last job failed with
http://jenkins.qa.suse.de/job/submit-openQA-TW-to-oS_Fctry/1004/console
```
bash: line 165: retry: command not found
```
As I don't know where we would need to install `retry` it might be the best to revert it for now