### PR TITLE
Add dependencies for racktables scripts

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -36,6 +36,8 @@ main_requires:
   retry:
   html-xml-utils:
   xmlstarlet:
+  python3-requests:
+  python3-beautifulsoup4:
 test_requires:
   perl(Test::Output):
   perl(Test::Warnings):

--- a/dist/rpm/os-autoinst-scripts-deps.spec
+++ b/dist/rpm/os-autoinst-scripts-deps.spec
@@ -25,7 +25,7 @@ Group:          Development/Tools/Other
 BuildArch:      noarch
 Url:            https://github.com/os-autoinst/scripts
 # The following line is generated from dependencies.yaml
-%define main_requires bash coreutils curl grep html-xml-utils jq openQA-client openssh-clients osc perl >= 5.010 perl(Data::Dumper) perl(FindBin) perl(Getopt::Long) perl(Mojo::File) perl(Text::Markdown) perl(YAML::PP) retry sed sudo xmlstarlet yq
+%define main_requires bash coreutils curl grep html-xml-utils jq openQA-client openssh-clients osc perl >= 5.010 perl(Data::Dumper) perl(FindBin) perl(Getopt::Long) perl(Mojo::File) perl(Text::Markdown) perl(YAML::PP) python3-beautifulsoup4 python3-requests retry sed sudo xmlstarlet yq
 # The following line is generated from dependencies.yaml
 %define test_requires perl(Test::MockModule) perl(Test::Most) perl(Test::Output) perl(Test::Warnings)
 # The following line is generated from dependencies.yaml


### PR DESCRIPTION
This adds necessary packages required to run the racktables script from within our scripts-ci.