### PR TITLE
monitor-openqa_job: Report restarted job_id

### DIFF
--- a/monitor-openqa_job
+++ b/monitor-openqa_job
@@ -34,6 +34,8 @@ for job_id in $(job_ids job_post_response); do
     $openqa_cli monitor --host "$host" --follow --poll-interval "$sleep_time" "$job_id"
     response=$($openqa_cli api --host "$host" jobs/"$job_id" follow=1)
     result=$(echo "$response" | jq -r '.job.result')
+    # job_id might have changed if it was restarted
+    job_id=$(echo "$response" | jq -r '.job.id')
     log-info "Result of job $job_id: $result"
     if [[ $result != 'passed' ]] && [[ -n $obs_package_name ]]; then
         version=$(echo "$response" | jq -r '.job.settings.VERSION')


### PR DESCRIPTION
The output might currently be confusing if a job was restarted.

Issue: https://progress.opensuse.org/issues/185527