### PR TITLE
Handle errors from the label_on_issues_from_issue_tracker

### DIFF
--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -6,7 +6,7 @@
 set -o pipefail -o errtrace
 
 # shellcheck source=/dev/null
-. "$(dirname "$0")"/_common
+. "$(dirname "${BASH_SOURCE[0]}")"/_common
 
 host="${host:-"openqa.opensuse.org"}"
 scheme="${scheme:-"https"}"
@@ -41,14 +41,14 @@ handle_unreachable() {
         # the page might be gone, try the scheme+host we configured (might be different one though)
         if ! grep -q "$host_url" <<< "$testurl"; then
             echoerr "'$testurl' is not reachable and 'host_url' parameter does not match '$testurl', can not check further, continuing with next"
-            return
+            return 1
         fi
         if ! curl "${curl_args[@]}" -s --head "$host_url"; then
             echoerr "'$host_url' is not reachable, bailing out"
             curl "${curl_args[@]}" --head "$host_url"
         fi
         echoerr "'$testurl' is not reachable, assuming deleted, continuing with next"
-        return
+        return 1
     fi
     # resorting to downloading the job details page instead of the
     # log, overwrites $out
@@ -61,7 +61,7 @@ handle_unreachable() {
     if hxnormalize -x "$out" | hxselect -s '\n' -c '.links_a .resborder' | grep -qPzo '(?s)Gru job failed.*connection error.*Inactivity timeout'; then
         "${client_call[@]}" -X POST jobs/"$id"/comments text='poo#62456 test incompletes after failing in GRU download task on "Inactivity timeout" with no logs'
         "${client_call[@]}" -X POST jobs/"$id"/restart
-        return
+        return 1
     fi
 }
 
@@ -136,19 +136,23 @@ investigate_issue() {
     echo "$reason" >> "$out"
     if [[ "$curl_output" != "200" ]] && [[ "$curl_output" != "301" ]]; then
         # if we can not even access the page it is something more critical
-        handle_unreachable "$testurl" "$out"
-        # Assume autoinst-log.txt still not found but process job anyway due to reason var
-        if [[ -n $reason ]] && [[ $curl_output = "404" ]] && [[ $reason != null ]]; then
-            label_on_issues_from_issue_tracker "$id"
+        handle_unreachable "$testurl" "$out" || return
+        [[ $curl_output != 404 ]] && return
         # Checking timestamp
-        elif [[ $(date -uIs -d '-14days') > $(grep timeago "$out" | hxselect -s '\n' -c '.timeago::attr(title)') ]]; then
+        if [[ $(date -uIs -d '-14days') > $(grep timeago "$out" | hxselect -s '\n' -c '.timeago::attr(title)') ]]; then
             # if the page is there but not even an autoinst-log.txt exists
             # then the job might be too old and logs are already deleted.
-            echoerr "'$testurl' does not have autoinst-log.txt but is rather old, ignoring"
+            echoerr "'$testurl' job#${id} without autoinst-log.txt older than 14 days. Do not label"
             return
         fi
-    elif label_on_issues_from_issue_tracker "$id"; then
-        return
+        # not unreachable, no log, no reason, not too old
+        if [[ -z $reason ]] || [[ $reason = null ]]; then
+            echoerr "'$testurl' does not have autoinst-log.txt or reason, cannot label"
+            return
+        fi
+    fi
+
+    label_on_issues_from_issue_tracker "$id" && return
 
     ## Issues without tickets, e.g. potential singular, manual debug jobs,
     # wrong user settings, etc.
@@ -156,11 +160,9 @@ investigate_issue() {
     # $client_prefix curl -s -H "Content-Type: application/json" -X POST -H "X-Redmine-API-Key: $(sed -n 's/redmine-token = //p' ~/.query_redminerc)" --data '{"issue": {"project_id": 36, "category_id": 152, priority_id: 5, "subject": "test from command line"}}' https://progress.opensuse.org/issues.json
     # but we should check if the issue already exists, e.g. same
     # subject line
-    elif label_on_issues_without_tickets "$id"; then
-        return
-    else
-        handle_unreviewed "$testurl" "$out" "$reason" "$group_id" "$email_unreviewed" "$from_email" "$notification_address" "$job_data" "$dry_run"
-    fi
+    label_on_issues_without_tickets "$id" && return
+
+    handle_unreviewed "$testurl" "$out" "$reason" "$group_id" "$email_unreviewed" "$from_email" "$notification_address" "$job_data" "$dry_run"
 }
 
 label_issue() {

--- a/test/07-openqa-label-known-issues.t
+++ b/test/07-openqa-label-known-issues.t
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+source test/init
+bpan:source bashplus +err +fs +sym
+
+plan tests 15
+
+source openqa-label-known-issues
+client_args=(api --host "$host_url")
+
+export KEEP_REPORT_FILE=1
+
+client_output=''
+mock-client-output() {
+    client_output+="client_call $@"$'\n'
+    echo "$client_output\n"
+}
+
+client_call=(mock-client-output "${client_call[@]}")
+autoinst_log=$dir/data/04-autoinst.txt
+
+try-client-output() {
+    client_output=''
+    try "$*"' && echo "$client_output"'
+}
+openqa-cli() {
+    local id=$(basename "$4")
+    cat "$dir/data/$id.json"
+}
+curl() {
+    if [[ "$7" =~ /(404|414|101|102)/file/autoinst-log.txt ]]; then
+        echo -n "404"
+    else
+        echo -n "200"
+    fi
+}
+comment_on_job() {
+    local id=$1 comment=$2 force_result=${3:-''}
+    echo "$comment"
+}
+out=''
+hxnormalize() {
+    cat "$2"
+}
+hxselect() {
+    cat -
+}
+
+try investigate_issue
+is "$rc" 1 'id required'
+# error in tap output is from here
+
+issues="159876
+[security] test fails in krb auto_review:\"com:/tmp/nfsdir /tmp/mntdir' failed\":force_result:softfailed
+openqa-force-result
+137420
+[qe-sap] test fails in network_peering auto_review:\"az network vnet peering create.+failed\"
+action
+73375
+Job incompletes with reason auto_review:\"(?m)api failure$\" (and no further details)
+action"
+
+# test data with reason but 404 in curl respond
+id=404
+testurl="https://openqa.opensuse.org/tests/${id}"
+try-client-output investigate_issue $id
+is "$rc" 0 'investigate_issue with missing autoinst-log and with reason in job_data'
+has "$got" "without autoinst-log.txt older than 14 days. Do not label" "exits succefully when is old job without autoinst-log.txt"
+
+# all assets are missing
+id=101
+testurl="https://openqa.opensuse.org/tests/${id}"
+# `cur_date` is used on the following 4 test cases
+cur_date=$(date +%F)
+sed -i "s/yyyy-mm-dd/${cur_date}/" "$dir/data/${id}.json"
++fs:mktemp
+tmplog=$temp
+echo -n "Result: <b>incomplete</b>, finished <abbr class=\"timeago\" title=\"${cur_date}T08:06:42Z\"</abbr>>" > $tmplog
+out=$tmplog
+try-client-output investigate_issue $id
+is "$rc" 0 'investigate_issue with missing autoinst-log but with reason in job_data'
+has "$got" "does not have autoinst-log.txt or reason, cannot label" "investigation exits when no reason and autoinst-log"
+# Cleanup 404.json
+sed -i "s/${cur_date}/yyyy-mm-dd/" "$dir/data/${id}.json"
+
+# Unknown reason - not included in issues
+id=102
+testurl="https://openqa.opensuse.org/tests/${id}"
+echo -n "Result: <b>incomplete</b>, finished <abbr class=\"timeago\" title=\"${cur_date}T08:06:42Z\"</abbr>>" > $tmplog
+echo -n "\nthe reason is whatever" >> $tmplog
+out=$tmplog
+try-client-output investigate_issue $id
+is "$rc" 0 'investigate no old issue with missing autoinst-log and unknown reason in job_data'
+has "$got" "Unknown test issue, to be reviewed" "investigation still label Unknown reason"
+
+id=414
+testurl="https://openqa.opensuse.org/tests/${id}"
+try-client-output investigate_issue $id
+is "$rc" 0 'investigate_issue with missing old autoinst-log and without reason in job_data'
+has "$got" "does not have autoinst-log.txt or reason, cannot label" "investigation exits successfully when no reason and no autoinst-log"
+
+id=200
+testurl="https://openqa.opensuse.org/tests/${id}"
+cp $autoinst_log $tmplog
+out=$tmplog
+try-client-output investigate_issue $id
+is "$rc" 0 'investigate_issue with autoinst-log and without reason'
+has "$got" "test fails in network_peering" "investigation label job with matched autoinst-log context"
+
+# handle_unreview branch
+echo > "$tmplog"
+out=$tmplog
+try-client-output investigate_issue $id
+is "$rc" 0 'job with empty autoinst-log checks unknown issue'
+has "$got" "Unknown test issue, to be reviewed" "investigation still label Unknown issue"
+
+echo -n "[error] Failed to download" > $out
+try-client-output investigate_issue $id
+is "$rc" 0 'job label without tickets'
+has "$got" "label:download_error potentially out-of-space worker?" "investistigation label correctly job without ticket"

--- a/test/data/04-autoinst.txt
+++ b/test/data/04-autoinst.txt
@@ -1,0 +1,2 @@
+test 200 autoinst
+az network vnet peering create. something failed

--- a/test/data/101.json
+++ b/test/data/101.json
@@ -1,0 +1,23 @@
+{
+    "job": {
+	"id": 101,
+	"group_id": 326,
+	"parents": {
+            "Chained": [],
+            "Directly chained": [],
+            "Parallel": []
+	},
+	"result": "incomplete",
+	"settings": {
+            "ARCH": "x86_64",
+            "BUILD": "testing",
+            "DISTRI": "Tumbleweed",
+            "FLAVOR": "Online",
+            "WORKER_CLASS": "qemu_x86_64"
+	},
+	"state": "done",
+	"t_finished": "yyyy-mm-ddT16:53:05",
+	"t_started": "yyyy-mm-dd16:45:53",
+	"test": "footest_incomplete"
+    }
+}

--- a/test/data/102.json
+++ b/test/data/102.json
@@ -1,0 +1,24 @@
+{
+    "job": {
+	"id": 102,
+	"group_id": 326,
+	"parents": {
+            "Chained": [],
+            "Directly chained": [],
+            "Parallel": []
+	},
+	"result": "incomplete",
+	"reason": "cant find this",
+	"settings": {
+            "ARCH": "x86_64",
+            "BUILD": "testing",
+            "DISTRI": "Tumbleweed",
+            "FLAVOR": "Online",
+            "WORKER_CLASS": "qemu_x86_64"
+	},
+	"state": "done",
+	"t_finished": "yyyy-mm-ddT16:53:05",
+	"t_started": "yyyy-mm-ddT16:45:53",
+	"test": "footest_incomplete"
+    }
+}

--- a/test/data/200.json
+++ b/test/data/200.json
@@ -1,0 +1,23 @@
+{
+    "job": {
+	"id": 200,
+	"group_id": 326,
+	"parents": {
+            "Chained": [],
+            "Directly chained": [],
+            "Parallel": []
+	},
+	"result": "failed",
+	"settings": {
+            "ARCH": "x86_64",
+            "BUILD": "testing",
+            "DISTRI": "Tumbleweed",
+            "FLAVOR": "Online",
+            "WORKER_CLASS": "qemu_x86_64"
+	},
+	"state": "done",
+	"t_finished": "2024-08-19T16:53:05",
+	"t_started": "2024-08-19T16:45:53",
+	"test": "footest_failed"
+    }
+}

--- a/test/data/404.json
+++ b/test/data/404.json
@@ -1,0 +1,24 @@
+{
+    "job": {
+	"id": 404,
+	"group_id": 326,
+	"parents": {
+            "Chained": [],
+            "Directly chained": [],
+            "Parallel": []
+	},
+	"result": "incomplete",
+	"reason": "api failure",
+	"settings": {
+            "ARCH": "x86_64",
+            "BUILD": "testing",
+            "DISTRI": "Tumbleweed",
+            "FLAVOR": "Online",
+            "WORKER_CLASS": "qemu_x86_64"
+	},
+	"state": "done",
+	"t_finished": "2023-08-19T16:53:05",
+	"t_started": "2023-08-19T16:45:53",
+	"test": "footest_incomplete"
+    }
+}

--- a/test/data/414.json
+++ b/test/data/414.json
@@ -1,0 +1,23 @@
+{
+    "job": {
+	"id": 414,
+	"group_id": 326,
+	"parents": {
+            "Chained": [],
+            "Directly chained": [],
+            "Parallel": []
+	},
+	"result": "failed",
+	"settings": {
+            "ARCH": "x86_64",
+            "BUILD": "testing",
+            "DISTRI": "Tumbleweed",
+            "FLAVOR": "Online",
+            "WORKER_CLASS": "qemu_x86_64"
+	},
+	"state": "done",
+	"t_finished": "2023-08-19T16:53:05",
+	"t_started": "2023-08-19T16:45:53",
+	"test": "footest_failed"
+    }
+}


### PR DESCRIPTION
When `label_on_issues_from_issue_tracker` fails means that it doesn't add a
label on the ticket. Not added a comment it should not signal an ERR which
triggers the trap to be executed.
The current commit tries to solve again the problem which
https://github.com/os-autoinst/scripts/pull/335 solved but introduced a
new bug with a bad design.
After this commit the `label_on_issues_from_issue_tracker` is removed from the
_if_ block which caused early exit from trap when exit code was non-zero.
Redesigned in a simplier readable format keeping the logic the same and included
the requirements intacted. `label_on_issues_from_issue_tracker` is accessed
when autoinst-log exits or reason is found.
In case of some curl issues, no labeling occurs when the job is
old based on a hard-coded variable or when none of the requisites found.
Finally if none of them matches the issues the script will continue
with the next checks in the sequence of actions, as it was before.

https://progress.opensuse.org/issues/165716