### PR TITLE
Remove investigation comment on job when clone fail

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -374,7 +374,15 @@ investigate() {
     comment_id=$(sync_via_investigation_comment "$id" "$first_cluster_job_id") || rc=$?
     [[ $rc != 255 ]] && return $rc
 
-    out=$(trigger_jobs "$id" "${@:2}") || return $?
+    out=""
+    if ! out=$(trigger_jobs "$id" "${@:2}" 2>&1); then
+        local comment="Triggering investigation jobs failed: $out"
+        echoerr "Unexpected error encountered when trigger job $id: '$out'"
+        client-put-job-comment "$first_cluster_job_id" "$comment_id" "$comment"
+        return 1
+    fi
+
+    echo "$out"
     $verbose && echo "$0, id: '$id', out: '$out'"
     finalize_investigation_comment "$id" "$first_cluster_job_id" "$comment_id" "$out"
 }


### PR DESCRIPTION
When the clone fails the script update the comment of the investigation with an alert and the motivation of the failure:

![image](https://github.com/user-attachments/assets/eec2cc32-32c3-45df-b1b2-7f586d9db911)


reference: https://progress.opensuse.org/issues/180218