### PR TITLE
Allow cloning jobs from GitHub comment bodies

### DIFF
--- a/openqa-clone-and-monitor-job-from-pr
+++ b/openqa-clone-and-monitor-job-from-pr
@@ -53,22 +53,41 @@ package openqa_clone_and_monitor_job_from_pr;    # for testing
 
 use Mojo::Base -strict, -signatures;
 use Mojo::JSON qw(decode_json);
+use Mojo::JSON::Pointer;
+use Mojo::UserAgent;
 use Text::ParseWords qw(shellwords);
 
 my $expected_url = $ENV{OPENQA_HOST} // 'https://openqa.opensuse.org';
 my $group_id = $ENV{OPENQA_SCHEDULE_GROUP_ID} // 118;
-my $pr_body = $ENV{GH_PR_BODY} // '';
-my $gh_repo = $ENV{GH_REPO} or die 'GH_REPO must be set';
-my $gh_ref = $ENV{GH_REF} or die 'GH_REF must be set';
+my $pr_body = $ENV{GH_PR_BODY} // $ENV{GH_COMMENT_BODY} // '';
+my $gh_repo = $ENV{GH_REPO};
+my $gh_pr_url = $ENV{GH_PR_URL};
+my $gh_statuses_url = $ENV{GH_STATUSES_URL};
+my $gh_ref = $ENV{GH_REF};
 my $gh_srv = $ENV{GITHUB_SERVER_URL} or die 'GITHUB_SERVER_URL must be set';
+my $gh_api = $ENV{GITHUB_API_URL};
+my $gh_token = $ENV{GITHUB_TOKEN} // '';
 my $api_key = $ENV{OPENQA_API_KEY} or die 'OPENQA_API_KEY must be set';
 my $api_secret = $ENV{OPENQA_API_SECRET} or die 'OPENQA_API_SECRET must be set';
+my $user = $ENV{GH_COMMENT_AUTHOR} // '';
+my $restrict_orga = $ENV{RESTRICT_ORGA} // '';
+my $restrict_team = $ENV{RESTRICT_TEAM} // '';
 my @secrets = ('--apikey', $api_key, '--apisecret', $api_secret);
-my @vars = ("BUILD=$gh_repo.git#$gh_ref", "_GROUP_ID=$group_id", "CASEDIR=$gh_srv/$gh_repo.git#$gh_ref");
+my $gh_clone_url = $gh_repo ? "$gh_repo.git" : undef;
+my %gh_headers = (Accept => 'application/vnd.github+json', Authorization => "Bearer $gh_token");
+die 'GH_REF or GH_PR_URL must be set' unless $gh_ref || $gh_pr_url;
+die 'GH_REPO or GH_PR_URL must be set' unless $gh_repo || $gh_pr_url;
+die 'GITHUB_TOKEN and GITHUB_API_URL must be set when RESTRICT_ variables are set'
+    if (!$gh_token || !$gh_api) && ($restrict_orga || $restrict_team);
 
 # use `shellwords` to split arguments like a shell would (so one can use quotes to avoid splitting)
 # use `grep` to filter out arguments starting with `-`/`--` to avoid users passing unexpected flags/arguments
 sub _split_and_filter_arguments ($args) { grep { $_ && $_ !~ qr/^\s*-/ } shellwords $args }
