### PR TITLE
Only consider builds with only numbers in them to not break existing logic

### DIFF
--- a/openqa-schedule-mm-ping-test
+++ b/openqa-schedule-mm-ping-test
@@ -54,7 +54,7 @@ job_templates:
       PARALLEL_WITH: ping_server
 EOF
 
-hdd=$(runcli openqa-cli api --host "$openqa_url" jobs version="$version" scope=relevant arch="$arch" flavor="$flavor" test="$test_name" latest=1 | runjq -r '.jobs | map(select(.result == "passed")) | max_by(.settings.BUILD) .settings.HDD_1')
+hdd=$(runcli openqa-cli api --host "$openqa_url" jobs version="$version" scope=relevant arch="$arch" flavor="$flavor" test="$test_name" latest=1 | runjq -r '.jobs | map(select(.result == "passed")) | map(select(.settings.BUILD | test("^[0-9]+$"))) | max_by(.settings.BUILD) .settings.HDD_1')
 time openqa-cli schedule \
     --monitor \
     --host "$openqa_url" \


### PR DESCRIPTION
This fixes our multimachine tests which currently consider `Martchus/os-autoinst-distri-opensuse.git#mm-sync` the "highest" build number and therefore using a very old HDD asset from early 2024.

With this applied we ensure that jq's max_by only receives numbers and therefore can sort correctly.