### PR TITLE
Add ipxe server name for netboot.qe.prg2.suse.org

### DIFF
--- a/ipxe/menu.ipxe
+++ b/ipxe/menu.ipxe
@@ -6,9 +6,10 @@
 #set variables
 set menu-timeout 30000
 set server-name netboot
-iseq ${next-server} 10.150.1.11   && set server-name openqa.opensuse.org ||
-iseq ${next-server} 10.168.192.10 && set server-name qe.nue2.suse.org ||
-iseq ${next-server} 10.162.0.1    && set server-name qanet.qa.suse.de ||
+iseq ${next-server} 10.150.1.11    && set server-name openqa.opensuse.org ||
+iseq ${next-server} 10.168.192.10  && set server-name qe.nue2.suse.org ||
+iseq ${next-server} 10.162.0.1     && set server-name qanet.qa.suse.de ||
+iseq ${next-server} 10.144.110.161 && set server-name netboot.qe.prg2.suse.org ||
 
 :start
 menu iPXE boot menu for ${server-name}


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/155524