### PR TITLE
Submit packages via Git for the openSUSE:Leap:16.0 target project

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -73,9 +73,21 @@ wait_for_package_build() {
     fi
 }
 
+make_obs_submit_request() {
+    local package=$1 target=$2 version=$3 cmd=($osc sr) req='' rc=''
+    log-info "## Ready to submit $package to $target ##"
+    req=$(get_obs_sr_id "$target" "$dst_project" "$package" || :)
+    # TODO: check if it's a different revision than HEAD
+    [[ -n $req ]] && cmd+=(-s "$req")
+    if ! "${cmd[@]}" -m "Update to ${version}" "$target"; then
+        rc=$?
+        failed_packages+=("$package:$rc")
+    fi
+}
+
 update_package() {
     log-info "update_package $*"
-    local package=$1
+    local package=$1 version=
     xmlstarlet ed -L -i "/services/service" --type attr -n mode --value 'disabled' _service
     sed -i -e 's,mode="disabled" mode="disabled",mode="disabled",' _service
     reenable_buildtime_services
@@ -103,17 +115,7 @@ update_package() {
     wait_for_package_build "$submit_target"
     for target in "${targets[@]}"; do
         [[ $target == none ]] && continue # allow specifying submit_target_extra=none for easier testing
-        cmd="$osc sr"
-        log-info "## Ready to submit $package to $target ##"
-        req=$(get_obs_sr_id "$target" "$dst_project" "$package" || :)
-        # TODO: check if it's a different revision than HEAD
-        if test -n "$req"; then
-            cmd="$cmd -s $req"
-        fi
-        if ! $cmd -m "Update to ${version}" "$target"; then
-            rc=$?
-            failed_packages+=("$package:$rc")
-        fi
+        make_obs_submit_request "$package" "$target" "$version"
     done
     return $rc
 }

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -80,14 +80,11 @@ wait_for_package_build() {
 
 make_obs_submit_request() {
     # shellcheck disable=SC2206
-    local package=$1 target=$2 version=$3 cmd=($osc sr) req='' rc='' # $osc is supposed to be split, hence disabling SC2206
+    local package=$1 target=$2 version=$3 cmd=($osc sr) req='' # $osc is supposed to be split, hence disabling SC2206
     req=$(get_obs_sr_id "$target" "$dst_project" "$package" || :)
     # TODO: check if it's a different revision than HEAD
     [[ -n $req ]] && cmd+=(-s "$req")
-    if ! "${cmd[@]}" -m "Update to ${version}" "$target"; then
-        rc=$?
-        failed_packages+=("$package:$rc")
-    fi
+    "${cmd[@]}" -m "Update to ${version}" "$target" || return $?
 }
 
 make_git_submit_request() {
@@ -152,12 +149,11 @@ update_package() {
     for target in "${targets[@]}"; do
         [[ $target == none ]] && continue # allow specifying submit_target_extra=none for easier testing
         log-info "## Ready to submit $package to $target ##"
+        local submit_cmd=make_obs_submit_request
+        local args=("$package" "$target" "$version")
         local git_branch=${git_branches[$target]}
-        if [[ $git_branch ]]; then
-            make_git_submit_request "$package" "$target" "$version" "$git_branch" || failed_packages+=("$package:$?")
-        else
-            make_obs_submit_request "$package" "$target" "$version"
-        fi
+        [[ $git_branch ]] && submit_cmd=make_git_submit_request args+=("$git_branch")
+        "$submit_cmd" "${args[@]}" || rc=$? failed_packages+=("$package:$?")
     done
     return $rc
 }

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -79,7 +79,8 @@ wait_for_package_build() {
 }
 
 make_obs_submit_request() {
-    local package=$1 target=$2 version=$3 cmd=($osc sr) req='' rc=''
+    # shellcheck disable=SC2206
+    local package=$1 target=$2 version=$3 cmd=($osc sr) req='' rc='' # $osc is supposed to be split, hence disabling SC2206
     req=$(get_obs_sr_id "$target" "$dst_project" "$package" || :)
     # TODO: check if it's a different revision than HEAD
     [[ -n $req ]] && cmd+=(-s "$req")

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -24,6 +24,11 @@ submit_target_extra=${submit_target_extra:-"openSUSE:Backports:SLE-15-SP6:Update
 IFS=',' read -ra targets <<< "$submit_target,$submit_target_extra"
 failed_packages=()
 
+# declare Git branches of submit targets which have already been migrated to Git
+declare -A git_branches=(
+    ['openSUSE:Leap:16.0']=leap-16.0
+)
+
 encode_variable() {
     #  https://stackoverflow.com/a/298258
     perl -MURI::Escape -e 'print uri_escape($ARGV[0])' "$1"
@@ -75,7 +80,6 @@ wait_for_package_build() {
 
 make_obs_submit_request() {
     local package=$1 target=$2 version=$3 cmd=($osc sr) req='' rc=''
-    log-info "## Ready to submit $package to $target ##"
     req=$(get_obs_sr_id "$target" "$dst_project" "$package" || :)
     # TODO: check if it's a different revision than HEAD
     [[ -n $req ]] && cmd+=(-s "$req")
@@ -83,6 +87,37 @@ make_obs_submit_request() {
         rc=$?
         failed_packages+=("$package:$rc")
     fi
+}
+
+make_git_submit_request() {
+    local package=$1 target=$2 version=$3 branch=$4 forked_repo=''
+    title="Update to $version"
+    description="Automatic submission via https://github.com/os-autoinst/scripts/blob/master/os-autoinst-obs-auto-submit"
+
+    # ensure a directory to store Git repositories under has been created
+    git_dir=../git-repos
+    mkdir -p "$git_dir"
+
+    # ensure the user we are authenticating with has a fork of the package we want to submit
+    # note: For `gib-obs` commands to work one needs to create a config file, e.g. via:
+    #       `git-obs login add --url=https://src.opensuse.org obs --set-as-default --user=… --token=…`
+    #       For `git push` to work (done below) you need to deploy an SSH key on the Gitea instance.
+    #       Checkout https://opensuse-commander.readthedocs.io/en/latest/git-obs-quickstart.html for details.
+    forked_repo=$($git_obs repo fork "pool/$package" 2>&1 > /dev/null | perl -ne 'print for /Fork .*: (.*)/g')
+
+    # enter a working copy of the fork and switch to the branch the submission should be based on
+    $git_obs repo clone --no-ssh-strict-host-key-checking "$forked_repo" || return $?
+    cd "$package"
+    $git switch "$branch"
+
+    # remove everything and replace it with the updated files we have just created (in the calling function)
+    rm -v ./*
+    cp -v ../../"$package"/* ./
+
+    # commit, push and create PR
+    $git commit --all --message "$title"
+    $git push -f || return $?
+    $git_obs pr create --title "$title" --description "$description" --target-branch="$branch" || return $?
 }
 
 update_package() {
@@ -115,7 +150,13 @@ update_package() {
     wait_for_package_build "$submit_target"
     for target in "${targets[@]}"; do
         [[ $target == none ]] && continue # allow specifying submit_target_extra=none for easier testing
-        make_obs_submit_request "$package" "$target" "$version"
+        log-info "## Ready to submit $package to $target ##"
+        local git_branch=${git_branches[$target]}
+        if [[ $git_branch ]]; then
+            make_git_submit_request "$package" "$target" "$version" "$git_branch" || failed_packages+=("$package:$?")
+        else
+            make_obs_submit_request "$package" "$target" "$version"
+        fi
     done
     return $rc
 }
@@ -275,5 +316,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 prefix="${prefix:-""}"
 [ "$dry_run" = "1" ] && prefix="echo"
 osc="${osc:-"$prefix retry -e -- osc"}"
+git=${git:-"$prefix retry -e -- git"}
+git_obs=${git_obs:-"$prefix retry -e -- git-obs"}
 
 caller 0 > /dev/null || main "$@"

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -102,6 +102,7 @@ update_package() {
     rc=0
     wait_for_package_build "$submit_target"
     for target in "${targets[@]}"; do
+        [[ $target == none ]] && continue # allow specifying submit_target_extra=none for easier testing
         cmd="$osc sr"
         log-info "## Ready to submit $package to $target ##"
         req=$(get_obs_sr_id "$target" "$dst_project" "$package" || :)

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -273,6 +273,7 @@ has_pending_submission() {
 submit() {
     log-info "submit()"
     # submit from staging project if specified
+    local must_cleanup_staging=
     if [[ -n $staging_project && $staging_project != none && $staging_project != "$src_project" ]]; then
         src_project=$staging_project
         must_cleanup_staging=1


### PR DESCRIPTION
The project `openSUSE:Leap:16.0` has been migrated to Git so we need to
submit there by creating Git PRs.

This changes requires setting up the config for `git-obs` in production
and deployment of SSH keys on https://src.opensuse.org/. See
https://opensuse-commander.readthedocs.io/en/latest/git-obs-quickstart.html
for details.

The commands contained by this change are based on the Git packaging
workflow documentation, see
https://en.opensuse.org/openSUSE:Git_Packaging_Workflow#Using_git-obs_and_plain_git_(fork_workflow).

Related ticket: https://progress.opensuse.org/issues/187356

---

I haven't tested this much except for a local run that managed to create
this submit request: https://src.opensuse.org/pool/openQA/pulls/1

So I'm waiting for feedback on that submit request. If it is good I'll undraft
this PR and will also see whether I can create unit tests for this with reasonable
effort.