### PR TITLE
openqa-trigger-bisect-jobs: Also evaluate "exclude_name_regex"

### DIFF
--- a/openqa-trigger-bisect-jobs
+++ b/openqa-trigger-bisect-jobs
@@ -264,6 +264,11 @@ def main(args):
         if re.search(exclude_group_regex, full_group):
             return
 
+    exclude_name_regex = os.environ.get("exclude_name_regex", "")
+    if len(exclude_name_regex) > 0 and re.search(exclude_name_regex, job["test"]):
+        log.debug("job name '%s' matches 'exclude_name_regex', skipping" % job["test"])
+        return
+
     log.debug("Received job data: %s" % test_data)
     test = job["settings"]["TEST"]
     prio = int(job["priority"]) + args.priority_add

--- a/openqa-trigger-bisect-jobs
+++ b/openqa-trigger-bisect-jobs
@@ -262,6 +262,7 @@ def main(args):
         if "parent_group" in job:
             full_group = "%s / %s" % (job["parent_group"], full_group)
         if re.search(exclude_group_regex, full_group):
+            log.debug("job group '%s' matches 'exclude_group_regex', skipping" % full_group)
             return
 
     exclude_name_regex = os.environ.get("exclude_name_regex", "")

--- a/tests/test_trigger_bisect_jobs.py
+++ b/tests/test_trigger_bisect_jobs.py
@@ -24,9 +24,6 @@ spec = importlib.util.spec_from_loader(loader.name, loader)
 openqa = importlib.util.module_from_spec(spec)
 loader.exec_module(openqa)
 
-# should only affect test_exclude_group_regex() as it does not match other tests
-os.environ["exclude_group_regex"] = "s.*parent?-group / some-.*"
-
 Incident = openqa.Incident
 
 
@@ -301,10 +298,25 @@ def test_exclude_group_regex():
     args = args_factory()
     openqa.openqa_clone = MagicMock(return_value="")
     openqa.fetch_url = MagicMock(side_effect=mocked_fetch_url)
+    # should only affect test_exclude_group_regex() as it does not match other tests
+    os.environ["exclude_group_regex"] = "s.*parent?-group / some-.*"
 
     args.url = "http://openqa.opensuse.org/tests/123457"
     openqa.main(args)
     openqa.openqa_clone.assert_not_called()
+    del os.environ["exclude_group_regex"]
+
+
+def test_exclude_name_regex():
+    args = args_factory()
+    openqa.openqa_clone = MagicMock(return_value="")
+    openqa.fetch_url = MagicMock(side_effect=mocked_fetch_url)
+
+    os.environ["exclude_name_regex"] = "with.*group"
+    args.url = "http://openqa.opensuse.org/tests/123457"
+    openqa.main(args)
+    openqa.openqa_clone.assert_not_called()
+    del os.environ["exclude_name_regex"]
 
 
 def test_exclude_investigated():


### PR DESCRIPTION
It was observed that openqa-trigger-bisect-jobs were triggered even
though according openqa-investigate jobs were not as the variable
"exclude_name_regex" would exclude the job. However unlike
"exclude_group_regex" the variable "exclude_name_regex"  so far
was only evaluated within openqa-investigate, not
openqa-trigger-bisect-jobs. This commit adds according handling within
openqa-trigger-bisect-jobs with according unit test.