### PR TITLE
os-autoinst-obs-auto-submit: Fix case of no previous pending request

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -72,7 +72,7 @@ update_package() {
     $osc ci -m "Offline generation of ${version}" $ci_args
     wait_for_package_build
     cmd="$osc sr"
-    req=$(factory_request "$package")
+    req=$(factory_request "$package" || :)
     # TODO: check if it's a different revision than HEAD
     if test -n "$req"; then
         cmd="$cmd -s $req"


### PR DESCRIPTION
This is a follow-up to the recent change to abort the script on
unexpected pipefails. In case there is no pending submit request we must
ignore the exit status as the check for the value validity is done
afterwards anyway.

Related progress issue: https://progress.opensuse.org/issues/157018