### PR TITLE
Prevent override the autoinst-log context within handle_unreachable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           python --version
           pytest --version
       - run: |
-          sudo apt-get install cpanminus
+          sudo apt-get install cpanminus html-xml-utils
           sudo cpanm -n -M https://cpan.metacpan.org --installdeps .
       - name: unit- and integration tests
         run: |

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -130,7 +130,8 @@ label_on_issues_without_tickets() {
 }
 
 investigate_issue() {
-    local id="${1##*/}"
+    local testurl=$1
+    local id="${testurl##*/}"
     local reason
     local curl_output
     echo "Requesting jobs/${id} via openqa-cli"
@@ -174,7 +175,7 @@ investigate_issue() {
 }
 
 label_issue() {
-    testurl="${1:?"Need 'testurl'"}"
+    local testurl="${1:?"Need 'testurl'"}"
     [[ "$dry_run" = "1" ]] && client_prefix="echo"
     if [[ -z "$client_call" ]]; then
         client_call=(openqa-cli "${client_args[@]}")

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -28,15 +28,16 @@ MOJO_CONNECT_TIMEOUT=${MOJO_CONNECT_TIMEOUT:-30}
 client_args=(api --header 'User-Agent: openqa-label-known-issues (https://github.com/os-autoinst/scripts)' --host "$host_url" --retries="$retries")
 
 out="${REPORT_FILE:-$(mktemp -t openqa-label-known-issues--output-XXXX)}"
+declare timeago
 trap 'error-handler "$LINENO"' ERR
 trap 'test "$KEEP_REPORT_FILE" == "1" || rm "$out"' EXIT
+trap 'test "$KEEP_JOB_HTML_FILE" == "1" || rm "$html_out"' EXIT
 
 echoerr() { echo "$@" >&2; }
 
 handle_unreachable() {
     local testurl=$1
-    local out=$2
-
+    html_out=${JOB_HTML_FILE:-$(mktemp -t openqa-label-known-issues--job-details-XXXX)}
     if ! curl "${curl_args[@]}" -s --head "$testurl" -o /dev/null; then
         # the page might be gone, try the scheme+host we configured (might be different one though)
         if ! grep -q "$host_url" <<< "$testurl"; then
@@ -51,17 +52,18 @@ handle_unreachable() {
         return 1
     fi
     # resorting to downloading the job details page instead of the
-    # log, overwrites $out
-    if ! curl "${curl_args[@]}" -s "$testurl" -o "$out"; then
+    # log
+    if ! curl "${curl_args[@]}" -s "$testurl" -o "${html_out}"; then
         echoerr "'$testurl' can be reached but not downloaded, bailing out"
         curl "${curl_args[@]}" "$testurl"
         exit 2
     fi
+    timeago=$(grep timeago "$html_out" | hxselect -s '\n' -c '.timeago::attr(title)')
 
-    if hxnormalize -x "$out" | hxselect -s '\n' -c '.links_a .resborder' | grep -qPzo '(?s)Gru job failed.*connection error.*Inactivity timeout'; then
+    if hxnormalize -x "${html_out}" | hxselect -s '\n' -c '.links_a .resborder' | grep -qPzo '(?s)Gru job failed.*connection error.*Inactivity timeout'; then
         "${client_call[@]}" -X POST jobs/"$id"/comments text='poo#62456 test incompletes after failing in GRU download task on "Inactivity timeout" with no logs'
         "${client_call[@]}" -X POST jobs/"$id"/restart
-        return 1
+        return
     fi
 }
 
@@ -137,9 +139,10 @@ investigate_issue() {
     if [[ "$curl_output" != "200" ]] && [[ "$curl_output" != "301" ]]; then
         # if we can not even access the page it is something more critical
         handle_unreachable "$testurl" "$out" || return
+
         [[ $curl_output != 404 ]] && return
-        # Checking timestamp
-        if [[ $(date -uIs -d '-14days') > $(grep timeago "$out" | hxselect -s '\n' -c '.timeago::attr(title)') ]]; then
+        # Checking timestamp given by job details page
+        if [[ $(date -uIs -d '-14days') > $timeago ]]; then
             # if the page is there but not even an autoinst-log.txt exists
             # then the job might be too old and logs are already deleted.
             echoerr "'$testurl' job#${id} without autoinst-log.txt older than 14 days. Do not label"

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -28,15 +28,19 @@ MOJO_CONNECT_TIMEOUT=${MOJO_CONNECT_TIMEOUT:-30}
 client_args=(api --header 'User-Agent: openqa-label-known-issues (https://github.com/os-autoinst/scripts)' --host "$host_url" --retries="$retries")
 
 out="${REPORT_FILE:-$(mktemp -t openqa-label-known-issues--output-XXXX)}"
-declare timeago
 trap 'error-handler "$LINENO"' ERR
-trap 'test "$KEEP_REPORT_FILE" == "1" || rm "$out"' EXIT
-trap 'test "$KEEP_JOB_HTML_FILE" == "1" || rm "$html_out"' EXIT
+trap '_cleanup' EXIT
+
+_cleanup() {
+    test "$KEEP_REPORT_FILE" == "1" || rm "$out"
+    test "$KEEP_JOB_HTML_FILE" == "1" || rm -f "$html_out"
+}
 
 echoerr() { echo "$@" >&2; }
 
 handle_unreachable() {
     local testurl=$1
+    local timeago
     html_out=${JOB_HTML_FILE:-$(mktemp -t openqa-label-known-issues--job-details-XXXX)}
     if ! curl "${curl_args[@]}" -s --head "$testurl" -o /dev/null; then
         # the page might be gone, try the scheme+host we configured (might be different one though)
@@ -58,12 +62,20 @@ handle_unreachable() {
         curl "${curl_args[@]}" "$testurl"
         exit 2
     fi
-    timeago=$(grep timeago "$html_out" | hxselect -s '\n' -c '.timeago::attr(title)')
 
     if hxnormalize -x "${html_out}" | hxselect -s '\n' -c '.links_a .resborder' | grep -qPzo '(?s)Gru job failed.*connection error.*Inactivity timeout'; then
         "${client_call[@]}" -X POST jobs/"$id"/comments text='poo#62456 test incompletes after failing in GRU download task on "Inactivity timeout" with no logs'
         "${client_call[@]}" -X POST jobs/"$id"/restart
-        return
+        return 1
+    fi
+
+    # Checking timestamp given by job details page
+    timeago=$(grep timeago "$html_out" | hxselect -s '\n' -c '.timeago::attr(title)')
+    if [[ $(date -uIs -d '-14days') > $timeago ]]; then
+        # if the page is there but not even an autoinst-log.txt exists
+        # then the job might be too old and logs are already deleted.
+        echoerr "'$testurl' job#${id} without autoinst-log.txt older than 14 days. Do not label"
+        return 1
     fi
 }
 
@@ -138,16 +150,9 @@ investigate_issue() {
     echo "$reason" >> "$out"
     if [[ "$curl_output" != "200" ]] && [[ "$curl_output" != "301" ]]; then
         # if we can not even access the page it is something more critical
-        handle_unreachable "$testurl" "$out" || return
+        handle_unreachable "$testurl" "$out" || return 0
 
         [[ $curl_output != 404 ]] && return
-        # Checking timestamp given by job details page
-        if [[ $(date -uIs -d '-14days') > $timeago ]]; then
-            # if the page is there but not even an autoinst-log.txt exists
-            # then the job might be too old and logs are already deleted.
-            echoerr "'$testurl' job#${id} without autoinst-log.txt older than 14 days. Do not label"
-            return
-        fi
         # not unreachable, no log, no reason, not too old
         if [[ -z $reason ]] || [[ $reason = null ]]; then
             echoerr "'$testurl' does not have autoinst-log.txt or reason, cannot label"

--- a/test/07-openqa-label-known-issues.t
+++ b/test/07-openqa-label-known-issues.t
@@ -40,20 +40,6 @@ comment_on_job() {
     echo "$comment"
 }
 out=''
-hxnormalize() {
-    cat "$2"
-}
-
-hxselect() {
-    if [ -p /dev/stdin ]; then
-	in="$(cat)"
-	if echo "$in" | grep -q "incomplete"; then
-	    echo "$in" | awk -F'title="' '{split($2, a, "\""); print a[1]}'
-	    return 0
-	fi
-	cat -
-    fi
-}
 
 try investigate_issue
 is "$rc" 1 'id required'

--- a/test/07-openqa-label-known-issues.t
+++ b/test/07-openqa-label-known-issues.t
@@ -41,7 +41,7 @@ comment_on_job() {
 }
 out=''
 
-try investigate_issue
+try investigate_issue || true
 is "$rc" 1 'id required'
 # error in tap output is from here
 

--- a/test/07-openqa-label-known-issues.t
+++ b/test/07-openqa-label-known-issues.t
@@ -67,7 +67,7 @@ setup() {
 # test data with reason but 404 in curl respond
 setup 404
 older40d_date=$(date -uIs -d '-40days')
-echo -n "Result:<b>incomplete</b>finished<abbr class=\"timeago\" title=\"${older40d_date}\"</abbr>>" > $tmpjobpage
+echo -n "Result:<b>incomplete</b>finished<abbr class=\"timeago\" title=\"${older40d_date}\"></abbr>" > $tmpjobpage
 export JOB_HTML_FILE=$tmpjobpage
 try-client-output investigate_issue $testurl
 is "$rc" 0 'investigate_issue with missing autoinst-log and with reason in job_data' #ok 3
@@ -78,7 +78,7 @@ setup 101
 # `older1d_date` is used on the following 4 test cases
 older1d_date=$(date -uIs -d '-1days')
 sed -i "s/yyyy-mm-dd/${older1d_date}/" "$dir/data/${id}.json"
-echo -n "Result:<b>incomplete</b>finished<abbr class=\"timeago\" title=\"${older1d_date}\"</abbr>>" > $tmpjobpage
+echo -n "Result:<b>incomplete</b>finished<abbr class=\"timeago\" title=\"${older1d_date}\"></abbr>" > $tmpjobpage
 html_out=$tmpjobpage
 export JOB_HTML_FILE=$tmpjobpage
 echo > $tmplog

--- a/test/07-openqa-label-known-issues.t
+++ b/test/07-openqa-label-known-issues.t
@@ -55,13 +55,14 @@ action
 Job incompletes with reason auto_review:\"(?m)api failure$\" (and no further details)
 action"
 
+tmplog=$(mktemp)
+out=$tmplog
+tmpjobpage=$(mktemp)
+
 setup() {
   local id=$1
   declare -g id=$id
   declare -g testurl="https://openqa.opensuse.org/tests/${id}"
-  declare -g tmplog=$(mktemp)
-  declare -g out=$tmplog
-  declare -g tmpjobpage=$(mktemp)
 }
 
 # test data with reason but 404 in curl respond
@@ -82,7 +83,6 @@ echo -n "Result:<b>incomplete</b>finished<abbr class=\"timeago\" title=\"${older
 html_out=$tmpjobpage
 export JOB_HTML_FILE=$tmpjobpage
 echo > $tmplog
-out=$tmplog
 try-client-output investigate_issue $id
 is "$rc" 0 'investigate_issue with missing autoinst-log but with reason in job_data' # ok 4
 has "$got" "does not have autoinst-log.txt or reason, cannot label" "investigation exits when no reason and autoinst-log"
@@ -92,7 +92,6 @@ sed -i "s/${older1d_date}/yyyy-mm-dd/" "$dir/data/${id}.json"
 # Unknown reason - not included in issues
 setup 102
 echo -n "\nthe reason is whatever" >> $tmplog
-out=$tmplog
 try-client-output investigate_issue $id
 is "$rc" 0 'investigate no old issue with missing autoinst-log and unknown reason in job_data'
 has "$got" "Unknown test issue, to be reviewed" "investigation still label Unknown reason"
@@ -104,14 +103,12 @@ has "$got" "does not have autoinst-log.txt or reason, cannot label" "investigati
 
 setup 200
 cp $autoinst_log $tmplog
-out=$tmplog
 try-client-output investigate_issue $id
 is "$rc" 0 'investigate_issue with autoinst-log and without reason'
 has "$got" "test fails in network_peering" "investigation label job with matched autoinst-log context"
 
 # handle_unreview branch
 echo > "$tmplog"
-out=$tmplog
 try-client-output investigate_issue $id
 is "$rc" 0 'job with empty autoinst-log checks unknown issue'
 has "$got" "Unknown test issue, to be reviewed" "investigation still label Unknown issue"

--- a/test/07-openqa-label-known-issues.t
+++ b/test/07-openqa-label-known-issues.t
@@ -30,9 +30,9 @@ openqa-cli() {
 }
 curl() {
     if [[ "$7" =~ /(404|414|101|102)/file/autoinst-log.txt ]]; then
-	echo -n "404"
+        echo -n "404"
     else
-	echo -n "200"
+        echo -n "200"
     fi
 }
 comment_on_job() {

--- a/test/07-openqa-label-known-issues.t
+++ b/test/07-openqa-label-known-issues.t
@@ -60,9 +60,8 @@ out=$tmplog
 tmpjobpage=$(mktemp)
 
 setup() {
-  local id=$1
-  declare -g id=$id
-  declare -g testurl="https://openqa.opensuse.org/tests/${id}"
+    id=$1
+    testurl="https://openqa.opensuse.org/tests/${id}"
 }
 
 # test data with reason but 404 in curl respond
@@ -70,7 +69,7 @@ setup 404
 older40d_date=$(date -uIs -d '-40days')
 echo -n "Result:<b>incomplete</b>finished<abbr class=\"timeago\" title=\"${older40d_date}\"</abbr>>" > $tmpjobpage
 export JOB_HTML_FILE=$tmpjobpage
-try-client-output investigate_issue $id
+try-client-output investigate_issue $testurl
 is "$rc" 0 'investigate_issue with missing autoinst-log and with reason in job_data' #ok 3
 has "$got" "without autoinst-log.txt older than 14 days. Do not label" "exits succefully when is old job without autoinst-log.txt"
 
@@ -83,7 +82,7 @@ echo -n "Result:<b>incomplete</b>finished<abbr class=\"timeago\" title=\"${older
 html_out=$tmpjobpage
 export JOB_HTML_FILE=$tmpjobpage
 echo > $tmplog
-try-client-output investigate_issue $id
+try-client-output investigate_issue $testurl
 is "$rc" 0 'investigate_issue with missing autoinst-log but with reason in job_data' # ok 4
 has "$got" "does not have autoinst-log.txt or reason, cannot label" "investigation exits when no reason and autoinst-log"
 # Cleanup 404.json
@@ -92,28 +91,28 @@ sed -i "s/${older1d_date}/yyyy-mm-dd/" "$dir/data/${id}.json"
 # Unknown reason - not included in issues
 setup 102
 echo -n "\nthe reason is whatever" >> $tmplog
-try-client-output investigate_issue $id
+try-client-output investigate_issue $testurl
 is "$rc" 0 'investigate no old issue with missing autoinst-log and unknown reason in job_data'
 has "$got" "Unknown test issue, to be reviewed" "investigation still label Unknown reason"
 
 setup 414
-try-client-output investigate_issue $id
+try-client-output investigate_issue $testurl
 is "$rc" 0 'investigate_issue with missing old autoinst-log and without reason in job_data'
 has "$got" "does not have autoinst-log.txt or reason, cannot label" "investigation exits successfully when no reason and no autoinst-log"
 
 setup 200
 cp $autoinst_log $tmplog
-try-client-output investigate_issue $id
+try-client-output investigate_issue $testurl
 is "$rc" 0 'investigate_issue with autoinst-log and without reason'
 has "$got" "test fails in network_peering" "investigation label job with matched autoinst-log context"
 
 # handle_unreview branch
 echo > "$tmplog"
-try-client-output investigate_issue $id
+try-client-output investigate_issue $testurl
 is "$rc" 0 'job with empty autoinst-log checks unknown issue'
 has "$got" "Unknown test issue, to be reviewed" "investigation still label Unknown issue"
 
 echo -n "[error] Failed to download" > $out
-try-client-output investigate_issue $id
+try-client-output investigate_issue $testurl
 is "$rc" 0 'job label without tickets'
 has "$got" "label:download_error potentially out-of-space worker?" "investistigation label correctly job without ticket"


### PR DESCRIPTION
`handle_unreachable` can override the log file passed to the function. This should not allowed because when the `handle_unreviewed` function is reach will run with incorrect logs. Solving the issue creating a separate temp local file
 for handle_unreachable and extract timeago in a variable in order to use it to
 determine the age of the job. This keeps clear now the out variable which
 should only contain the autoinst-log+reason.

https://progress.opensuse.org/issues/166772