### PR TITLE
Avoid infinite while loop and --follow job restarts

### DIFF
--- a/monitor-openqa_job
+++ b/monitor-openqa_job
@@ -31,10 +31,7 @@ declare -A failed_versions
 failed_jobs=()
 for job_id in $(job_ids job_post_response); do
     log-info "Waiting for job $job_id to finish"
-    while sleep "${sleep_time}"; do
-        job_state=$($openqa_cli api --host "$host" jobs/"$job_id" | jq -r '.job.state')
-        [[ $job_state = 'done' ]] && break
-    done
+    $openqa_cli monitor --follow --poll-interval "$sleep_time" "$job_id"
     response=$($openqa_cli api --host "$host" jobs/"$job_id")
     result=$(echo "$response" | jq -r '.job.result')
     log-info "Result of job $job_id: $result"


### PR DESCRIPTION
Avoid infinite while loop and --follow job restarts

Replaces duplicate code with a `openqa-cli monitor --follow` call, as that
functionality is already implemented, e.g. `openqa-cli monitor --follow --o3 5138554`.

Related Issue: https://progress.opensuse.org/issues/184387

Co-authored-by: gpuliti <gpuliti@suse.com>
Co-authored-by: baierjan <jbaier@suse.com>