### PR TITLE
Log `openqa-cli` errors and ignore non-existent jobs in investigation script

### DIFF
--- a/_common
+++ b/_common
@@ -126,7 +126,19 @@ runcurl() {
 
 openqa-api-get() {
     client_args=(api --header 'User-Agent: openqa-investigate (https://github.com/os-autoinst/scripts)' --host "$host_url")
-    openqa-cli "${client_args[@]}" --json "$@"
+    local rc response
+    set +e
+    response=$(openqa-cli "${client_args[@]}" --json "$@" 2>&1)
+    rc=$?
+    set -e
+    # write the response always to stdout (even in error case) so the caller can make sense of it
+    echo "$response"
+    [[ $rc == 0 ]] && return 0
+    # print a warning in the error case including the response (which would otherwise not be logged as the caller is expected
+    # to capture the output)
+    response=$(shorten_string "$response")
+    warn "openqa-cli ($(caller)): Error making API request ($*): $response"
+    return 1
 }
 
 comment_on_job() {

--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -35,7 +35,11 @@ label() {
 hook() {
     local id="${1:?"Need 'job_id'"}"
     local url=$host_url/tests/$id
-    job_data=$(openqa-api-get "jobs/$id")
+    local rc=0
+    job_data=$(openqa-api-get "jobs/$id") || rc=$?
+    local not_found_regex='404 Not Found'
+    [[ $job_data =~ $not_found_regex ]] && warn "Ignoring non-existent job $id" && return
+    [[ $rc != 0 ]] && return $rc
     state="$(echo "$job_data" | runjq -r '.job.state')" || return $?
     result="$(echo "$job_data" | runjq -r '.job.result')" || return $?
     [[ "$state" != "done" ]] && return


### PR DESCRIPTION
See particular commit messages and https://progress.opensuse.org/issues/166403.

---

Note that I didn't find any occurrences where `curl` is invoked directly (not via `runcurl`) so I guess `openqa-cli` is the problematic call here. It also prints exactly the same error we saw in the ticket, e.g.:

```
openqa-cli api --o3 foo
404 Not Found
{"error_status":404}
```

(The JSON part is not visible in the logs in the ticket because that is captured.)

---

I tested these changes locally by invoking the investigation script with existing and non-existing job IDs. Now we would get the following in the error case:

```
scheme=http host=127.0.0.1:9526 ./openqa-label-known-issues-and-investigate-hook 12345
openqa-cli (39 ./openqa-label-known-issues-and-investigate-hook): Error making API request (jobs/12345): 404 Not Found
{"error_status":404}
Ignoring non-existent job 12345
```