### PR TITLE
openqa-investigate: Fix last_good_tests_and_build for cluster jobs

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -47,9 +47,10 @@ clone() {
     [[ $unsupported_cluster_jobs != 0 ]] \
         && echoerr "Unable to clone job $id: it is part of a directly chained cluster (not supported)" && return 2
 
-    name="$(echo "$clone_job_data" | runjq -r '.job.test'):investigate$name_suffix" || return $?
+    base_name="$(echo "$clone_job_data" | runjq -r '.job.test')" || return $?
+    name="$base_name:investigate$name_suffix"
     base_prio=$(echo "$clone_job_data" | runjq -r '.job.priority') || return $?
-    clone_settings=("TEST+=:investigate$name_suffix" '_TRIGGER_JOB_DONE_HOOK=1' '_GROUP_ID=0' 'BUILD=')
+    clone_settings=('_TRIGGER_JOB_DONE_HOOK=1' '_GROUP_ID=0' 'BUILD=')
     if [[ $refspec ]]; then
         vars_json=$(fetch-vars-json "$origin")
         testgiturl=$(echo "$vars_json" | runjq -r '.TEST_GIT_URL')
@@ -67,12 +68,13 @@ clone() {
         if [[ $name_suffix =~ (last_good_tests_and_build) ]]; then
             worker_vars_settings=$(echo "$vars_json" | runjq -r '.WORKER_CLASS') || return $?
             if [[ $worker_vars_settings != null ]]; then
-                clone_settings+=("WORKER_CLASS=${worker_vars_settings}")
+                clone_settings+=("WORKER_CLASS:$base_name=${worker_vars_settings}")
             else
                 name+="(unidentified worker class in vars.json)"
             fi
         fi
     fi
+    clone_settings+=("TEST+=:investigate$name_suffix")
     [[ -n ${*:5} ]] && clone_settings+=("${@:5}")
     # clear "PUBLISH_" settings to avoid overriding production assets
     # shellcheck disable=SC2207

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -250,7 +250,7 @@ is "$rc" 0 "Successful clone"
 like "$got" 'CASEDIR=.*/os-autoinst-testrepo.git#refspec' "job is cloned and CASEDIR is set correctly"
 
 try clone 10022 10030 last_good_tests_and_build:123 refspec
-has "$got" 'WORKER_CLASS=foo,duh,bar' "job assigns the same WORKER_CLASS"
+has "$got" 'WORKER_CLASS:vim=foo,duh,bar' "job assigns the WORKER_CLASS only to the origin job clone"
 
 try clone 10021 10030 last_good_tests_and_build:123 refspec
 has "$got" 'unidentified worker class in vars.json' "info shown in the name is WORKER_CLASS is empty"


### PR DESCRIPTION
openqa-investigate deliberately triggers exact worker class combinations
for "last_good_build_and_test". For unique worker class combinations in
combination with parallel cluster jobs this caused the problem that a
single worker instance can not work on more than one job in parallel
hence the job cluster could never be assigned to any worker.

This commit fixes the problem by using the openqa-clone-job feature to
apply job specific settings based on the resulting test name. As we also
alter the test name the order needs to be changed to ensure that the
worker class setting is applied first based on the original test name
and only after that we set the test suffix name.

Verified manually with

```
env dry_run=1 host=openqa.suse.de force=true openqa-investigate https://openqa.suse.de/tests/16622911
```

and executing the resulting openqa-clone-job invocation with
"--export-command":

```
openqa-clone-job --export-command --json-output --skip-chained-deps --max-depth 0 \
--parental-inheritance --within-instance https://openqa.suse.de/tests/16474387 \
_TRIGGER_JOB_DONE_HOOK=1 _GROUP_ID=0 BUILD= \
CASEDIR=https://github.com/os-autoinst/os-autoinst-distri-opensuse.git#2568d56c0376bcc652e9b26c62dd13547e66715d \
WORKER_CLASS:cc_audit_remote_client=s390-kvm,s390-kvm-sle12-mm,s390zl13,s390kvm103,zone-cc,region-prg,datacenter-dc7,location-prg2,worker33,cpu-x86_64,cpu-x86_64-v2,cpu-x86_64-v3 \
TEST+=:investigate:last_good_tests_and_build:2568d56c0376bcc652e9b26c62dd13547e66715d+117.1 \
OPENQA_INVESTIGATE_ORIGIN=https://openqa.suse.de/t16622911
```

as well as tested by actually creating jobs and checking the scheduling
parameters for correctness.

Related progress issue: https://progress.opensuse.org/issues/176418