### PR TITLE
Revert "Revert "Reduce allowed network states for ping tests""

### DIFF
--- a/openqa-schedule-mm-ping-test
+++ b/openqa-schedule-mm-ping-test
@@ -33,7 +33,7 @@ machines:
   DESKTOP: textmode
   IS_MM_SERVER: '1'
   NICTYPE: tap
-  EXPECTED_NM_CONNECTIVITY: none
+  EXPECTED_NM_CONNECTIVITY: '(limited|full)'
   QEMU_DISABLE_SNAPSHOTS: '1'
   YAML_SCHEDULE: schedule/functional/mm_ping.yaml
 


### PR DESCRIPTION
Reverts os-autoinst/scripts#355

Only merge **after** https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20651