### PR TITLE
Prevent test jobs for MM setup from being obsoleted

### DIFF
--- a/openqa-schedule-mm-ping-test
+++ b/openqa-schedule-mm-ping-test
@@ -6,6 +6,7 @@ set -eu -o pipefail
 openqa_url=${openqa_url:-https://openqa.opensuse.org}
 distri=${distri:-opensuse}
 flavor=${flavor:-DVD}
+flavor_override=${flavor_override:-mm-monitoring} # override flavor to avoid obsoletion by other scheduled products
 arch=${arch:-x86_64}
 version=${version:-Tumbleweed}
 test_name=${test_name:-ping_client}
@@ -18,7 +19,7 @@ cat > "$tmpfile" << EOF
 products:
   mm-ping-test:
     distri: $distri
-    flavor: $flavor
+    flavor: $flavor_override
     arch: $arch
     version: $version
 
@@ -58,6 +59,6 @@ time openqa-cli schedule \
     --monitor \
     --host "$openqa_url" \
     --param-file SCENARIO_DEFINITIONS_YAML="$tmpfile" \
-    DISTRI="$distri" VERSION="$version" FLAVOR="$flavor" ARCH="$arch" \
+    DISTRI="$distri" VERSION="$version" FLAVOR="$flavor_override" ARCH="$arch" \
     BUILD="$(date -Im)" _GROUP_ID=0 \
     HDD_1="$hdd"


### PR DESCRIPTION
Those test jobs are not scheduled with `_OBSOLETE=1` themselves but so far they use a very common combination of DISTRI, VERSION, FLAVOR and ARCH. This means that they are likely obsoleted by other scheduled products using the same combination.

The FLAVOR variable is not used by the test code so this changes simply overrides it making the combination of settings unique. I spawned to set of test jobs on o3 (by simply invoking `./openqa-schedule-mm-ping-test` locally) to verify that this works.

Related ticket: https://progress.opensuse.org/issues/174583#note-48