### PR TITLE
Fix expansion for submit_target_extra

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -29,7 +29,7 @@ get_submit_target_extra_latest_version() {
     echo "$latest_submit_target_extra_version:Update"
 }
 
-submit_target_extra="{submit_target_extra:-get_submit_target_extra_latest_version}"
+submit_target_extra=${submit_target_extra:-$(get_submit_target_extra_latest_version)}
 IFS=',' read -ra targets <<< "$submit_target,$submit_target_extra"
 failed_packages=()
 

--- a/test/08-os-autoinst-obs-auto-submit.t
+++ b/test/08-os-autoinst-obs-auto-submit.t
@@ -4,7 +4,6 @@ source test/init
 bpan:source bashplus +err +fs +sym
 
 plan tests 6
-source os-autoinst-obs-auto-submit
 
 submit_target_extra_project="openSUSE:Backports"
 osc_dists_output='
@@ -22,6 +21,7 @@ osc() {
         return 1
     fi
 }
+source os-autoinst-obs-auto-submit
 
 try get_submit_target_extra_latest_version
 is "$rc" 0 "rc should be 0"


### PR DESCRIPTION
First the expansion is missing $ at the beginning and it makes it assign the expression as a string. Additional ensure that the get_submit_target_extra_latest_version is called as code and returns its value.

https://progress.opensuse.org/issues/127037