### PR TITLE
Wait until all packages in the snapshot are actually published

### DIFF
--- a/trigger-openqa_in_openqa
+++ b/trigger-openqa_in_openqa
@@ -80,6 +80,8 @@ create_devel_openqa_snapshot() {
         echo "Creating snapshots of $package"
         $osc release --no-delay --target-project "$staging_project" --target-repository=openSUSE_Tumbleweed -r openSUSE_Tumbleweed -a x86_64 "$src_project" "$package"
     done
+    echo "Wait until all packages are published under $staging_project"
+    $osc prjresults --watch --xml -r openSUSE_Tumbleweed -a x86_64 "$staging_project"
 }
 
 trigger() {


### PR DESCRIPTION
First we ensure all wanted packages inside devel:openQA are published properly, after that we "release" them via `osc release`. As this is not an atomic operation and OBS still needs some time to properly publish the copied packages, we can use `osc prjresult -w` to wait until that happens. That will ensure that the staging project (i.e. devel:openQA:testing) does contain some binaries packages to test.

Reference: https://progress.opensuse.org/issues/174451