### PR TITLE
Revert "Potentially improve os-autoinst-obs-auto-submit with "osc sr --cleanup""

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -123,11 +123,6 @@ update_package() {
         if test -n "$req"; then
             cmd="$cmd -s $req"
         fi
-        # Cleanup submissions after acceptance for next call on :tested
-        # projects, e.g. devel:openQA:tested
-        if osc info | grep -q "Project name:.*:tested"; then
-            cmd="$cmd --cleanup"
-        fi
         if ! $cmd -m "Update to ${version}" "$target"; then
             rc=$?
             failed_packages+=("$package:$rc")


### PR DESCRIPTION
Reverts os-autoinst/scripts#408 as we create multiple submissions from the same source and must not remove the source before all submissions are accepted. As an example https://build.opensuse.org/request/show/1283681 was accepted to Factory causing https://build.opensuse.org/request/show/1283682 to a maintenance project to be revoked.

## Summary by Sourcery

Revert the `osc sr --cleanup` invocation to avoid prematurely deleting submission sources before all maintenance requests complete.

Bug Fixes:
- Prevent removal of the package source after the first submission to ensure subsequent submissions are not revoked

Chores:
- Undo the cleanup behavior introduced in the previous commit