### PR TITLE
Add back default Backports target for submit_target_extra

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -7,7 +7,7 @@ src_project=${src_project:-devel:openQA}
 dst_project=${dst_project:-${src_project}:tested}
 staging_project=${staging_project:-${src_project}:testing}
 submit_target="${submit_target:-"openSUSE:Factory"}"
-submit_target_extra="${submit_target_extra:-}"
+submit_target_extra="${submit_target_extra:-"openSUSE:Backports:SLE-15-SP6:Update"}"
 dry_run="${dry_run:-"0"}"
 osc_poll_interval="${osc_poll_interval:-2}"
 osc_build_start_poll_tries="${osc_build_start_poll_tries:-30}"
@@ -93,8 +93,8 @@ update_package() {
     sed -i -e 's/^  \* $/  * Update to latest openQA version/' ./*.changes
     $osc ci -m "Offline generation of ${version}" $ci_args
     rc=0
+    wait_for_package_build "$submit_target"
     for target in "${targets[@]}"; do
-        wait_for_package_build "$target"
         cmd="$osc sr"
         req=$(get_obs_sr_id "$target" "$dst_project" "$package" || :)
         # TODO: check if it's a different revision than HEAD


### PR DESCRIPTION
Essentially revert the revert by
https://github.com/os-autoinst/scripts/pull/392/files and apply the fix for the jenkins[0].
The problem had been spotted and the fix was already applied in https://github.com/os-autoinst/scripts/pull/390 but it didnt make it to the production before the revert.

[0] https://progress.opensuse.org/issues/180866