### PR TITLE
Prevent stack trace from subprocess.check_output

### DIFF
--- a/openqa-trigger-bisect-jobs
+++ b/openqa-trigger-bisect-jobs
@@ -111,7 +111,8 @@ client_args = [
 def call(cmds, dry_run=False):
     log.debug("call: %s" % cmds)
     return subprocess.check_output(
-        (["echo", "Simulating: "] if dry_run else []) + cmds
+        (["echo", "Simulating: "] if dry_run else []) + cmds,
+        stderr=subprocess.STDOUT
     ).decode("utf-8")
 
 
@@ -299,10 +300,19 @@ def main(args):
             ]
         )
 
-        out = openqa_clone(
-            params,
-            args.dry_run,
-        )
+        try:
+            out = openqa_clone(
+                params,
+                args.dry_run,
+            )
+        except subprocess.SubprocessError as err:
+            process_output = err.output if err.output else ""
+            log.error(f"{type(err).__name__}: {process_output} ")
+            if 'the repositories for the below updates are unavailable' not in str(process_output):
+                raise
+            else:
+                sys.exit(0)
+
         created_job_ids = []
         try:
             created_job_ids = json.loads(out).values()

--- a/tests/test_trigger_bisect_jobs.py
+++ b/tests/test_trigger_bisect_jobs.py
@@ -7,9 +7,11 @@ import importlib.machinery
 import importlib.util
 import json
 import os.path
-from unittest.mock import MagicMock, call
+import sys
+from unittest.mock import MagicMock, call, patch
 from urllib.parse import urlparse
 
+import pytest
 import requests
 
 rootpath = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -66,6 +68,31 @@ cmds = [
     "OPENQA_INVESTIGATE_ORIGIN=https://openqa.opensuse.org/tests/7848818",
 ]
 
+def test_catch_CalledProcessError(caplog):
+    import subprocess
+    args = args_factory()
+    args.url = "https://openqa.opensuse.org/tests/7848818"
+    openqa.fetch_url = MagicMock(side_effect=mocked_fetch_url)
+    cmd_args = ["openqa-clone-job"]
+    exp_err = "returned non-zero exit status 255."
+    with patch("subprocess.check_output",
+        side_effect=subprocess.CalledProcessError(returncode=255,
+                                                  cmd=cmd_args,
+                                                  output=exp_err)):
+        with pytest.raises(subprocess.CalledProcessError) as e:
+            openqa.main(args)
+    assert(e.value.returncode == 255)        
+    assert f"CalledProcessError: {exp_err}" in caplog.text
+
+    exp_err = "Current job 7848818 will fail, because the repositories for the below updates are unavailable"
+    with patch("subprocess.check_output",
+        side_effect=subprocess.CalledProcessError(returncode=255,
+                                                  cmd=cmd_args,
+                                                  output=exp_err)):
+        with pytest.raises(SystemExit) as e:
+            openqa.main(args)
+    assert(e.value.code == 0)        
+    assert f"CalledProcessError: {exp_err}" in caplog.text
 
 def test_clone():
     openqa.call = MagicMock(side_effect=mocked_call)


### PR DESCRIPTION
This commit makes sure that the python stack trace is handled appropiately in main function, and logs the error neverthless, for easy tracking. It uses SubprocessError is order to get a general variaty of exceptions from subprocess.

https://progress.opensuse.org/issues/174601