### PR TITLE
Turn info into debug message

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -118,7 +118,7 @@ update_package() {
 }
 
 last_revision() {
-    log-info "last_revision $*"
+    log-debug "last_revision $*"
     local project=$1
     local package=$2
     local file=$package.changes


### PR DESCRIPTION
The output of the function is used as input for xmlstarlet, so it should not go to stdout.

Issue: https://progress.opensuse.org/issues/185077