### PR TITLE
Fix project name for Leap submission

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -19,7 +19,7 @@ XMLSTARLET=$(command -v xmlstarlet || true)
 . "$(dirname "${BASH_SOURCE[0]}")"/_common
 
 # Use fixed Backport version for now
-submit_target_extra=${submit_target_extra:-"openSUSE:Backports:SLE-15-SP6:Update,Leap:16.0"}
+submit_target_extra=${submit_target_extra:-"openSUSE:Backports:SLE-15-SP6:Update,openSUSE:Leap:16.0"}
 IFS=',' read -ra targets <<< "$submit_target,$submit_target_extra"
 failed_packages=()
 


### PR DESCRIPTION
https://progress.opensuse.org/issues/127037

## Summary by Sourcery

Bug Fixes:
- Fix project name used for Leap submissions in os-autoinst-obs-auto-submit