### PR TITLE
Print warning messages to stderr

### DIFF
--- a/_common
+++ b/_common
@@ -76,7 +76,7 @@ exp_retry() {
         return 1
     fi
     wait_sec=$((2 ** exponent))
-    echo "Waiting ${wait_sec}s until retry #${stop_exponent}"
+    warn "Waiting ${wait_sec}s until retry #${stop_exponent}"
     sleep "$wait_sec"
 }
 


### PR DESCRIPTION
So that jq doesn't receive it as its input

Issue: https://progress.opensuse.org/issues/163769