### PR TITLE
Add loglevel support and colors for better readability

### DIFF
--- a/_common
+++ b/_common
@@ -4,6 +4,7 @@
 # instances, for example over openqa-cli.
 
 errorlog=""
+osc=${osc:-osc}
 
 warn() { printf '%s\n' "$@" >&2; }
 
@@ -348,14 +349,62 @@ get-dependencies-ajax() {
 
 list_packages() {
     local obs_project=$1
-    osc ls "$obs_project" | grep -v '\-test$'
+    $osc ls "$obs_project" | grep -v '\-test$'
 }
 
 delete_packages_from_obs_project() {
+    log-info "delete_packages_from_obs_project()"
     local obs_project=$1
     local packages
     packages=$(list_packages "$obs_project") || true # osc ls returns non-zero return code for empty projects
     for package in $packages; do
-        osc rdelete -m "Cleaning up $package to allow triggering new jobs" "$obs_project" "$package"
+        log-info "Deleting $package from $obs_project"
+        $osc rdelete -m "Cleaning up $package to allow triggering new jobs" "$obs_project" "$package"
     done
+}
+
+declare _COLOR_BOLD='\x1b[1m'
+declare _COLOR_RED='\x1b[31m'
+declare _COLOR_GREEN='\x1b[32m'
+declare _COLOR_CYAN='\x1b[36m'
+declare _COLOR_PURPLE='\x1b[35m'
+declare _COLOR_YELLOW='\x1b[33m'
+declare _COLOR_DARKGRAY='\x1b[90m'
+declare _COLOR_INFO="$_COLOR_CYAN$_COLOR_BOLD"
+declare _COLOR_WARNING="$_COLOR_YELLOW$_COLOR_BOLD"
+declare _COLOR_ERROR="$_COLOR_RED$_COLOR_BOLD"
+declare _NO_COLOR='\x1b[0m'
+
+color=${color:-auto}
+colorize() {
+    local fh=$1
+    local msgcolor="_COLOR_$2"
+    local msg=$3
+    local fn=1
+    [[ $fh == 'err' ]] && fn=2
+    if [[ -t "$fn" && $color == "auto" || $color == "always" ]]; then
+        msg="${!msgcolor}$msg${_NO_COLOR}"
+    fi
+    if [[ $fh == 'err' ]]; then
+        echo -e "$msg" >&2
+    else
+        echo -e "$msg"
+    fi
+}
+
+log-info() {
+    colorize "out" "INFO" "[info] $*"
+}
+
+log-debug() {
+    colorize "err" "DARKGRAY" "[debug] $*"
+}
+
+log-warn() {
+    colorize "err" "WARNING" "[warn] $*"
+}
+
+debug_osc() {
+    log-debug "### osc $*"
+    osc "$@"
 }

--- a/monitor-openqa_job
+++ b/monitor-openqa_job
@@ -10,6 +10,7 @@
 set -euo pipefail
 
 # configuration variables with defaults.
+color=${color:-auto}
 sleep_time="${sleep_time:-"10"}"
 openqa_cli="${openqa_cli:-"openqa-cli"}"
 host="${host:-"https://openqa.opensuse.org"}"
@@ -29,14 +30,14 @@ export OPENQA_CLI_RETRIES
 declare -A failed_versions
 failed_jobs=()
 for job_id in $(job_ids job_post_response); do
-    echo "Waiting for job $job_id to finish"
+    log-info "Waiting for job $job_id to finish"
     while sleep "${sleep_time}"; do
         job_state=$($openqa_cli api --host "$host" jobs/"$job_id" | jq -r '.job.state')
         [[ $job_state = 'done' ]] && break
     done
     response=$($openqa_cli api --host "$host" jobs/"$job_id")
     result=$(echo "$response" | jq -r '.job.result')
-    echo "Result of job $job_id: $result"
+    log-info "Result of job $job_id: $result"
     if [[ $result != 'passed' ]] && [[ -n $obs_package_name ]]; then
         version=$(echo "$response" | jq -r '.job.settings.VERSION')
         failed_versions[$version]=1
@@ -45,10 +46,9 @@ for job_id in $(job_ids job_post_response); do
 done
 
 ((${#failed_jobs[@]} > 0)) || exit 0
-
-echo "${#failed_jobs[@]} jobs did not pass:"
+log-warn "${#failed_jobs[@]} jobs did not pass:"
 for id in "${failed_jobs[@]}"; do
-    echo "$host/t$id"
+    log-warn "$host/t$id"
 done
 
 # delete packages from staging project in error case as we will not continue submitting those packages
@@ -57,7 +57,7 @@ delete_packages_from_obs_project "$staging_project"
 # comment on failed jobs
 [[ $comment_on_obs ]] || exit 1
 
-echo "Posting comment with failed jobs to OBS"
+log-info "Posting comment with failed jobs to OBS"
 osc api "/comments/$obs_component/$obs_package_name" | grep id= | sed -n 's/.*id="\([^"]*\)">.*test.* failed.*/\1/p' | while read -r id; do
     osc api -X DELETE /comment/"$id"
 done

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 export LC_ALL=C
+color=${color:-auto}
 src_project=${src_project:-devel:openQA}
 dst_project=${dst_project:-${src_project}:tested}
 staging_project=${staging_project:-${src_project}:testing}
@@ -47,6 +48,7 @@ reenable_buildtime_services() {
 
 wait_for_package_build() {
     local target=$1
+    log-info "wait_for_package_build $target"
     target_escaped=$(echo -n "$target" | sed -e 's|\:|_|g') # avoid, e.g. "repoid 'openSUSE:Factory' is illegal"
     local osc_query="https://api.opensuse.org/public/build/$dst_project/_result?repository=$target_escaped&package=$package"
     local wip_states='\(unknown\|blocked\|scheduled\|dispatching\|building\|signing\|finished\)'
@@ -54,25 +56,26 @@ wait_for_package_build() {
     local attempts="$osc_build_start_poll_tries"
     while ! curl -sS "$osc_query" | grep -e "$wip_states"; do
         if [[ $attempts -le 0 ]]; then
-            echo "warning: Re-build of $package has not been considered in time (or package has been re-built so fast that we've missed it)"
+            log-warn "Re-build of $package has not been considered in time (or package has been re-built so fast that we've missed it)"
             break
         fi
-        echo "Waiting for re-build of $package to be considered (attempts left: $attempts)"
+        log-info "Waiting for re-build of $package to be considered (attempts left: $attempts)"
         sleep "$osc_poll_interval"
         attempts=$((attempts - 1))
     done
     while curl -sS "$osc_query" | grep -e "$wip_states"; do
-        echo "Waiting while $package is in progress"
+        log-info "Waiting while $package is in progress"
         sleep "$osc_poll_interval"
     done
     if curl -sS "$osc_query" | grep -e "$bad_states"; then
-        echo "Building $package has failed, skipping submission"
+        log-info "Building $package has failed, skipping submission"
         return 1
     fi
 }
 
 update_package() {
-    package=$1
+    log-info "update_package $*"
+    local package=$1
     xmlstarlet ed -L -i "/services/service" --type attr -n mode --value 'disabled' _service
     sed -i -e 's,mode="disabled" mode="disabled",mode="disabled",' _service
     reenable_buildtime_services
@@ -94,12 +97,13 @@ update_package() {
     # We would get an empty changelog when there are no changes to files contained
     # in this package/container. So add some text.
     sed -i -e 's/^  \* $/  * Update to latest openQA version/' ./*.changes
+    $osc status
     $osc ci -m "Offline generation of ${version}" $ci_args
     rc=0
     wait_for_package_build "$submit_target"
     for target in "${targets[@]}"; do
         cmd="$osc sr"
-        echo "## Ready to submit $package to $target ##"
+        log-info "## Ready to submit $package to $target ##"
         req=$(get_obs_sr_id "$target" "$dst_project" "$package" || :)
         # TODO: check if it's a different revision than HEAD
         if test -n "$req"; then
@@ -114,10 +118,11 @@ update_package() {
 }
 
 last_revision() {
-    project=$1
-    package=$2
-    file=$package.changes
-    service=obs_scm
+    log-info "last_revision $*"
+    local project=$1
+    local package=$2
+    local file=$package.changes
+    local service=obs_scm
     if [[ $project != "$submit_target" ]]; then
         file=_service:$service:$file
     fi
@@ -133,9 +138,10 @@ last_revision() {
 }
 
 sync_changesrevision() {
-    dir=$1
-    package=$2
-    target_rev=$3
+    log-info "sync_changesrevision $*"
+    local dir=$1
+    local package=$2
+    local target_rev=$3
     path="$dir/$package"
     $prefix xmlstarlet ed -L -u "//param[@name='changesrevision']" -v "$target_rev" "$path"/_servicedata
     if ! diff -u "$path"/.osc/_servicedata "$path"/_servicedata; then
@@ -147,14 +153,15 @@ sync_changesrevision() {
 }
 
 get_spec_changes_in_requirements() {
+    log-info "get_spec_changes_in_requirements $*"
     local package=$1
     local project=$2
     { diff -u "$package-factory.spec" "$project/$package/_service:obs_scm:$package.spec" || :; } | grep '^[+-]Requires'
 }
 
 generate_os-autoinst-distri-opensuse-deps_changelog() {
-    dir=$1
-    package=$2
+    local dir=$1
+    local package=$2
     $osc cat "$submit_target" "$package" "$package".changes > "$package"-factory.changes
     {
         echo "-------------------------------------------------------------------"
@@ -168,7 +175,8 @@ generate_os-autoinst-distri-opensuse-deps_changelog() {
 }
 
 handle_auto_submit() {
-    package=$1
+    log-info "handle_auto_submit $*"
+    local package=$1
     $osc service wait "$src_project" "$package"
     $osc co --server-side-source-service-files "$src_project"/"$package"
     if [[ "$package" == "os-autoinst-distri-opensuse-deps" ]]; then
@@ -177,14 +185,14 @@ handle_auto_submit() {
             # dependency added or removed
             generate_os-autoinst-distri-opensuse-deps_changelog "$src_project" "$package"
         else
-            echo "No dependency changes for $package"
+            log-info "No dependency changes for $package"
             return
         fi
     else
         target_rev=$(last_revision "$submit_target" "$package")
         sync_changesrevision "$src_project" "$package" "$target_rev"
         if [[ "$target_rev" == "$(last_revision "$src_project" "$package")" ]]; then
-            echo "Latest revision already in $submit_target"
+            log-info "Latest revision already in $submit_target"
             return
         fi
     fi
@@ -203,27 +211,29 @@ get_project_packages() {
 }
 
 has_pending_submission() {
-    local out
+    log-info "has_pending_submission()"
+    local requestlist
     # throttle number of submissions to allow only one SR within a certain number of days
     # note: Avoid using `grep --quiet` here to keep consuming input so osc does not run into "BrokenPipeError: [Errno 32] Broken pipe".
     [[ $throttle_days == 0 ]] && return 0
-    out=$($osc request list --project "$dst_project" --type submit --state new,review --mine --days "$throttle_days")
-    if echo "$out" | grep 'Created by' > /dev/null; then
-        echo "Skipping submission, there is still a pending SR younger than $throttle_days days."
-        echo "$out"
+    requestlist=$($osc request list --project "$dst_project" --type submit --state new,review --mine --days "$throttle_days")
+    if echo "$requestlist" | grep 'Created by' > /dev/null; then
+        log-info "Skipping submission, there is still a pending SR younger than $throttle_days days."
+        echo "$requestlist"
         return 1
     fi
     return 0
 }
 
 submit() {
+    log-info "submit()"
     # submit from staging project if specified
     if [[ -n $staging_project && $staging_project != none && $staging_project != "$src_project" ]]; then
         src_project=$staging_project
         must_cleanup_staging=1
     fi
     if [[ -e job_post_skip_submission ]]; then
-        echo "Skipping submission, reason: "
+        log-info "Skipping submission, reason: "
         cat job_post_skip_submission
         return 0
     fi
@@ -238,11 +248,11 @@ submit() {
             [[ $must_cleanup_staging ]] && $osc rdelete -m "Cleaning up $package from $staging_project for next submission" "$staging_project" "$package"
         done
         if [[ ${#failed_packages[@]} -gt 0 ]]; then
-            echo "Failed packages:"
+            log-warn "Failed packages:"
             for item in "${failed_packages[@]}"; do
                 package=${item%:*}
                 exit_status=${item#*:}
-                echo "- $package (exit status: $exit_status)"
+                log-warn "- $package (exit status: $exit_status)"
             done
         fi
         return "$rc"

--- a/test/08-auto-submit.t
+++ b/test/08-auto-submit.t
@@ -18,7 +18,7 @@ _request_list() {
 osc=mock_osc
 source os-autoinst-obs-auto-submit
 
-diag "########### has_pending_submission"
+note "########### has_pending_submission"
 
 throttle_days=0
 try has_pending_submission
@@ -34,4 +34,4 @@ _request_list() {
 }
 try has_pending_submission
 is "$rc" 0 "returns 0 without existing SRs"
-is "$got" "" "no output"
+like "$got" "info.*has_pending_submission" "no output"

--- a/test/09-logging.t
+++ b/test/09-logging.t
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+echo 1..1
+
+color=always
+source _common
+
+log-warn "Demo warning"
+log-info "Demo info" >&2
+log-debug "Demo debug"
+
+echo "ok 1"

--- a/trigger-openqa_in_openqa
+++ b/trigger-openqa_in_openqa
@@ -10,6 +10,7 @@ set -euo pipefail
 . "$(dirname "$0")"/_common
 
 # configuration variables with defaults.
+color=${color:-auto}
 target_host="${target_host:-"openqa.opensuse.org"}"
 target_host_proto="${target_host_proto:-"https"}"
 dry_run="${dry_run:-"0"}"
@@ -66,7 +67,7 @@ download_scenario() {
 
 create_snapshots() {
     local package=$1
-    echo "Creating snapshots of $package"
+    log-info "Creating snapshots of $package"
     $osc release --no-delay --target-project "$staging_project" --target-repository=openSUSE_Tumbleweed -r openSUSE_Tumbleweed -a x86_64 "$src_project" "$package"
 }
 
@@ -75,7 +76,7 @@ create_devel_openqa_snapshot() {
     auto_submit_packages=$(list_packages "$dst_project")
     staged_packages=$(list_packages "$staging_project") || true # osc ls returns non-zero return code for empty projects
     if [[ $staged_packages ]]; then
-        echo "Only triggering tests from $src_project (not overriding $staging_project and doing a submission) because openQA-in-openQA tests or a submission is still pending (as $staging_project still contains packages: $staged_packages)" \
+        echo "Only triggering tests from $src_project (not overriding $staging_project and doing a submission) because $staging_project still contains packages: $staged_packages" \
             | tee job_post_skip_submission
         staging_project=$src_project
         staging_group_id=$group_id
@@ -83,7 +84,7 @@ create_devel_openqa_snapshot() {
     elif [[ -e job_post_skip_submission ]]; then
         rm job_post_skip_submission
     fi
-    echo "Checking if all relevant packages are built and published before creating snapshot under $staging_project"
+    log-info "Checking if all relevant packages are built and published before creating snapshot under $staging_project"
     for package in $auto_submit_packages; do
         local state
         state=$($osc results -r openSUSE_Tumbleweed -a x86_64 --no-multibuild "$src_project" "$package")
@@ -94,7 +95,7 @@ create_devel_openqa_snapshot() {
         fi
         create_snapshots "$package"
     done
-    echo "Wait until all packages are published under $staging_project"
+    log-info "Wait until all packages are published under $staging_project"
     $osc prjresults --watch --xml -r openSUSE_Tumbleweed -a x86_64 "$staging_project"
 }
 


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/178105

For debugging osc calls, you would need to set `osc=debug_osc script...`