### PR TITLE
Prevent useless retries on osc cat always failing in pipe

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 export LC_ALL=C
 src_project="${src_project:-"devel:openQA"}"
@@ -88,7 +88,7 @@ last_revision() {
         file=_service:$service:$file
     fi
     local line
-    line=$($osc cat "$project/$package/$file" | grep 'Update to version' | head -n1)
+    line=$(grep -m1 'Update to version' <($osc cat "$project/$package/$file"))
     # shellcheck disable=SC2001
     echo "$line" | sed -e 's,.*\.\([^.]*\):$,\1,'
 }


### PR DESCRIPTION
https://github.com/os-autoinst/scripts/pull/305 introduced a problem
causing "osc cat" to always retry as it fails within a piped call.
Apparently there is a SIGPIPE due to the head in the command:

```
osc cat … | grep '…' | head -n1
```

which can be seen with `echo "${PIPESTATUS[@]}"`. The
`grep … | head -n1`
can be simplified to `grep -m1` which gets rid of the sigpipe of
grep but keeps the failure of osc cat. But we can use process
substitution to rescue :)

This also allows us to enforce the proper handling of pipefails
everywhere else.

Related progress issue: https://progress.opensuse.org/issues/157018