### PR TITLE
Fix sporadic error about broken pipe when checking recent SRs

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -183,7 +183,7 @@ fi
 
 # throttle number of submissions to allow only one SR within a certain number of days
 if [[ $throttle_days != 0 ]] && $osc request list --project "$dst_project" --type submit --state new,review --mine --days "$throttle_days" | grep --quiet 'Created by'; then
-    echo "Skipping submission, there is still a pending SR younger than $throttle_days."
+    echo "Skipping submission, there is still a pending SR younger than $throttle_days days."
     exit 0
 fi
 

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -182,13 +182,8 @@ if [[ -e job_post_skip_submission ]]; then
 fi
 
 # throttle number of submissions to allow only one SR within a certain number of days
-if [[ $throttle_days != 0 ]] && $osc request list --project "$dst_project" --type submit --state new,review --mine --days "$throttle_days" \
-    | {
-        grep --quiet 'Created by'
-        rc=$?
-        cat > /dev/null # keep consuming input so osc does not run into "BrokenPipeError: [Errno 32] Broken pipe"
-        exit $rc
-    }; then
+# note: Avoid using `grep --quiet` here to keep consuming input so osc does not run into "BrokenPipeError: [Errno 32] Broken pipe".
+if [[ $throttle_days != 0 ]] && $osc request list --project "$dst_project" --type submit --state new,review --mine --days "$throttle_days" | grep 'Created by' > /dev/null; then
     echo "Skipping submission, there is still a pending SR younger than $throttle_days days."
     exit 0
 fi

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -182,7 +182,13 @@ if [[ -e job_post_skip_submission ]]; then
 fi
 
 # throttle number of submissions to allow only one SR within a certain number of days
-if [[ $throttle_days != 0 ]] && $osc request list --project "$dst_project" --type submit --state new,review --mine --days "$throttle_days" | grep --quiet 'Created by'; then
+if [[ $throttle_days != 0 ]] && $osc request list --project "$dst_project" --type submit --state new,review --mine --days "$throttle_days" \
+    | {
+        grep --quiet 'Created by'
+        rc=$?
+        cat > /dev/null # keep consuming input so osc does not run into "BrokenPipeError: [Errno 32] Broken pipe"
+        exit $rc
+    }; then
     echo "Skipping submission, there is still a pending SR younger than $throttle_days days."
     exit 0
 fi


### PR DESCRIPTION
This code sometimes runs into:

```
Exception ignored in: <osc.util.safewriter.SafeWriter object at 0x7fbe42c17860>
BrokenPipeError: [Errno 32] Broken pipe
Retrying up to 3 more times after sleeping 3s …
```

This is easily reproducible by adding the condition into a separate script
and running it a few times. The additional `cat > /dev/null` which this
change introduces seems to fix the issue.

Related ticket: https://progress.opensuse.org/issues/167395