### PR TITLE
Follow the scheduled job restart

### DIFF
--- a/openqa-schedule-mm-ping-test
+++ b/openqa-schedule-mm-ping-test
@@ -56,7 +56,7 @@ EOF
 
 hdd=$(runcli openqa-cli api --host "$openqa_url" jobs version="$version" scope=relevant arch="$arch" flavor="$flavor" test="$test_name" latest=1 | runjq -r '.jobs | map(select(.result == "passed")) | max_by(.settings.BUILD) .settings.HDD_1')
 time openqa-cli schedule \
-    --monitor \
+    --monitor --follow \
     --host "$openqa_url" \
     --param-file SCENARIO_DEFINITIONS_YAML="$tmpfile" \
     DISTRI="$distri" VERSION="$version" FLAVOR="$flavor_override" ARCH="$arch" \


### PR DESCRIPTION
Following the scheduled job restart

As already described on https://github.com/os-autoinst/scripts/pull/426
we have tested the fix by run locally:

```
{"blocked_by_id":null,"id":5138554,"result":"none","state":"running"}
Job state of job ID 5138554: running, waiting … (delay: 10; waited 0s)
{"blocked_by_id":null,"id":5138554,"result":"none","state":"running"}
Job state of job ID 5138554: running, waiting … (delay: 10; waited 10s)
...
{"blocked_by_id":null,"id":5138554,"result":"passed","state":"done"}
```

We have run the script locally and restart a created job, this is the
output:

```
❯ ./openqa-schedule-mm-ping-test
{"count":2,"failed":[],"ids":[5138637,5138638],"scheduled_product_id":495767}
2 jobs have been created:
 - https://openqa.opensuse.org/tests/5138637
 - https://openqa.opensuse.org/tests/5138638
{"blocked_by_id":null,"id":5138637,"result":"none","state":"scheduled"}
Job state of job ID 5138637: scheduled, waiting … (delay: 10; waited 0s)
{"blocked_by_id":null,"id":5138637,"result":"none","state":"running"}
Job state of job ID 5138637: running, waiting … (delay: 10; waited 12s)
{"blocked_by_id":null,"id":5138637,"result":"none","state":"running"}
Job state of job ID 5138637: running, waiting … (delay: 10; waited 22s)
{"blocked_by_id":null,"id":5138637,"result":"none","state":"running"}
Job state of job ID 5138637: running, waiting … (delay: 10; waited 32s)
{"blocked_by_id":null,"followed_id":5138637,"id":5138639,"result":"none","state":"running"}
...
Job state of job ID 5138637: running, waiting … (delay: 10; waited 92s)
{"blocked_by_id":null,"followed_id":5138637,"id":5138639,"result":"none","state":"running"}
Job state of job ID 5138637: running, waiting … (delay: 10; waited 102s)
{"blocked_by_id":null,"followed_id":5138637,"id":5138639,"result":"none","state":"running"}
Job state of job ID 5138637: running, waiting … (delay: 10; waited 112s)
{"blocked_by_id":null,"followed_id":5138637,"id":5138639,"result":"none","state":"running"}
Job state of job ID 5138637: running, waiting … (delay: 10; waited 122s)
{"blocked_by_id":null,"followed_id":5138637,"id":5138639,"result":"passed","state":"done"}
{"blocked_by_id":null,"followed_id":5138638,"id":5138640,"result":"passed","state":"done"}

real    2m12.767s
user    0m0.250s
sys     0m0.055s
```

Related Issue: https://progress.opensuse.org/issues/184387