### PR TITLE
Move staging package deletion into loop

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -230,9 +230,9 @@ submit() {
         auto_submit_packages=$(get_project_packages)
         for package in $auto_submit_packages; do
             handle_auto_submit "$package" || rc=$?
+            # delete package from staging project
+            [[ $must_cleanup_staging ]] && $osc rdelete -m "Cleaning up $package from $staging_project for next submission" "$staging_project" "$package"
         done
-        # delete package from staging project
-        [[ $must_cleanup_staging ]] && $osc rdelete -m "Cleaning up $package from $staging_project for next submission" "$staging_project" "$package"
         if [[ ${#failed_packages[@]} -gt 0 ]]; then
             echo "Failed packages:"
             for item in "${failed_packages[@]}"; do


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/178105

Otherwise it would delete only the last package from the loop.

This bug was introduced in 360f247977c724e7b4aed8fd71b0fcb11e48e2e4