### PR TITLE
os-autoinst-obs-auto-submit: Mark expected failure explicitly

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -143,9 +143,7 @@ handle_auto_submit() {
     $osc co --server-side-source-service-files "$src_project"/"$package"
     if [[ "$package" == "os-autoinst-distri-opensuse-deps" ]]; then
         $osc cat "$submit_target" "$package" "$package.spec" > "$package-factory.spec"
-        set +o pipefail
-        if diff -u "$package"-factory.spec "$src_project/$package/_service:obs_scm:$package".spec | grep "^[+-]Requires"; then
-            set -o pipefail
+        if { diff -u "$package"-factory.spec "$src_project/$package/_service:obs_scm:$package".spec || :; } | grep "^[+-]Requires"; then
             # dependency added or removed
             generate_os-autoinst-distri-opensuse-deps_changelog "$src_project" "$package"
         else


### PR DESCRIPTION
This is a follow-up to 6fd3443 keeping the pipefail flag intact but
explicitly discarding the exit code of the "diff" call which should not
impact the further evaluation. I tested this manually with two differing
fails and checking the exit code like this:

```
set -o pipefail
diff file1 file2 | grep $content
(diff file1 file2 ||:) | grep $content
```

Related progress issue: https://progress.opensuse.org/issues/176316

Related to
* #367