### PR TITLE
openqa-schedule-mm-ping-test: Allow test to not have external connectivity

### DIFF
--- a/openqa-schedule-mm-ping-test
+++ b/openqa-schedule-mm-ping-test
@@ -33,6 +33,7 @@ machines:
   DESKTOP: textmode
   IS_MM_SERVER: '1'
   NICTYPE: tap
+  EXPECTED_NM_CONNECTIVITY: none
   QEMU_DISABLE_SNAPSHOTS: '1'
   YAML_SCHEDULE: schedule/functional/mm_ping.yaml
 


### PR DESCRIPTION
This basically just aligns our yaml-schedule in the test with the test suite definition on o3 where this test is running.

The "better" value for this would be `(Partial|Full)` but this requires https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20651 to be merged which I need to test first because it can cause quite a fallout if done wrong.

Related ticket with some more details: https://progress.opensuse.org/issues/169531#note-18