### PR TITLE
Avoid python trace from subprocess.check_output

### DIFF
--- a/openqa-trigger-bisect-jobs
+++ b/openqa-trigger-bisect-jobs
@@ -7,8 +7,8 @@ import json
 import logging
 import os
 import re
-import subprocess
 import sys
+import subprocess
 from urllib.parse import urlparse, urlunparse
 
 import requests
@@ -111,18 +111,31 @@ client_args = [
 def call(cmds, dry_run=False):
     try:
         log.debug("call: %s" % cmds)
-        return subprocess.check_output(
-            (["echo", "Simulating: "] if dry_run else []) + cmds
-        ).decode("utf-8")
-    except subprocess.CalledProcessError as e:
-        subprocess_error = json.dumps({
-            "cmd": cmds[0],
-            "returncode": e.returncode,
-            "stderr": e.stderr if e.stderr else None
-        })
-        log.error(json.loads(subprocess_error))
-        print("DEBUG: Calling sys.exit()") 
-        sys.exit(e.returncode)
+        return {
+            "output": subprocess.check_output(
+            (["echo", "Simulating: "] if dry_run else []) + cmds,
+            stderr=subprocess.STDOUT,
+            shell=True).decode("utf-8"),
+            "error": False
+        }
+    except subprocess.SubprocessError as err:
+        url_pattern = re.compile(r"(https://.*)/tests/(\d+)")
+        url_match = next(
+            ((i, item) for i, item in enumerate(cmds) 
+            if isinstance(item, str) and url_pattern.match(item)),
+            None
+        )
+        found = url_pattern.match(url_match[1])
+        error_info = {
+            "cmd": cmds,
+            "failed_id": found.group(1),
+            "host": found.group(0),
+            "err_type": type(err).__name__,
+            "stderr": err.stderr if err.stderr else "No error putput",
+            "error": True
+        }
+        log.error(error_info["stderr"])
+        return json.dumps(error_info)
 
 def openqa_comment(job, host, comment, dry_run):
     args = client_args + [
@@ -155,7 +168,9 @@ def openqa_clone(
     default_opts=["--skip-chained-deps", "--json-output", "--within-instance"],
     default_cmds=["_GROUP=0"],
 ):
-    return call(["openqa-clone-job"] + default_opts + cmds + default_cmds, dry_run)
+    cmd = ["openqa-clone-job"] + default_opts + cmds + default_cmds
+    json_res = call(cmd, dry_run)
+    return json.loads(json_res)
 
 
 def fetch_url(url, request_type="text"):
@@ -312,6 +327,9 @@ def main(args):
             params,
             args.dry_run,
         )
+        if out["error"] is True:
+            openqa_comment(out['failed_id'], out['host'], out['stderr'], args.dry_run)
+            sys.exit()
 
         created_job_ids = []
         try:

--- a/openqa-trigger-bisect-jobs
+++ b/openqa-trigger-bisect-jobs
@@ -115,8 +115,14 @@ def call(cmds, dry_run=False):
             (["echo", "Simulating: "] if dry_run else []) + cmds
         ).decode("utf-8")
     except subprocess.CalledProcessError as e:
-        log.error("%s failed with return code %s", cmds[0], e.returncode)
-        return e.output.decode("utf-8")
+        subprocess_error = json.dumps({
+            "cmd": cmds[0],
+            "returncode": e.returncode,
+            "stderr": e.stderr if e.stderr else None
+        })
+        log.error(json.loads(subprocess_error))
+        print("DEBUG: Calling sys.exit()") 
+        sys.exit(e.returncode)
 
 def openqa_comment(job, host, comment, dry_run):
     args = client_args + [
@@ -306,6 +312,7 @@ def main(args):
             params,
             args.dry_run,
         )
+
         created_job_ids = []
         try:
             created_job_ids = json.loads(out).values()

