### PR TITLE
monitor-openqa_job: Retry on openQA connect error

### DIFF
--- a/monitor-openqa_job
+++ b/monitor-openqa_job
@@ -18,7 +18,7 @@ obs_component="${obs_component:-"package"}"
 obs_package_name="${1:-""}"
 staging_project=${staging_project:-devel:openQA:testing}
 comment_on_obs=${comment_on_obs:-}
-OPENQA_CLI_RETRIES="${OPENQA_CLI_RETRIES:-7}"
+OPENQA_CLI_RETRIES="${openqa_cli_retries:-7}"
 
 export OPENQA_CLI_RETRIES
 

--- a/monitor-openqa_job
+++ b/monitor-openqa_job
@@ -18,6 +18,9 @@ obs_component="${obs_component:-"package"}"
 obs_package_name="${1:-""}"
 staging_project=${staging_project:-devel:openQA:testing}
 comment_on_obs=${comment_on_obs:-}
+OPENQA_CLI_RETRIES="${OPENQA_CLI_RETRIES:-7}"
+
+export OPENQA_CLI_RETRIES
 
 # shellcheck source=/dev/null
 . "$(dirname "$0")"/_common


### PR DESCRIPTION
This commits adds retrying of openQA API calls on connect errors using
the openqa-cli built-in retry feature preventing a premature exit of
monitor-openqa_job on spurious errors looking like this:

```
00:00:00.036819 00:00:00.019101 +(./monitor-openqa_job:31): main(): for job_id in $(job_ids job_post_response)
00:00:00.036854 00:00:00.000035 +(./monitor-openqa_job:32): main(): echo 'Waiting for job 5061967 to finish'
00:00:00.036866 00:00:00.000011 Waiting for job 5061967 to finish
00:00:00.036876 00:00:00.000007 +(./monitor-openqa_job:33): main(): sleep 10
00:00:10.041811 00:00:10.004827 ++(./monitor-openqa_job:34): main(): openqa-cli api --host https://openqa.opensuse.org jobs/5061967
00:00:10.041886 00:00:00.000109 ++(./monitor-openqa_job:34): main(): jq -r .job.state
00:00:40.238207 00:00:30.196335 Request failed, hit error 0, retrying up to 7 more times after waiting … (delay: 3; waited 30s)
00:01:13.268280 00:00:33.030040 Request failed, hit error 0, retrying up to 6 more times after waiting … (delay: 3; waited 63s)
```

This is only handling retries on errors. The looping using a 10s period
is unaltered.

Related progress issue: https://progress.opensuse.org/issues/182471