### PR TITLE
Makefile: Fix missing ruff format check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test-yaml:
 
 checkstyle-python:
 	@which ruff >/dev/null 2>&1 || echo "Command 'ruff' not found, can not execute python style checks"
-	ruff check
+	ruff format --check && ruff check
 
 update-deps:
 	tools/update-deps --cpanfile cpanfile --specfile dist/rpm/os-autoinst-scripts-deps.spec


### PR DESCRIPTION
ruff format and check are separate commands and need to be called
separatedly to ensure both correct format and style. Also see
https://github.com/astral-sh/ruff/discussions/9048 and
https://github.com/astral-sh/ruff/issues/8232