### PR TITLE
Fix submitting `os-autoinst-distri-opensuse-deps`

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -143,7 +143,9 @@ handle_auto_submit() {
     $osc co --server-side-source-service-files "$src_project"/"$package"
     if [[ "$package" == "os-autoinst-distri-opensuse-deps" ]]; then
         $osc cat "$submit_target" "$package" "$package.spec" > "$package-factory.spec"
+        set +o pipefail
         if diff -u "$package"-factory.spec "$src_project/$package/_service:obs_scm:$package".spec | grep "^[+-]Requires"; then
+            set -o pipefail
             # dependency added or removed
             generate_os-autoinst-distri-opensuse-deps_changelog "$src_project" "$package"
         else


### PR DESCRIPTION
* Disable pipefail temporarily to ignore the "failing" diff command (which is expected to return a non-zero exit code in case the files are different)
* See https://progress.opensuse.org/issues/176316