### PR TITLE
Adjust search criteria to also find Maintenance requests

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -34,7 +34,7 @@ get_obs_sr_id() {
     local package=$3
     local states actions
     states=$(encode_variable "state/@name='declined' or state/@name='new' or state/@name='review'")
-    actions=$(encode_variable "action/target/@project='$target' and action/source/@project='$dst_project' and action/target/@package='$package'")
+    actions=$(encode_variable "action/target/@project='$target' and action/source/@project='$dst_project' and action/source/@package='$package'")
     $osc api "/search/request/id?match=($states)%20and%20($actions)" | xmlstarlet sel -t -v "/collection/request/@id"
 }
 


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/184210

Maintenance requests have the package in `<source>` but not in `<target>`:
```
<source project="devel:openQA:tested" package="os-autoinst" rev="1371263c05ece850ff83c4386e79f097"/>
<target project="openSUSE:Maintenance" releaseproject="openSUSE:Backports:SLE-15-SP6:Update"/>
```
While Factory has it in both, that's why it was working so far:
```
<source project="devel:openQA:tested" package="os-autoinst" rev="1371263c05ece850ff83c4386e79f097"/>
<target project="openSUSE:Factory" package="os-autoinst"/>
```
## Summary by Sourcery

Bug Fixes:
- Fix omission of maintenance requests by adjusting the search criteria to use the package in <source> when <target> lacks a package attribute