### PR TITLE
Pick latest version only when Update path exists

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -21,7 +21,16 @@ XMLSTARLET=$(command -v xmlstarlet || true)
 get_submit_target_extra_latest_version() {
     # awk iterates through all the fields in the match to avoid fixed position
     # and it should match with the part which starts with `submit_target_extra_project`+`:`
-    latest_submit_target_extra_version=$(osc dists | grep "$submit_target_extra_project" | awk -v prj="$submit_target_extra_project" '{for (i=1; i<=NF; i++) if ($i ~ "^" prj ":") print $i}' | sort --version-sort | tail -n 1)
+    version_sorted=$(osc dists | grep "$submit_target_extra_project" | awk -v prj="$submit_target_extra_project" '{for (i=1; i<=NF; i++) if ($i ~ "^" prj ":") print $i}' | sort --version-sort | tac)
+    latest_submit_target_extra_version=''
+    for version in $version_sorted; do
+        # dont need the XML output for checking existence.
+        # if $prj does not exist return 404
+        if osc meta prj "${version}:Update" > /dev/null 2>&1; then
+            latest_submit_target_extra_version=$version && break
+        fi
+    done
+
     if [[ -z $latest_submit_target_extra_version ]]; then
         echo "Project not found." && return 1
     fi

--- a/test/08-os-autoinst-obs-auto-submit.t
+++ b/test/08-os-autoinst-obs-auto-submit.t
@@ -16,6 +16,19 @@ osc() {
     if [[ "$1" == "dists" ]]; then
         echo "$osc_dists_output"
         return 0
+    elif [[ "$1" == "meta" ]]; then
+        val="$3"
+        case "${val}" in
+            "openSUSE:Backports:SLE-15-SP6:Update")
+                return 0
+                ;;
+            "openSUSE:Backports:SLE-17-SP5:Update")
+                return 0
+                ;;
+            *)
+                return 1
+                ;;
+        esac
     else
         echo "Not mocked 'osc' call:" "$@" >&2
         return 1


### PR DESCRIPTION
Use the `osc repo` in comnination with `osc dists` to submit to the most recent :Update repo. Likely no need for more than two distribution to find the desired one.

https://progress.opensuse.org/issues/127037

## Summary by Sourcery

Use `osc repo`, `osc dists`, and `osc meta` to detect and submit to the latest :Update repository, scanning only the two most recent distributions.

Enhancements:
- Integrate `osc meta` checks into the submission workflow to verify availability of Update repos before submission.
- Limit distribution version scanning to the two most recent service pack releases for performance and predictability.

Tests:
- Mock `osc meta` responses for openSUSE:Backports:SLE-15-SP6:Update and SLE-17-SP5:Update to ensure correct path selection.
- Enhance the `osc()` test stub to return success only for the specified Update repositories and failure otherwise.