### PR TITLE
Fix job group for triggering full openQA-in-openQA test runs

### DIFF
--- a/trigger-openqa_in_openqa
+++ b/trigger-openqa_in_openqa
@@ -39,6 +39,7 @@ main() {
     # and use for submit requests
     if [[ $full_run ]]; then
         staging_project=$src_project
+        staging_group_id=$group_id
     else
         create_devel_openqa_snapshot
     fi


### PR DESCRIPTION
This is a fixup of 7b11a8b9762ef4afda7308b5fd5294b54c50dea7 which reverts the behavior in case of full runs so they are still triggered in the regular job group and not in the staging job group.

Related ticket: https://progress.opensuse.org/issues/185653