### PR TITLE
Exit trigger_jobs when clone fails

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -53,7 +53,7 @@ clone() {
     base_prio=$(echo "$clone_job_data" | runjq -r '.job.priority') || return $?
     clone_settings=('_TRIGGER_JOB_DONE_HOOK=1' "_GROUP_ID=$investigation_gid" 'BUILD=')
     if [[ $refspec ]]; then
-        vars_json=$(fetch-vars-json "$origin")
+        vars_json=$(fetch-vars-json "$origin") || return $?
         testgiturl=$(echo "$vars_json" | runjq -r '.TEST_GIT_URL')
         casedir=$(echo "$clone_job_data" | runjq -r '.job.settings.CASEDIR') || return $?
         if [[ $testgiturl != null ]]; then
@@ -81,7 +81,7 @@ clone() {
     # shellcheck disable=SC2207
     clone_settings+=($(echo "$clone_job_data" | runjq -r '.job.settings | keys[] | select (startswith("PUBLISH_")) | . + "=none"')) || return $?
     clone_settings+=("OPENQA_INVESTIGATE_ORIGIN=$host_url/t$origin")
-    out=$($clone_call "$host_url/tests/$id" "${clone_settings[@]}")
+    out=$($clone_call "$host_url/tests/$id" "${clone_settings[@]}") || return $?
     if [[ $dry_run = 1 ]]; then
         echo "$out"
         out="{ \"$origin\": 42}"
@@ -103,7 +103,7 @@ clone() {
 trigger_jobs() {
     id="${1:?"Need 'job_id'"}"
     # for 1. current job/build + current test -> check if reproducible/sporadic
-    clone "$id" "$id" 'retry' '' "${@:2}"
+    clone "$id" "$id" 'retry' '' "${@:2}" || return $?
 
     job_url="$host_url/tests/$id"
     investigation=$(runcurl "${curl_args[@]}" -sS "$job_url"/investigation_ajax) || return $?
@@ -132,7 +132,7 @@ trigger_jobs() {
         # efficient and also needing to know which git repo to use
         #refspec_arg="TEST_GIT_REFSPEC=$last_good_tests"
         refspec_arg=$last_good_tests
-        clone "$id" "$id" "last_good_tests:$last_good_tests" "$refspec_arg" "${@:2}"
+        clone "$id" "$id" "last_good_tests:$last_good_tests" "$refspec_arg" "${@:2}" || return $?
     fi
 
     # 3. last good job/build + current test -> check for product regression
@@ -145,7 +145,7 @@ trigger_jobs() {
         # here we clone with unspecified test refspec, i.e. this could be a
         # more recent tests version. As an alternative we could explicitly
         # checkout the git version from "first bad"
-        clone "$id" "$last_good" "last_good_build:$last_good_build" '' "${@:2}"
+        clone "$id" "$last_good" "last_good_build:$last_good_build" '' "${@:2}" || return $?
     fi
 
     # 4. last good job/build + last good test -> check for other problem
@@ -155,7 +155,7 @@ trigger_jobs() {
     elif [[ -z $last_good_build ]]; then
         echo "No product regression expected. Not triggered 'good build+test' as it would be the same as 2., current build + good test"
     else
-        clone "$id" "$last_good" "last_good_tests_and_build:$last_good_tests+$last_good_build" "$refspec_arg" "${@:2}"
+        clone "$id" "$last_good" "last_good_tests_and_build:$last_good_tests+$last_good_build" "$refspec_arg" "${@:2}" || return $?
     fi
 }
 


### PR DESCRIPTION
My previous change f78111e adding `|| return $?` after `trigger_jobs` resulted in calls inside of that not being fatal anymore, so we have to check those calls explicitly now.

Specifically the clone was failing because of those jobs:

    Current job ... will fail, because the repositories for the below updates are unavailable

And for those it created investigation comments with empty ids, because it
never cloned anything and the ids were empty.

Issue: https://progress.opensuse.org/issues/180065