### PR TITLE
Prevent leaked background processes of "osc cat"

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -89,7 +89,12 @@ last_revision() {
         file=_service:$service:$file
     fi
     local line
-    line=$(grep -m1 'Update to version' <($osc cat "$project/$package/$file"))
+    # prevent SIGPIPE triggering osc cat to fail with the command group piping
+    # exceeding output to /dev/null
+    line=$($osc cat "$project/$package/$file" | {
+        grep -m1 'Update to version'
+        cat > /dev/null
+    })
     # shellcheck disable=SC2001
     echo "$line" | sed -e 's,.*\.\([^.]*\):$,\1,'
 }


### PR DESCRIPTION
My previous change from using a pipe to process substitution helped to
not accumulate unnecessary waiting time due to retries of "osc cat" but
it caused the "osc cat" to still continue in the background leading to
intermingled output. So instead now this commit goes back to using a
pipe operator but combined with "cat >/dev/null" to swallow all
superfluous output to make "osc cat" happy and not cause retriggers.

Tested locally with

```
project="devel:openQA"; package=openQA; file=openQA.changes; osc="retry -s0 -e -- osc"; $osc cat "$project/$package/$file" | { grep -m1 'Update to version'; cat >/dev/null; }
```

Related progress issue: https://progress.opensuse.org/issues/157018