### PR TITLE
openqa-investigate: Allow to overwrite 'host_url' as well

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -11,7 +11,7 @@ set -euo pipefail
 
 host="${host:-"openqa.opensuse.org"}"
 scheme="${scheme:-"https"}"
-host_url="$scheme://$host"
+host_url=${host_url:-"$scheme://$host"}
 investigation_gid=${investigation_gid:-0}
 dry_run="${dry_run:-"0"}"
 verbose="${verbose:-"false"}"


### PR DESCRIPTION
The variable 'host_url' helps to be set e.g. in case one wants to call
with HTTP-only