### PR TITLE
Only create staging area for regular Factory submission jobs

### DIFF
--- a/trigger-openqa_in_openqa
+++ b/trigger-openqa_in_openqa
@@ -35,7 +35,14 @@ main() {
     local qcow build
     download_scenario
     download_latest_published_tumbleweed_image
-    create_devel_openqa_snapshot
+
+    #  Only use devel:openQA:testing for the hourly runs which we monitor
+    # and use for submit requests
+    if [[ $full_run ]]; then
+        staging_project=$src_project
+    else
+        create_devel_openqa_snapshot
+    fi
     trigger
 }
 


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/178105

Right now the full run runs daily and will create devel:openQA:testing but never delete it afterwards.

We don't use the results for anything, so they can just run on devel:openQA

## Summary by Sourcery

Limit staging area creation to only regular Factory submission jobs and reuse the main devel:openQA project for full daily runs.

Enhancements:
- Only create the devel:openQA:testing staging project for regular Factory submissions
- Point full daily runs at devel:openQA instead of creating an unused staging project