### PR TITLE
Use a single API query in `openqa-advanced-retrigger-jobs`

### DIFF
--- a/openqa-advanced-retrigger-jobs
+++ b/openqa-advanced-retrigger-jobs
@@ -6,14 +6,25 @@ worker_string="${WORKER+"assigned_worker_id in (select id from workers where (ho
 result="${result:-"result='incomplete'"}"
 additional_filters="${additional_filters+" and $additional_filters"}"
 comment="${comment:-""}"
+max_jobs_per_request=25
 dry_run="${dry_run:-"0"}"
 [ "$dry_run" = "1" ] && client_prefix="echo"
 sql_command="select id from jobs where (${worker_string}${result} and clone_id is null and t_finished >= '$failed_since'$additional_filters);"
-query_params=()
 # shellcheck disable=SC2029
 job_ids=${JOB_IDS:-$(ssh "$host" "sudo -u geekotest psql --no-align --tuples-only --command=\"$sql_command\" openqa")}
-for job_id in $job_ids; do query_params+=("jobs=$job_id"); done
-[[ $comment ]] && query_params+=("comment=$comment")
+
+query_params=()
 [[ $cli_protocol ]] && host=$cli_protocol://$host
 [[ $cli_port ]] && host+=:$cli_port
-$client_prefix openqa-cli api --host "$host" -X POST jobs/restart "${query_params[@]}"
+restart-jobs() {
+    [[ ${#query_params[@]} -lt 1 ]] && return
+    [[ $comment ]] && query_params+=("comment=$comment")
+    $client_prefix openqa-cli api --host "$host" -X POST jobs/restart "${query_params[@]}"
+    query_params=()
+}
+
+for job_id in $job_ids; do
+    query_params+=("jobs=$job_id")
+    [[ ${#query_params[@]} -ge "$max_jobs_per_request" ]] && restart-jobs
+done
+restart-jobs

--- a/openqa-advanced-retrigger-jobs
+++ b/openqa-advanced-retrigger-jobs
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 #worker="${worker:-"openqaworker4"}"
 host="${host:-"openqa.opensuse.org"}"
 failed_since="${failed_since:-"$(date -I)"}"
@@ -9,8 +9,10 @@ additional_filters="${additional_filters+" and $additional_filters"}"
 comment="${comment:-""}"
 dry_run="${dry_run:-"0"}"
 [ "$dry_run" = "1" ] && client_prefix="echo"
+sql_command="select id from jobs where (${worker_string}${result} and clone_id is null and t_finished >= '$failed_since'$additional_filters);"
+query_params=()
 # shellcheck disable=SC2029
-for i in $(ssh "$host" "sudo -u geekotest psql --no-align --tuples-only --command=\"select id from jobs where (${worker_string}${result} and clone_id is null and t_finished >= '$failed_since'$additional_filters);\" openqa"); do
-    $client_prefix openqa-cli api --host "$host" -X POST jobs/"$i"/restart
-    [ -n "$comment" ] && $client_prefix openqa-cli api --host "$host" -X POST jobs/"$i"/comments text="$comment"
-done
+job_ids=${JOB_IDS:-$(ssh "$host" "sudo -u geekotest psql --no-align --tuples-only --command=\"$sql_command\" openqa")}
+for job_id in $job_ids; do query_params+=("jobs=$job_id"); done
+[[ $comment ]] && query_params+=("comment=$comment")
+$client_prefix openqa-cli api --host "$host" -X POST jobs/restart "${query_params[@]}"

--- a/openqa-advanced-retrigger-jobs
+++ b/openqa-advanced-retrigger-jobs
@@ -14,4 +14,6 @@ query_params=()
 job_ids=${JOB_IDS:-$(ssh "$host" "sudo -u geekotest psql --no-align --tuples-only --command=\"$sql_command\" openqa")}
 for job_id in $job_ids; do query_params+=("jobs=$job_id"); done
 [[ $comment ]] && query_params+=("comment=$comment")
+[[ $cli_protocol ]] && host=$cli_protocol://$host
+[[ $cli_port ]] && host+=:$cli_port
 $client_prefix openqa-cli api --host "$host" -X POST jobs/restart "${query_params[@]}"

--- a/openqa-advanced-retrigger-jobs
+++ b/openqa-advanced-retrigger-jobs
@@ -1,5 +1,4 @@
 #!/bin/bash -e
-#worker="${worker:-"openqaworker4"}"
 host="${host:-"openqa.opensuse.org"}"
 failed_since="${failed_since:-"$(date -I)"}"
 instance_string="${INSTANCE+" and instance='$INSTANCE'"}"


### PR DESCRIPTION
Tested with a dry run against o3 and a regular run against my local
instance overriding `JOB_IDS`.

Related ticket: https://progress.opensuse.org/issues/168013