--- a/openqa-trigger-bisect-jobs
+++ b/openqa-trigger-bisect-jobs
@@ -109,11 +109,14 @@ client_args = [
 
 
 def call(cmds, dry_run=False):
-    log.debug("call: %s" % cmds)
-    return subprocess.check_output(
-        (["echo", "Simulating: "] if dry_run else []) + cmds
-    ).decode("utf-8")
-
+    try:
+        log.debug("call: %s" % cmds)
+        return subprocess.check_output(
+            (["echo", "Simulating: "] if dry_run else []) + cmds
+        ).decode("utf-8")
+    except subprocess.CalledProcessError as e:
+        log.error("%s failed with return code %s", cmds[0], e.returncode)
+        return e.output.decode("utf-8")
 
 def openqa_comment(job, host, comment, dry_run):
     args = client_args + [

--- a/openqa-trigger-bisect-jobs
+++ b/openqa-trigger-bisect-jobs
@@ -7,8 +7,8 @@ import json
 import logging
 import os
 import re
-import sys
 import subprocess
+import sys
 from urllib.parse import urlparse, urlunparse
 
 import requests
@@ -170,7 +170,10 @@ def openqa_clone(
 ):
     cmd = ["openqa-clone-job"] + default_opts + cmds + default_cmds
     json_res = call(cmd, dry_run)
-    return json.loads(json_res)
+    try:
+        return json.loads(json_res)
+    except Exception as e:
+        log.error("openqa-clone-job returned non-JSON output: " + str(json_res))
 
 
 def fetch_url(url, request_type="text"):
@@ -327,15 +330,14 @@ def main(args):
             params,
             args.dry_run,
         )
+
         if out["error"] is True:
             openqa_comment(out['failed_id'], out['host'], out['stderr'], args.dry_run)
             sys.exit()
 
         created_job_ids = []
-        try:
-            created_job_ids = json.loads(out).values()
-        except Exception as e:
-            log.error("openqa-clone-job returned non-JSON output: " + out)
+        created_job_ids = out['output'].values()
+
         for job_id in sorted(created_job_ids):
             log.info(f"Created {job_id}")
             created += f"* **{test_name}**: {base_url}/t{job_id}\n"

--- a/tests/test_trigger_bisect_jobs.py
+++ b/tests/test_trigger_bisect_jobs.py
@@ -56,7 +56,7 @@ def mocked_fetch_url(url, request_type="text"):
 
 
 def mocked_call(cmds, dry_run=False):
-    return cmds
+    return json.dumps(cmds)
 
 
 orig_fetch_url = openqa.fetch_url
@@ -144,7 +144,7 @@ def test_set_job_prio():
 def test_triggers():
     args = args_factory()
     args.url = "https://openqa.opensuse.org/tests/7848818"
-    openqa.openqa_clone = MagicMock(return_value='{"7848818": 234567}')
+    openqa.openqa_clone = MagicMock(return_value={"output": {"7848818": 234567}, "error": False})
     openqa.openqa_comment = MagicMock(return_value='')
     openqa.openqa_set_job_prio = MagicMock(return_value='')
     openqa.fetch_url = MagicMock(side_effect=mocked_fetch_url)
@@ -218,7 +218,7 @@ def test_triggers():
     ]
     assert prio_calls == openqa.openqa_set_job_prio.call_args_list
 
-    
+
 def test_problems():
     args = args_factory()
     openqa.openqa_clone = MagicMock(return_value="")

--- a/tests/test_trigger_bisect_jobs.py
+++ b/tests/test_trigger_bisect_jobs.py
@@ -74,17 +74,13 @@ def test_catch_CalledProcessError(caplog):
     args.url = "https://openqa.opensuse.org/tests/7848818"
     openqa.fetch_url = MagicMock(side_effect=mocked_fetch_url)
     expected_err = "foo failed due to subprocess raised CalledProcessError with exit code: 255"
-    # subprocess.check_output = MagicMock(side_effect=subprocess.CalledProcessError(returncode=255,
-    #                                                                               cmd='foo',
-    #                                                                               stderr=expected_err))
+
     with patch("subprocess.check_output",
         side_effect=subprocess.CalledProcessError(returncode=255,
                                                   cmd=cmds[0],
                                                   stderr=expected_err)):
-        with pytest.raises(SystemExit) as exc_info:
+        with pytest.raises(SystemExit) as exc:
             openqa.main(args)
-  
-    assert exc_info.value.code == 255
     assert expected_err in caplog.text
 
 def test_clone():


### PR DESCRIPTION
Wrap the subprocess.check_output inside a try/catch to log a custom error. The check_output run the command which sets check parameter to True and causes the trace output, when the exit code is non-zero.

https://progress.opensuse.org/issues/174601