### PR TITLE
Allow labeling checks even when autoinst-log.txt does not exist

### DIFF
--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -33,10 +33,9 @@ trap 'test "$KEEP_REPORT_FILE" == "1" || rm "$out"' EXIT
 
 echoerr() { echo "$@" >&2; }
 
-handle_unreachable_or_no_log() {
-    local id=$1
-    local testurl=$2
-    local out=$3
+handle_unreachable() {
+    local testurl=$1
+    local out=$2
 
     if ! curl "${curl_args[@]}" -s --head "$testurl" -o /dev/null; then
         # the page might be gone, try the scheme+host we configured (might be different one though)
@@ -58,13 +57,7 @@ handle_unreachable_or_no_log() {
         curl "${curl_args[@]}" "$testurl"
         exit 2
     fi
-    # if the page is there but not even an autoinst-log.txt exists
-    # then the job might be too old and logs are already deleted.
-    # Checking timestamp
-    if [[ $(date -uIs -d '-14days') > $(grep timeago "$out" | hxselect -s '\n' -c '.timeago::attr(title)') ]]; then
-        echoerr "'$testurl' does not have autoinst-log.txt but is rather old, ignoring"
-        return
-    fi
+
     if hxnormalize -x "$out" | hxselect -s '\n' -c '.links_a .resborder' | grep -qPzo '(?s)Gru job failed.*connection error.*Inactivity timeout'; then
         "${client_call[@]}" -X POST jobs/"$id"/comments text='poo#62456 test incompletes after failing in GRU download task on "Inactivity timeout" with no logs'
         "${client_call[@]}" -X POST jobs/"$id"/restart
@@ -143,7 +136,17 @@ investigate_issue() {
     echo "$reason" >> "$out"
     if [[ "$curl_output" != "200" ]] && [[ "$curl_output" != "301" ]]; then
         # if we can not even access the page it is something more critical
-        handle_unreachable_or_no_log "$id" "$testurl" "$out"
+        handle_unreachable "$testurl" "$out"
+        # Assume autoinst-log.txt still not found but process job anyway due to reason var
+        if [[ -n $reason ]] && [[ $curl_output = "404" ]] && [[ $reason != null ]]; then
+            label_on_issues_from_issue_tracker "$id"
+        # Checking timestamp
+        elif [[ $(date -uIs -d '-14days') > $(grep timeago "$out" | hxselect -s '\n' -c '.timeago::attr(title)') ]]; then
+            # if the page is there but not even an autoinst-log.txt exists
+            # then the job might be too old and logs are already deleted.
+            echoerr "'$testurl' does not have autoinst-log.txt but is rather old, ignoring"
+            return
+        fi
     elif label_on_issues_from_issue_tracker "$id"; then
         return
 


### PR DESCRIPTION
Explicit call label_on_issues_from_issue_tracker for a job assuming that
autoinst-log.txt is already lost. Action is taken  a lit premature before                                                                                                                                                                                                      
further checks but ensures the flow doesnt change. 
 https://progress.opensuse.org/issues/164296