### PR TITLE
Log number of current retry instead of the maximum

### DIFF
--- a/_common
+++ b/_common
@@ -78,7 +78,7 @@ exp_retry() {
         return 1
     fi
     wait_sec=$((2 ** exponent))
-    warn "Waiting ${wait_sec}s until retry #${stop_exponent}"
+    warn "Waiting ${wait_sec}s until retry #${exponent}"
     sleep "$wait_sec"
 }
 


### PR DESCRIPTION
stop_exponent is the maximum number of retries, so we are currently always logging the same number instead of the actual current number.

I found this while looking into the o3 gru journal
```
May 07 04:38:03 ariel openqa-gru[10868]: Waiting 1s until retry #12
May 07 04:38:09 ariel openqa-gru[10868]: curl (187 /opt/os-autoinst-scripts/openqa-label-known-issues): ...
May 07 04:38:09 ariel openqa-gru[10868]: Waiting 2s until retry #12
May 07 04:38:16 ariel openqa-gru[10868]: curl (187 /opt/os-autoinst-scripts/openqa-label-known-issues): ...
May 07 04:38:16 ariel openqa-gru[10868]: Waiting 4s until retry #12
May 07 04:38:25 ariel openqa-gru[10868]: curl (187 /opt/os-autoinst-scripts/openqa-label-known-issues): ...
May 07 04:38:25 ariel openqa-gru[10868]: Waiting 8s until retry #12
May 07 04:38:38 ariel openqa-gru[10868]: curl (187 /opt/os-autoinst-scripts/openqa-label-known-issues): ...
May 07 04:38:38 ariel openqa-gru[10868]: Waiting 16s until retry #12
```