### PR TITLE
Skip posting investigation comment if original job has already been deleted

### DIFF
--- a/_common
+++ b/_common
@@ -15,6 +15,8 @@ curl_args=()
 markdown_cmd=$(command -v Markdown.pl) || markdown_cmd=$(command -v markdown) \
     || warn "+++ (Markdown.pl|markdown) not found, please install Text::Markdown +++"
 openqa_cli="${openqa_cli:-""}"
+# shellcheck disable=SC2034
+not_found_regex='404 Not Found'
 
 error-handler() {
     local line=$1
@@ -312,8 +314,8 @@ fetch-vars-json() {
 }
 
 client-get-job() {
-    local tid=$1
-    openqa-cli "${client_args[@]}" --json jobs/"$tid" || return $?
+    local job_id=$1
+    openqa-api-get jobs/"$job_id" || return $?
 }
 client-put-job() {
     local tid=$1 data=$2

--- a/openqa-investigate
+++ b/openqa-investigate
@@ -283,7 +283,10 @@ post-investigate() {
     retry_result="$(echo "$job_data" | runjq -r '.job.result')" || return $?
     investigate_origin="$(echo "$job_data" | runjq -r '.job.settings.OPENQA_INVESTIGATE_ORIGIN')" || return 1
     origin_job_id=${investigate_origin#"$host_url/t"}
-    origin_job_data=$(client-get-job "$origin_job_id") || return $?
+    origin_job_data=$(client-get-job "$origin_job_id") || rc=$?
+    # shellcheck disable=SC2154
+    [[ $origin_job_data =~ $not_found_regex ]] && echo "Skipping posting investigation comment on original job $origin_job_id as it does not exist anymore" && return 0
+    [[ $rc != 0 ]] && return $rc
     origin_name="$(echo "$origin_job_data" | runjq -r '.job.test')" || return $?
     # cluster jobs might have the same OPENQA_INVESTIGATE_ORIGIN as the root retry job
     [[ $retry_name != "$origin_name:investigate:retry" ]] && echo "Job $retry_name ($id) is not a retry of $origin_name ($origin_job_id)" && return 0

--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -37,7 +37,7 @@ hook() {
     local url=$host_url/tests/$id
     local rc=0
     job_data=$(openqa-api-get "jobs/$id") || rc=$?
-    local not_found_regex='404 Not Found'
+    # shellcheck disable=SC2154
     [[ $job_data =~ $not_found_regex ]] && warn "Ignoring non-existent job $id" && return
     [[ $rc != 0 ]] && return $rc
     state="$(echo "$job_data" | runjq -r '.job.state')" || return $?

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -3,7 +3,7 @@
 source test/init
 bpan:source bashplus +err +fs +sym
 
-plan tests 87
+plan tests 88
 
 host=localhost
 url=https://localhost
@@ -32,7 +32,7 @@ fetch-vars-json() {
 rc=0
 out=$(clone 41 42 2>&1 > /dev/null) || rc=$?
 is "$rc" 1 'fails when unable to query job data'
-is "$out" "unable to query job data for 42: " 'query error on stderr'
+like "$out" "unable to query job data for 42: " 'query error on stderr'
 
 cli_rc=0
 consider_parallel_and_directly_chained_clusters=1
@@ -86,6 +86,9 @@ client-get-job() {
             ;;
         30032)
             echo '{"job": { "test": "vim:investigate:retry", "result": "passed", "settings": {"OPENQA_INVESTIGATE_ORIGIN": "3003"} } }'
+            ;;
+        404)
+            echo '404 Not Found'
             ;;
         *)
             echo '{"debug": "client-get-job '"$tid"'"}'
@@ -318,6 +321,11 @@ test-post-investigate() {
     local job_data='{"job": { "result": "failed", "settings": { "OPENQA_INVESTIGATE_ORIGIN": "https://localhost/t3002" } } }'
     try post-investigate 2039 "vim:investigate:retry"
     is "$rc" 142 'post-investigate returned 142 (not all jobs finished yet) (2039)'
+
+    # test does not exist anymore
+    local job_data='{"job": { "result": "failed", "settings": { "OPENQA_INVESTIGATE_ORIGIN": "https://localhost/t404" } } }'
+    try post-investigate 2040 "vim:investigate:retry"
+    is "$rc" 0 'post-investigate returned 0 if the original job does not exist anymore'
 
     # various combinations of investigation results
     t1="fail"


### PR DESCRIPTION
Besides the added unit tests, I tested this by commenting out `main()` and invoking the relevant function manually against my local test openQA instance.

Test with existing job:
```
$ export scheme=http host=127.0.0.1:9526
$ export job_data='{"job": { "result": "failed", "settings": { "OPENQA_INVESTIGATE_ORIGIN": "http://127.0.0.1:9526/t4266" } } }'
$ bash -c 'source ./openqa-investigate; post-investigate 12345 investigate:retry'
Job investigate:retry (12345) is not a retry of wireguard_client (4266)
```

Test with non-existing job:
```
$ export job_data='{"job": { "result": "failed", "settings": { "OPENQA_INVESTIGATE_ORIGIN": "http://127.0.0.1:9526/t5678" } } }'
$ bash -c 'source ./openqa-investigate; post-investigate 12345 investigate:retry'
openqa-cli (317 …/_common): Error making API request (jobs/5678): 404 Not Found
{"error_status":404}
Skip posting investigation comment on original job 5678 as it does not exist anymore
$ echo $?
0
```

Related ticket: https://progress.opensuse.org/issues/166403