### PR TITLE
Further adjust search target for Maintenance requests

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -32,6 +32,9 @@ get_obs_sr_id() {
     local target=$1
     local dst_project=$2
     local package=$3
+    # The project in the request target will be different than the original
+    # submit target for Backport requests
+    [[ $target =~ Backports ]] && target="openSUSE:Maintenance"
     local states actions
     states=$(encode_variable "state/@name='declined' or state/@name='new' or state/@name='review'")
     actions=$(encode_variable "action/target/@project='$target' and action/source/@project='$dst_project' and action/source/@package='$package'")


### PR DESCRIPTION
When we submit to the target `openSUSE:Backports:SLE-15-SP6:Update`, the target project in the resulting request will be `openSUSE:Maintenance`.

Issue: https://progress.opensuse.org/issues/184210

## Summary by Sourcery

Bug Fixes:
- Fix mapping so that submitting to openSUSE:Backports:SLE-15-SP6:Update targets openSUSE:Maintenance as intended