+
+sub _done ($log = undef) {
+    print $log if defined $log;
+    exit 0;
+}
 
 sub _parse_clone_args ($text) {
     my @clone_calls;
@@ -78,7 +97,7 @@ sub _parse_clone_args ($text) {
     return \@clone_calls if @clone_calls;
     print 'No test cloned; the PR description does not contain ';    # uncoverable statement
     print "a command like 'openqa: Clone $expected_url/tests/<JOB_ID>'.\n";    # uncoverable statement
-    exit 0;
+    _done;
 }
 
 sub _handle_cmd_error ($command, @args) {
@@ -97,15 +116,44 @@ sub _run_cmd_capturing_output ($command, @args) {
     return $output;
 }
 
-sub _clone_job ($args) {
-    my @args = (@secrets, qw(--json-output --skip-chained-deps --within-instance), @$args, @vars);
+sub _clone_job ($args, $vars) {
+    my @args = (@secrets, qw(--json-output --skip-chained-deps --within-instance), @$args, @$vars);
     my $json = _run_cmd_capturing_output 'openqa-clone-job', @args;
     return values %{decode_json($json)};
 }
 
+sub _restrict_to_team_members () {
+    return undef unless $restrict_orga || $restrict_team;
+    my $url = "$gh_api/orgs/$restrict_orga/teams/$restrict_team/memberships/$user";
+    my $ua = Mojo::UserAgent->new;
+    my $res = $ua->get($url, \%gh_headers)->res;
+    my $body = $res->body // '';
+    my $state = eval { $res->json('/state') } // '';
+    _done "No test cloned; the user '$user' is not member of the team '$restrict_team' within '$restrict_orga'.\n$body"
+        if $state ne 'active';
+}
+
+sub _determine_gh_ref_and_clone_url () {
+    return undef if $gh_ref;
+    my $ua = Mojo::UserAgent->new;
+    my $res = $ua->get($gh_pr_url, \%gh_headers)->res;
+    my $body = $res->body // '';
+    my $json = Mojo::JSON::Pointer->new(eval { $res->json } // {});
+    $gh_ref = $json->get('/head/sha');
+    $gh_clone_url = $json->get('/head/repo/clone_url');
+    $gh_statuses_url = $json->get('/head/repo/statuses_url');
+    _done "No test cloned; unable to determine ref and clone URL of PR via '$gh_pr_url'.\n$body"
+        unless defined $gh_ref && defined $gh_clone_url;
+    $gh_statuses_url =~ s/\{sha\}/$gh_ref/ if $gh_statuses_url;
+}
+
 sub run () {
+    _restrict_to_team_members;
+    _determine_gh_ref_and_clone_url;
+
     my $clone_args = _parse_clone_args($pr_body);
-    my @job_ids = map { _clone_job $_ } @$clone_args;
+    my @vars = ("BUILD=$gh_clone_url#$gh_ref", "_GROUP_ID=$group_id", "CASEDIR=$gh_srv/$gh_clone_url#$gh_ref");
+    my @job_ids = map { _clone_job $_, \@vars } @$clone_args;
     my @quoted_url_list = join(', ', map { "'$_->[0]'" } @$clone_args);
     my @job_url_list = map { "- $expected_url/tests/$_\n" } @job_ids;
     print "Cloned @quoted_url_list into:\n @job_url_list";

--- a/openqa-clone-and-monitor-job-from-pr
+++ b/openqa-clone-and-monitor-job-from-pr
@@ -70,11 +70,13 @@ my $gh_token = $ENV{GITHUB_TOKEN} // '';
 my $api_key = $ENV{OPENQA_API_KEY} or die 'OPENQA_API_KEY must be set';
 my $api_secret = $ENV{OPENQA_API_SECRET} or die 'OPENQA_API_SECRET must be set';
 my $user = $ENV{GH_COMMENT_AUTHOR} // '';
+my $comment_url = $ENV{GH_COMMENT_URL} // '';
 my $restrict_orga = $ENV{RESTRICT_ORGA} // '';
 my $restrict_team = $ENV{RESTRICT_TEAM} // '';
 my @secrets = ('--apikey', $api_key, '--apisecret', $api_secret);
 my $gh_clone_url = $gh_repo ? "$gh_repo.git" : undef;
 my %gh_headers = (Accept => 'application/vnd.github+json', Authorization => "Bearer $gh_token");
+my $ua = Mojo::UserAgent->new;
 die 'GH_REF or GH_PR_URL must be set' unless $gh_ref || $gh_pr_url;
 die 'GH_REPO or GH_PR_URL must be set' unless $gh_repo || $gh_pr_url;
 die 'GITHUB_TOKEN and GITHUB_API_URL must be set when RESTRICT_ variables are set'
@@ -84,9 +86,9 @@ die 'GITHUB_TOKEN and GITHUB_API_URL must be set when RESTRICT_ variables are se
 # use `grep` to filter out arguments starting with `-`/`--` to avoid users passing unexpected flags/arguments
 sub _split_and_filter_arguments ($args) { grep { $_ && $_ !~ qr/^\s*-/ } shellwords $args }
 
-sub _done ($log = undef) {
+sub _done ($log = undef, $status = 0) {
     print $log if defined $log;
-    exit 0;
+    exit $status;
 }
 
 sub _parse_clone_args ($text) {
@@ -125,7 +127,6 @@ sub _clone_job ($args, $vars) {
 sub _restrict_to_team_members () {
     return undef unless $restrict_orga || $restrict_team;
     my $url = "$gh_api/orgs/$restrict_orga/teams/$restrict_team/memberships/$user";
-    my $ua = Mojo::UserAgent->new;
     my $res = $ua->get($url, \%gh_headers)->res;
     my $body = $res->body // '';
     my $state = eval { $res->json('/state') } // '';
@@ -135,7 +136,6 @@ sub _restrict_to_team_members () {
 
 sub _determine_gh_ref_and_clone_url () {
     return undef if $gh_ref;
-    my $ua = Mojo::UserAgent->new;
     my $res = $ua->get($gh_pr_url, \%gh_headers)->res;
     my $body = $res->body // '';
     my $json = Mojo::JSON::Pointer->new(eval { $res->json } // {});
@@ -145,6 +145,19 @@ sub _determine_gh_ref_and_clone_url () {
     _done "No test cloned; unable to determine ref and clone URL of PR via '$gh_pr_url'.\n$body"
         unless defined $gh_ref && defined $gh_clone_url;
     $gh_statuses_url =~ s/\{sha\}/$gh_ref/ if $gh_statuses_url;
+}
+
+sub _update_status ($status) {
+    my $repo = $ENV{GITHUB_REPOSITORY};
+    my $run_id = $ENV{GITHUB_RUN_ID};
+    return undef unless $gh_statuses_url && $repo && $run_id;
+    my $target_url = "$gh_srv/$repo/actions/runs/$run_id";
+    my $ctx = "Run openQA test mentioned in comment '$comment_url' by '$user'";
+    my $description = $status eq 'pending' ? 'Monitoring cloned job(s)' : 'Job(s) have finished';
+    my %payload = (state => $status, target_url => $target_url, context => $ctx, description => $description);
+    my $res = $ua->post($gh_statuses_url, \%gh_headers, json => \%payload)->res;
+    my $body = $res->body;
+    print "Unable to update status on GitHub via '$gh_statuses_url'.\n$body\n" unless $res->is_success;
 }
 
 sub run () {
@@ -157,7 +170,11 @@ sub run () {
     my @quoted_url_list = join(', ', map { "'$_->[0]'" } @$clone_args);
     my @job_url_list = map { "- $expected_url/tests/$_\n" } @job_ids;
     print "Cloned @quoted_url_list into:\n @job_url_list";
-    _run_cmd 'openqa-cli', 'monitor', '--host', $expected_url, @secrets, @job_ids;
+    _update_status 'pending';
+    eval { _run_cmd 'openqa-cli', 'monitor', '--host', $expected_url, @secrets, @job_ids };
+    my $error = $@;
+    _update_status $error ? 'failure' : 'success';
+    _done $error, $error ? 1 : 0;
 }
 
 run unless caller;

--- a/test/05-clone-and-monitor.t
+++ b/test/05-clone-and-monitor.t
@@ -31,6 +31,9 @@ $mock->redefine(_run_cmd_capturing_output => sub ($command, @args) {
     push @invoked_commands, [$command, @args];
     $mock->original('_run_cmd_capturing_output')->('echo', shift @clone_responses);
 });
+$mock->redefine(_done => sub ($log = undef, $status = 0) {
+    is $status, 0, 'successful exit';
+});
 
 combined_like { openqa_clone_and_monitor_job_from_pr::run() }
 qr(Cloned.*4240.*4239.*into:.*monitor --host http://127\.0\.0\.1:9526 --apikey key --apisecret secret 4246 4245)s,

--- a/test/06-clone-and-monitor-from-comment.t
+++ b/test/06-clone-and-monitor-from-comment.t
@@ -1,0 +1,61 @@
+#!/usr/bin/env perl
+
+use Mojo::Base -strict, -signatures;
+
+use FindBin;
+use Test::More;
+use Test::Output qw(combined_like);
+use Test::Exception;
+use Test::MockModule;
+use Mojo::Transaction;
+use Mojo::Message::Response;
+
+$ENV{GH_PR_URL} = 'api.gh-srv.url/pr/42';
+$ENV{OPENQA_HOST} = 'http://127.0.0.1:9526';
+$ENV{OPENQA_API_KEY} = 'key';
+$ENV{OPENQA_API_SECRET} = 'secret';
+$ENV{GITHUB_SERVER_URL} = 'gh-srv-url';
+$ENV{GITHUB_API_URL} = 'api.gh-srv.url';
+$ENV{GITHUB_TOKEN} = 'gh-token';
+$ENV{GH_COMMENT_AUTHOR} = 'test-user';
+$ENV{GH_COMMENT_BODY} = 'openqa: Clone http://127.0.0.1:9526/tests/4239 FROM="comment"';
+$ENV{RESTRICT_ORGA} = 'os-autoinst';
+$ENV{RESTRICT_TEAM} = 'tests-maintainer';
+
+require "$FindBin::RealBin/../openqa-clone-and-monitor-job-from-pr";
+
+my $mock = Test::MockModule->new('openqa_clone_and_monitor_job_from_pr', no_auto => 1);
+$mock->redefine(_done => sub ($log = undef) {
+    print $log if $log;
+    die "done\n";
+});
+
+subtest 'test not cloned as user is not member of the required team' => sub {
+    combined_like { throws_ok { openqa_clone_and_monitor_job_from_pr::run() } qr/done/, 'early return' }
+    qr(No test cloned; the user 'test-user' is not member of the team 'tests-maintainer' within 'os-autoinst')s,
+    'info logged';
+};
+
+subtest 'test cloned if user member of required team' => sub {
+    my $ua_mock = Test::MockModule->new('Mojo::UserAgent', no_auto => 1);
+    my %expected_gh_headers = (Accept => 'application/vnd.github+json', Authorization => 'Bearer gh-token');
+    my @expected_gh_urls = (
+        'api.gh-srv.url/orgs/os-autoinst/teams/tests-maintainer/memberships/test-user',
+        'api.gh-srv.url/pr/42',
+    );
+    my @fake_responses = (
+        '{"state":"active"}',
+        '{"head":{"repo":{"clone_url":"foo"},"sha":"foo"}}',
+    );
+    $ua_mock->redefine(get => sub ($ua, $url, $gh_headers) {
+        is $url, shift @expected_gh_urls, 'GitHub API queried';
+        is_deeply $gh_headers, \%expected_gh_headers, 'headers for querying GitHub API specified' or diag explain $gh_headers;
+        return Mojo::Transaction->new(res => Mojo::Message::Response->new->body(shift @fake_responses));
+    });
+
+    combined_like {
+        throws_ok { openqa_clone_and_monitor_job_from_pr::run() } qr/exited with non-zero exist status/, 'error logged'
+    } qr/failed to get job '4239'/, 'attempted to cloned job 4239';
+};
+
+done_testing;

--- a/test/06-clone-and-monitor-from-comment.t
+++ b/test/06-clone-and-monitor-from-comment.t
@@ -17,7 +17,10 @@ $ENV{OPENQA_API_SECRET} = 'secret';
 $ENV{GITHUB_SERVER_URL} = 'gh-srv-url';
 $ENV{GITHUB_API_URL} = 'api.gh-srv.url';
 $ENV{GITHUB_TOKEN} = 'gh-token';
+$ENV{GITHUB_REPOSITORY} = 'os-autoinst/openSUSE';
+$ENV{GITHUB_RUN_ID} = '1234';
 $ENV{GH_COMMENT_AUTHOR} = 'test-user';
+$ENV{GH_COMMENT_URL} = 'link-to-comment';
 $ENV{GH_COMMENT_BODY} = 'openqa: Clone http://127.0.0.1:9526/tests/4239 FROM="comment"';
 $ENV{RESTRICT_ORGA} = 'os-autoinst';
 $ENV{RESTRICT_TEAM} = 'tests-maintainer';
@@ -25,37 +28,62 @@ $ENV{RESTRICT_TEAM} = 'tests-maintainer';
 require "$FindBin::RealBin/../openqa-clone-and-monitor-job-from-pr";
 
 my $mock = Test::MockModule->new('openqa_clone_and_monitor_job_from_pr', no_auto => 1);
-$mock->redefine(_done => sub ($log = undef) {
-    print $log if $log;
-    die "done\n";
+my @cloned_jobs;
+$mock->redefine(_clone_job => sub ($args, $vars) {
+    push @cloned_jobs, [$args, $vars];
+});
+my @invoked_commands;
+$mock->redefine(_run_cmd => sub ($command, @args) {
+    push @invoked_commands, [$command, @args];
+    die "pretend monotoring failed";
 });
 
 subtest 'test not cloned as user is not member of the required team' => sub {
+    $mock->redefine(_done => sub ($log = undef, $exit = 0) { print $log if $log; die "done\n" });
     combined_like { throws_ok { openqa_clone_and_monitor_job_from_pr::run() } qr/done/, 'early return' }
     qr(No test cloned; the user 'test-user' is not member of the team 'tests-maintainer' within 'os-autoinst')s,
     'info logged';
 };
 
-subtest 'test cloned if user member of required team' => sub {
+subtest 'test cloned if user member of required team, status updated on GitHub' => sub {
     my $ua_mock = Test::MockModule->new('Mojo::UserAgent', no_auto => 1);
     my %expected_gh_headers = (Accept => 'application/vnd.github+json', Authorization => 'Bearer gh-token');
     my @expected_gh_urls = (
         'api.gh-srv.url/orgs/os-autoinst/teams/tests-maintainer/memberships/test-user',
         'api.gh-srv.url/pr/42',
     );
+    my @expected_status_params = (
+        target_url => 'gh-srv-url/os-autoinst/openSUSE/actions/runs/1234',
+        context => "Run openQA test mentioned in comment 'link-to-comment' by 'test-user'",
+    );
+    my @expected_gh_post_urls = map { 'api.gh-srv.url/repos/os-autoinst/openSUSE/statuses/bar' } 1..2;
+    my @expected_gh_posts = (
+        {@expected_status_params, state => 'pending', description => 'Monitoring cloned job(s)'},
+        {@expected_status_params, state => 'failure', description => 'Job(s) have finished'},
+    );
     my @fake_responses = (
         '{"state":"active"}',
-        '{"head":{"repo":{"clone_url":"foo"},"sha":"foo"}}',
+        '{"head":{"repo":{"clone_url":"foo","statuses_url":"api.gh-srv.url/repos/os-autoinst/openSUSE/statuses/{sha}"},"sha":"bar"}}',
     );
     $ua_mock->redefine(get => sub ($ua, $url, $gh_headers) {
         is $url, shift @expected_gh_urls, 'GitHub API queried';
         is_deeply $gh_headers, \%expected_gh_headers, 'headers for querying GitHub API specified' or diag explain $gh_headers;
         return Mojo::Transaction->new(res => Mojo::Message::Response->new->body(shift @fake_responses));
     });
+    $ua_mock->redefine(post => sub ($ua, $url, $gh_headers, $data_type, $data) {
+        is $url, shift @expected_gh_post_urls, 'status posted via GitHub API';
+        is_deeply $data, shift @expected_gh_posts, 'expected status data posted' or diag explain $data;
+        is_deeply $gh_headers, \%expected_gh_headers, 'headers for posting via GitHub API specified' or diag explain $gh_headers;
+        return Mojo::Transaction->new(res => Mojo::Message::Response->new);
+    });
+    $mock->redefine(_done => sub ($log = undef, $exit = 0) {
+        print $log if $log;
+        is $exit, 1, 'exited with non-zero exit status';
+    });
 
-    combined_like {
-        throws_ok { openqa_clone_and_monitor_job_from_pr::run() } qr/exited with non-zero exist status/, 'error logged'
-    } qr/failed to get job '4239'/, 'attempted to cloned job 4239';
+    combined_like { openqa_clone_and_monitor_job_from_pr::run() } qr/pretend monotoring failed/, 'attempted to cloned and monitor job';
+    is scalar @expected_gh_urls, 0, 'all expected get requests made' or diag explain \@expected_gh_urls;
+    is scalar @expected_gh_post_urls, 0, 'all expected post requests made' or diag explain \@expected_gh_post_urls;
 };
 
 done_testing;


### PR DESCRIPTION
* Allow to restrict allowed users to a team of a GitHub organization to
  avoid security concerns
* Allow querying the PR ref and clone URL via the GitHub API because
  those are not part of the event data of comment events
* Update status on GitHub when cloning a job via a PR comment
* See https://progress.opensuse.org/issues/130940