### PR TITLE
Revert "Retry osc command-line invocations"

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -33,7 +33,6 @@ main_requires:
   perl(Mojo::File):
   perl(Text::Markdown):
   perl(YAML::PP):
-  retry:
   html-xml-utils:
   xmlstarlet:
 test_requires:

--- a/dist/rpm/os-autoinst-scripts-deps.spec
+++ b/dist/rpm/os-autoinst-scripts-deps.spec
@@ -25,7 +25,7 @@ Group:          Development/Tools/Other
 BuildArch:      noarch
 Url:            https://github.com/os-autoinst/scripts
 # The following line is generated from dependencies.yaml
-%define main_requires bash coreutils curl grep html-xml-utils jq openQA-client openssh-clients osc perl >= 5.010 perl(Data::Dumper) perl(FindBin) perl(Getopt::Long) perl(Mojo::File) perl(Text::Markdown) perl(YAML::PP) retry sed sudo xmlstarlet yq
+%define main_requires bash coreutils curl grep html-xml-utils jq openQA-client openssh-clients osc perl >= 5.010 perl(Data::Dumper) perl(FindBin) perl(Getopt::Long) perl(Mojo::File) perl(Text::Markdown) perl(YAML::PP) sed sudo xmlstarlet yq
 # The following line is generated from dependencies.yaml
 %define test_requires perl(Test::MockModule) perl(Test::Most) perl(Test::Output) perl(Test::Warnings)
 # The following line is generated from dependencies.yaml

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -155,7 +155,7 @@ handle_auto_submit() {
 }
 
 [ "$dry_run" = "1" ] && prefix="echo"
-osc="${osc:-"$prefix retry -e osc"}"
+osc="${osc:-"$prefix osc"}"
 
 TMPDIR=${TMPDIR:-$(mktemp -d -t os-autoinst-obs-auto-submit-XXXX)}
 trap 'rm -rf "$TMPDIR"' EXIT


### PR DESCRIPTION
Reverts os-autoinst/scripts#302

Apparently the -- is picked up by retry.

    retry: unrecognized option '--server-side-source-service-files'