### PR TITLE
Ensure staging project is still cleared on errors in auto submit script

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -198,10 +198,12 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 (
     cd "$TMPDIR"
+    rc=0
     auto_submit_packages=${packages:-$($osc ls "$dst_project" | grep -v '\-test$')}
     for package in $auto_submit_packages; do
-        handle_auto_submit "$package"
+        handle_auto_submit "$package" || rc=$?
         # delete package from staging project
         [[ $from_staging ]] && $osc rdelete -m "Cleaning up $package from $staging_project for next submission" "$staging_project" "$package"
     done
+    exit "$rc"
 )


### PR DESCRIPTION
* Delete the staging project if the submission ran into an error, e.g. because the build failed
* Continue with the next package; a build failure in one package doesn't mean we cannot submit other packages
    * Note that for *consistently* only submitting all or no packages we would need to to the error checking upfront.
* See https://progress.opensuse.org/issues/178102