### PR TITLE
Don't create empty changelog entries

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -69,6 +69,9 @@ update_package() {
     if [[ "$package" == "os-autoinst-distri-opensuse-deps" || "$package" =~ "container" ]]; then
         ci_args="--noservice"
     fi
+    # We would get an empty changelog when there are no changes to files contained
+    # in this package/container. So add some text.
+    sed -i -e 's/^  \* $/  * Update to latest openQA version/' ./*.changes
     $osc ci -m "Offline generation of ${version}" $ci_args
     wait_for_package_build
     cmd="$osc sr"


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/160418

Adding some info text as changelog entry when updating and no files in the package/container are directly affected.
We still need to update the package/container, as it needs to be rebuilt with the latest dependencies and the correct version set.