### PR TITLE
Disable tracing to limit the output

### DIFF
--- a/openqa-schedule-mm-ping-test
+++ b/openqa-schedule-mm-ping-test
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -eu -o pipefail
 
 . "$(dirname "$0")"/_common
 


### PR DESCRIPTION
Calling the wrappers with #329 could be quite noisy with all the debug information on as the whole API outputs gets reprinted in the terminal. Disable the debug info so the logs are visible in the Gitlab UI.

Reference: https://progress.opensuse.org/issues/163622