### PR TITLE
Allow triggering openQA-in-openQA tests if submission is pending

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -174,6 +174,12 @@ osc="${osc:-"$prefix retry -e -- osc"}"
 # submit from staging project if specified
 [[ $staging_project && $staging_project != none ]] && src_project=$staging_project from_staging=1
 
+if [[ -e job_post_skip_submission ]]; then
+    echo "Skipping submission, reason: "
+    cat job_post_skip_submission
+    exit 0
+fi
+
 TMPDIR=${TMPDIR:-$(mktemp -d -t os-autoinst-obs-auto-submit-XXXX)}
 trap 'rm -rf "$TMPDIR"' EXIT
 

--- a/trigger-openqa_in_openqa
+++ b/trigger-openqa_in_openqa
@@ -61,8 +61,12 @@ create_devel_openqa_snapshot() {
     auto_submit_packages=$(list_packages "$dst_project")
     staged_packages=$(list_packages "$staging_project") || true # osc ls returns non-zero return code for empty projects
     if [[ $staged_packages ]]; then
-        echo "Skipping, there are still openQA-in-openQA tests pending"
-        exit 0
+        echo "Only triggering tests from $src_project (not overriding $staging_project and doing a submission) because openQA-in-openQA tests or a submission is still pending (as $staging_project still contains packages)" \
+            | tee job_post_skip_submission
+        staging_project=$src_project
+        return
+    elif [[ -e job_post_skip_submission ]]; then
+        rm job_post_skip_submission
     fi
     echo "Creating snapshots under $staging_project"
     for package in $auto_submit_packages; do


### PR DESCRIPTION
We can schedule the tests anyway; we only should not override the staging repo and follow up with a submission. This way we see problems with openQA- in-openQA tests early - even when submissions are pending for a while.

To indicate that we should not do a submission, this change creates the file `job_post_skip_submission` in the current working directory which is picked up by e.g. Jenkins as artifact via the glob `job_post_*` and can be used by subsequent jobs. It is important to configure that subsequent jobs use the artifacts from the preceding job that triggered them and *not* the last successful job.

Related ticket: https://progress.opensuse.org/issues/167395