### PR TITLE
Limit max error length for curl msgs by cutting msg in the middle

### DIFF
--- a/_common
+++ b/_common
@@ -86,8 +86,7 @@ shorten_string() {
     local max_str_len=${max_str_len:-"120"}
     local max_str_len_half=$((max_str_len / 2))
     if [[ ${#sstring} -gt $max_str_len ]]; then
-        sstring_end=$(echo "$sstring" | cut -c "$((${#sstring} - max_str_len_half))-")
-        sstring="$(echo "$sstring" | cut -c "-${max_str_len_half}")…${sstring_end}"
+        sstring=${sstring:0:$max_str_len_half}…${sstring: -$max_str_len_half}
     fi
     echo "$sstring"
 }

--- a/_common
+++ b/_common
@@ -80,6 +80,18 @@ exp_retry() {
     sleep "$wait_sec"
 }
 
+# shorten a string in the middle, if it is too large
+shorten_string() {
+    local sstring="$1"
+    local max_str_len=${max_str_len:-"120"}
+    local max_str_len_half=$((max_str_len / 2))
+    if [[ ${#sstring} -gt $max_str_len ]]; then
+        sstring_end=$(echo "$sstring" | cut -c "$((${#sstring} - max_str_len_half))-")
+        sstring="$(echo "$sstring" | cut -c "-${max_str_len_half}")…${sstring_end}"
+    fi
+    echo "$sstring"
+}
+
 # Wrapper around curl that reports the HTTP status if it is not 200, and the
 # calling command and line
 # exp_retries: number of total tries - 0/unset for no retries. Sleep before each retry will double.
@@ -94,6 +106,7 @@ runcurl() {
         rc=$?
         set -e
         if [[ "$rc" != 0 ]]; then
+            response=$(shorten_string "$response")
             warn "curl ($(caller)): Error fetching ($*): $response"
             # shellcheck disable=SC2015
             exp_retry "$exp_retries" "$retry_exponent" && continue || break


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/164153

Output when having `_common` modified to always create an error:
```
$ bash -c ". _common;  runcurl f3l.de"
curl (1 NULL): Error fetching (f3l.de): {"id":135839,"project":{"id":36,"name":"openQA Tests"},"trac…86_64-desktcurl: (18) Recv failure: Connection reset by peer"
0 (re)tries exceeded
```