### PR TITLE
Use latest project version for submit_target_extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           python --version
           pytest --version
       - run: |
-          sudo apt-get install cpanminus html-xml-utils
+          sudo apt-get install cpanminus html-xml-utils xmlstarlet
           sudo cpanm -n -M https://cpan.metacpan.org --installdeps .
       - name: unit- and integration tests
         run: |

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -7,7 +7,7 @@ src_project=${src_project:-devel:openQA}
 dst_project=${dst_project:-${src_project}:tested}
 staging_project=${staging_project:-${src_project}:testing}
 submit_target="${submit_target:-"openSUSE:Factory"}"
-submit_target_extra="${submit_target_extra:-"openSUSE:Backports:SLE-15-SP6:Update"}"
+submit_target_extra_project="${submit_target_extra_project:-"openSUSE:Backports"}"
 dry_run="${dry_run:-"0"}"
 osc_poll_interval="${osc_poll_interval:-2}"
 osc_build_start_poll_tries="${osc_build_start_poll_tries:-30}"
@@ -16,8 +16,20 @@ XMLSTARLET=$(command -v xmlstarlet || true)
 [[ -n $XMLSTARLET ]] || (echo "Need xmlstarlet" && exit 1)
 
 # shellcheck source=/dev/null
-. "$(dirname "$0")"/_common
+. "$(dirname "${BASH_SOURCE[0]}")"/_common
 
+get_submit_target_extra_latest_version() {
+    # awk iterates through all the fields in the match to avoid fixed position
+    # and it should match with the part which starts with `submit_target_extra_project`+`:`
+    latest_submit_target_extra_version=$(osc dists | grep "$submit_target_extra_project" | awk -v prj="$submit_target_extra_project" '{for (i=1; i<=NF; i++) if ($i ~ "^" prj ":") print $i}' | sort --version-sort | tail -n 1)
+    if [[ -z $latest_submit_target_extra_version ]]; then
+        echo "Project not found." && return 1
+    fi
+    # Notice that the :Update doesn't come from osc output
+    echo "$latest_submit_target_extra_version:Update"
+}
+
+submit_target_extra="{submit_target_extra:-get_submit_target_extra_latest_version}"
 IFS=',' read -ra targets <<< "$submit_target,$submit_target_extra"
 failed_packages=()
 
@@ -96,6 +108,7 @@ update_package() {
     wait_for_package_build "$submit_target"
     for target in "${targets[@]}"; do
         cmd="$osc sr"
+        echo "## Ready to submit $package to $target ##"
         req=$(get_obs_sr_id "$target" "$dst_project" "$package" || :)
         # TODO: check if it's a different revision than HEAD
         if test -n "$req"; then

--- a/test/08-os-autoinst-obs-auto-submit.t
+++ b/test/08-os-autoinst-obs-auto-submit.t
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+source test/init
+bpan:source bashplus +err +fs +sym
+
+plan tests 6
+source os-autoinst-obs-auto-submit
+
+submit_target_extra_project="openSUSE:Backports"
+osc_dists_output='
+openSUSE Backports for SLE 15 SP6 openSUSE:Backports:SLE-15-SP6 15.6 standard
+openSUSE Backports for SLE 15 SP5 openSUSE:Backports:SLE-15-SP5 15.5 standard
+openSUSE Backports for SLE 15 SP6:Update  openSUSE:Backports:SLE-15-SP6:Update:GA 1.0 standard 
+openSUSE Backports for SLE 15 SP4 openSUSE:Backports:SLE-15-SP4 15.4 standard'
+
+osc() {
+    if [[ "$1" == "dists" ]]; then
+        echo "$osc_dists_output"
+        return 0
+    else
+        echo "Not mocked 'osc' call:" "$@" >&2
+        return 1
+    fi
+}
+
+try get_submit_target_extra_latest_version
+is "$rc" 0 "rc should be 0"
+is "$got" "openSUSE:Backports:SLE-15-SP6:Update" "the latest version is used from the osc dists output"
+
+osc_dists_output=''
+try get_submit_target_extra_latest_version
+is "$rc" 1 "rc should be 1"
+is "$got" "Project not found." "Error if project no match any from osc dists output"
+
+osc_dists_output='
+openSUSE Backports for SLE 15 SP6 openSUSE:Backports:SLE-15-SP6 15.6 standard
+openSUSE Backports for SLE 15 SP7 openSUSE:Backports:SLE-17-SP5 17.5 standard
+openSUSE Backports for SLE 15 SP6:Update  openSUSE:Backports:SLE-15-SP6:Update:GA 1.0 standard
+openSUSE Backports for SLE 15 SP4 openSUSE:Backports:SLE-15-SP4 15.4 standard'
+
+try get_submit_target_extra_latest_version
+is "$rc" 0 "rc should be 0"
+is "$got" "openSUSE:Backports:SLE-17-SP5:Update" "the latest version is used from the osc dists output comparing the major version"


### PR DESCRIPTION
Try to find through osc the latest version of a project inn order to determine
the final destination of the submit request for `submit_target_extra`.

related issue: https://progress.opensuse.org/issues/127037