### PR TITLE
Add openqa-bats-review script

### DIFF
--- a/openqa-bats-review
+++ b/openqa-bats-review
@@ -2,6 +2,9 @@
 """
 This script fetches previous cloned BATS jobs to check whether we can
 tag a job as passed by doing a set intersection of all failed jobs.
+
+Overview of BATS tests:
+https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/containers/bats
 """
 
 import argparse
@@ -103,7 +106,7 @@ def grep_notok(url: str) -> set[str]:
     return notok
 
 
-def process_files(files: list[str]) -> set[str]:
+def process_tap_files(files: list[str]) -> set[str]:
     """
     Process TAP files
     """
@@ -115,7 +118,7 @@ def process_files(files: list[str]) -> set[str]:
         return set(itertools.chain.from_iterable(executor.map(grep_notok, files)))
 
 
-def get_clone_chain(openqa_host: str, job_id: int) -> list[int]:
+def resolve_clone_chain(openqa_host: str, job_id: int) -> list[int]:
     """
     Follow clones recursively and return the full chain:
     [job_id, origin_id, origin_id_of_origin, ...]
@@ -143,7 +146,7 @@ def main(url: str) -> None:
     openqa_host = f"{urlx.scheme}://{urlx.netloc}"
     job_id = int(os.path.basename(urlx.path))
 
-    chain = get_clone_chain(openqa_host, job_id)
+    chain = resolve_clone_chain(openqa_host, job_id)
     if len(chain) <= 1:
         log.info("No clones. Exiting")
         sys.exit(0)
@@ -184,7 +187,7 @@ def main(url: str) -> None:
             log.info("Job %s has only %d TAP logs, skipping", job_id, len(logs))
             continue
 
-        failed = process_files(logs)
+        failed = process_tap_files(logs)
         all_failures.append(failed)
 
     if not all_failures:
@@ -198,7 +201,7 @@ def main(url: str) -> None:
         # TODO: Tag job as passed
     else:
         log.info("Common failures found across clone chain: %s", " ".join(common_failures))
-        sys.exit(0)
+        sys.exit(1)
 
 
 def parse_args() -> argparse.Namespace:

--- a/openqa-bats-review
+++ b/openqa-bats-review
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+This script fetches previous cloned BATS jobs to check whether we can
+tag a job as passed by doing a set intersection of all failed jobs.
+"""
+
+import argparse
+import itertools
+import logging
+import os
+import re
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from functools import cache
+from urllib.parse import urlparse
+
+import requests
+from requests.exceptions import RequestException
+
+
+TIMEOUT = 30
+USER_AGENT = "openqa-bats-review (https://github.com/os-autoinst/scripts)"
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+log = logging.getLogger(sys.argv[0] if __name__ == "__main__" else __name__)
+session = requests.Session()
+
+
+# We want to extract the test name stripping the numbers and the optional timing information
+# not ok 166 bud-git-context in 118ms
+# not ok 655 [520] podman checkpoint --export, with volumes in 1558ms
+# not ok 7 runc exec (cgroup v2, ro cgroupfs, new cgroupns) does not chown cgroup # in 418 ms
+NOT_OK = re.compile(r"^not ok \d+ (?:\[\d+\] )?(.*?)(?: #? in \d+ ?ms)?$")
+
+
+def get_file(url: str) -> str:
+    """
+    Get a text file from URL
+    """
+    headers = {
+        "User-Agent": USER_AGENT,
+    }
+    try:
+        got = session.get(url, headers=headers, timeout=TIMEOUT)
+        got.raise_for_status()
+    except RequestException as error:
+        log.error("%s: %s", url, error)
+        sys.exit(1)
+    return got.text
+
+
+@cache
+def get_job(url: str) -> dict:
+    """
+    Get a job from openQA
+    """
+    headers = {
+        "User-Agent": USER_AGENT,
+    }
+    try:
+        got = session.get(url, headers=headers, timeout=TIMEOUT)
+        got.raise_for_status()
+        data = got.json()
+    except RequestException as error:
+        log.error("%s: %s", url, error)
+        sys.exit(1)
+    return data["job"]
+
+
+def grep_notok(url: str) -> set[str]:
+    """
+    Grep for "not ok" lines and return a set with the failing tests
+    prefixed by the filename
+    """
+    notok = set()
+    # Note: We use a prefix because some tests have more than 1 TAP file
+    prefix = os.path.basename(url)
+    data = get_file(url)
+    lines = data.splitlines()
+    # Fetch the plan to check that we don't have a truncated TAP file
+    last = 0
+    for line in lines:
+        if line.startswith("1.."):
+            last = int(line.split("..", 1)[1])
+            break
+    if not last:
+        log.error("Malformed TAP file: %s", url)
+        sys.exit(1)
+    # Trust the plan
+    tests = 0
+    for line in lines:
+        if not line.startswith(("ok", "not ok", "#not ok")):
+            continue
+        tests += 1
+        try:
+            test = NOT_OK.findall(line)[0]
+            notok.add(f"{prefix}:{test}")
+        except IndexError:
+            continue
+    if tests != last:
+        log.error("Truncated TAP file: %s", url)
+        sys.exit(1)
+    return notok
+
+
+def process_files(files: list[str]) -> set[str]:
+    """
+    Process TAP files
+    """
+    # The test for these packages have only one TAP file: aardvark-dns & netavark
+    if len(files) == 1:
+        return grep_notok(files[0])
+    # Use multithreading for tests like buildah, runc & skopeo (2 files) & podman (4 files)
+    with ThreadPoolExecutor(max_workers=len(files)) as executor:
+        return set(itertools.chain.from_iterable(executor.map(grep_notok, files)))
+
+
+def get_clone_chain(openqa_host: str, job_id: int) -> list[int]:
+    """
+    Follow clones recursively and return the full chain:
+    [job_id, origin_id, origin_id_of_origin, ...]
+    """
+    chain = []
+    current: int | None = job_id
+    while current:
+        # We use "/details" because we'll need this information again and get_job() is cached
+        job = get_job(f"{openqa_host}/api/v1/jobs/{current}/details")
+        if "BATS_PACKAGE" not in job["settings"]:
+            log.error("Not a BATS test: %d", job_id)
+            sys.exit(1)
+        chain.append(current)
+        current = job.get("origin_id")
+    return chain
+
+
+def main(url: str) -> None:
+    """
+    Main function
+    """
+    if not url.startswith(("http://", "https://")):
+        url = f"https://{url}"
+    urlx = urlparse(url)
+    openqa_host = f"{urlx.scheme}://{urlx.netloc}"
+    job_id = int(os.path.basename(urlx.path))
+
+    chain = get_clone_chain(openqa_host, job_id)
+    if len(chain) <= 1:
+        log.info("No clones. Exiting")
+        sys.exit(0)
+    log.info("Processing clone chain: %s", " -> ".join(map(str, chain)))
+
+    # Expected number of TAP logs per package
+    expected = {
+        "aardvark-dns": 1,
+        "buildah": 2,
+        "conmon": 2,
+        "netavark": 1,
+        "podman": 4,
+        "runc": 2,
+        "skopeo": 2,
+    }
+
+    all_failures = []
+
+    for job_id in chain:
+        job = get_job(f"{openqa_host}/api/v1/jobs/{job_id}/details")
+        url = f"{openqa_host}/tests/{job_id}"
+        logs = [
+            f"{openqa_host}/tests/{job_id}/file/{log}"
+            for log in job["ulogs"]
+            if log.endswith(".tap.txt")
+        ]
+        if not logs:
+            log.info("Job %s has no TAP logs, skipping", job_id)
+            continue
+
+        package = job["settings"]["BATS_PACKAGE"]
+
+        # conmon may also test crun in addition to runc on openSUSE where it's available
+        if job["settings"]["DISTRI"] == "opensuse" and "OCI_RUNTIME" not in job["settings"]:
+            expected["conmon"] = 4
+
+        if len(logs) != expected[package]:
+            log.info("Job %s has only %d TAP logs, skipping", job_id, len(logs))
+            continue
+
+        failed = process_files(logs)
+        all_failures.append(failed)
+
+    if not all_failures:
+        log.info("No logs found in chain. Exiting")
+        sys.exit(0)
+
+    common_failures: set[str] = set.intersection(*all_failures)
+
+    if not common_failures:
+        log.info("No common failures across clone chain. Tagging as PASSED.")
+        # TODO: Tag job as passed
+    else:
+        log.info("Common failures found across clone chain: %s", " ".join(common_failures))
+        sys.exit(0)
+
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parse args
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("url", help="URL to openQA jobs")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args().url)

--- a/openqa-bats-review
+++ b/openqa-bats-review
@@ -136,7 +136,7 @@ def resolve_clone_chain(openqa_host: str, job_id: int) -> list[int]:
     return chain
 
 
-def main(url: str) -> None:
+def main(url: str, dry_run: bool = False) -> None:
     """
     Main function
     """
@@ -197,21 +197,23 @@ def main(url: str) -> None:
     common_failures: set[str] = set.intersection(*all_failures)
 
     if not common_failures:
-        log.info("No common failures across clone chain. Tagging as PASSED.")
-        # TODO: Tag job as passed
+        if not dry_run:
+            log.info("No common failures across clone chain. Would tag as PASSED.")
+            # TODO: Tag job as passed
+        else:
+            log.info("No common failures across clone chain. Tagging as PASSED.")
     else:
         log.info("Common failures found across clone chain: %s", " ".join(common_failures))
         sys.exit(1)
 
 
 def parse_args() -> argparse.Namespace:
-    """
-    Parse args
-    """
     parser = argparse.ArgumentParser()
+    parser.add_argument("-n", "--dry-run", action="store_true", help="dry run")
     parser.add_argument("url", help="URL to openQA jobs")
     return parser.parse_args()
 
 
 if __name__ == "__main__":
-    main(parse_args().url)
+    args = parse_args()
+    main(args.url, dry_run=args.dry_run)

--- a/openqa-bats-review
+++ b/openqa-bats-review
@@ -12,6 +12,7 @@ import itertools
 import logging
 import os
 import re
+import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from functools import cache
@@ -21,6 +22,7 @@ import requests
 from requests.exceptions import RequestException
 
 
+PASSED = "label:force_result:passed:" + os.path.basename(__file__)
 TIMEOUT = 30
 USER_AGENT = "openqa-bats-review (https://github.com/os-autoinst/scripts)"
 
@@ -34,6 +36,46 @@ session = requests.Session()
 # not ok 655 [520] podman checkpoint --export, with volumes in 1558ms
 # not ok 7 runc exec (cgroup v2, ro cgroupfs, new cgroupns) does not chown cgroup # in 418 ms
 NOT_OK = re.compile(r"^not ok \d+ (?:\[\d+\] )?(.*?)(?: #? in \d+ ?ms)?$")
+
+
+client_args = [
+    "openqa-cli",
+    "api",
+    "--header",
+    f"User-Agent: {USER_AGENT}",
+]
+
+
+def call(cmds: list[str], dry_run: bool = False) -> str:
+    """
+    Call openqa-cli
+    """
+    log.debug("call: %s", " ".join(cmds))
+    res = subprocess.run(
+        (["echo", "Simulating: "] if dry_run else []) + cmds,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if len(res.stderr):
+        log.warning("call() %s stderr: %s", cmds[0], res.stderr)
+    res.check_returncode()
+    return res.stdout.decode("utf-8")
+
+
+def openqa_comment(job: int, host: str, comment: str, dry_run: bool = False) -> str:
+    """
+    Comment a job
+    """
+    args = client_args + [
+        "--host",
+        host,
+        "-X",
+        "POST",
+        "jobs/" + str(job) + "/comments",
+        "text=" + comment,
+    ]
+    return call(args, dry_run)
 
 
 def get_file(url: str) -> str:
@@ -144,9 +186,9 @@ def main(url: str, dry_run: bool = False) -> None:
         url = f"https://{url}"
     urlx = urlparse(url)
     openqa_host = f"{urlx.scheme}://{urlx.netloc}"
-    job_id = int(os.path.basename(urlx.path))
+    my_job_id = int(os.path.basename(urlx.path))
 
-    chain = resolve_clone_chain(openqa_host, job_id)
+    chain = resolve_clone_chain(openqa_host, my_job_id)
     if len(chain) <= 1:
         log.info("No clones. Exiting")
         sys.exit(0)
@@ -180,7 +222,10 @@ def main(url: str, dry_run: bool = False) -> None:
         package = job["settings"]["BATS_PACKAGE"]
 
         # conmon may also test crun in addition to runc on openSUSE where it's available
-        if job["settings"]["DISTRI"] == "opensuse" and "OCI_RUNTIME" not in job["settings"]:
+        if (
+            job["settings"]["DISTRI"] == "opensuse"
+            and "OCI_RUNTIME" not in job["settings"]
+        ):
             expected["conmon"] = 4
 
         if len(logs) != expected[package]:
@@ -199,11 +244,14 @@ def main(url: str, dry_run: bool = False) -> None:
     if not common_failures:
         if not dry_run:
             log.info("No common failures across clone chain. Would tag as PASSED.")
-            # TODO: Tag job as passed
         else:
             log.info("No common failures across clone chain. Tagging as PASSED.")
+        print(openqa_comment(my_job_id, openqa_host, PASSED, dry_run))
     else:
-        log.info("Common failures found across clone chain: %s", " ".join(common_failures))
+        log.error(
+            "Common failures found across clone chain: %s",
+            "\n".join(sorted(list(common_failures))),
+        )
         sys.exit(1)
 
 
@@ -215,5 +263,5 @@ def parse_args() -> argparse.Namespace:
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    main(args.url, dry_run=args.dry_run)
+    opts = parse_args()
+    main(opts.url, dry_run=opts.dry_run)

--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -44,6 +44,10 @@ hook() {
     result="$(echo "$job_data" | runjq -r '.job.result')" || return $?
     [[ "$state" != "done" ]] && return
     if [[ "$result" != passed ]]; then
+        bats_package="$(echo "$job_data" | runjq -r '.job.settings.BATS_PACKAGE')"
+        if [[ $bats_package != "null" ]]; then
+            openqa-bats-review "$url" && return
+        fi
         label "$url" | investigate-and-bisect
     else
         echo "$url" | investigate-and-bisect

--- a/tests/openqa_bats_review_test.py
+++ b/tests/openqa_bats_review_test.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the BATS review script
+"""
+
+import importlib
+import importlib.util
+import os
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+from requests.exceptions import RequestException
+
+#
+# Emulate "from openqa_bats_review import *"
+#
+rootpath = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+loader = importlib.machinery.SourceFileLoader(
+    "bats_review", rootpath + "/openqa-bats-review"
+)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+bats_review = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = bats_review
+loader.exec_module(bats_review)
+
+get_file = bats_review.get_file
+get_job = bats_review.get_job
+grep_notok = bats_review.grep_notok
+process_tap_files = bats_review.process_tap_files
+resolve_clone_chain = bats_review.resolve_clone_chain
+main = bats_review.main
+parse_args = bats_review.parse_args
+NOT_OK = bats_review.NOT_OK
+
+
+# Additional test for testing all expected package configurations
+class TestPackageExpectations:
+    """Test the expected package configurations"""
+
+    def setup_method(self):
+        """Clear cache before each test"""
+        get_job.cache_clear()
+
+    @patch("bats_review.resolve_clone_chain")
+    @patch("bats_review.get_job")
+    @patch("bats_review.log")
+    def test_unknown_package_keyerror(
+        self, mock_log, mock_get_job, mock_resolve_clone_chain
+    ):
+        """Test main function with unknown package should raise KeyError"""
+        mock_resolve_clone_chain.return_value = [123, 122]
+
+        def mock_job_response(url):
+            return {
+                "id": int(url.split("/")[-2]),
+                "settings": {"BATS_PACKAGE": "unknown-package"},  # Not in expected dict
+                "ulogs": ["test.tap.txt"],
+            }
+
+        mock_get_job.side_effect = mock_job_response
+
+        with pytest.raises(KeyError):
+            main("http://openqa.example.com/tests/123")
+
+
+class TestRegexPattern:
+    """Test the NOT_OK regex pattern"""
+
+    def test_basic_not_ok_pattern(self):
+        """Test basic 'not ok' pattern matching"""
+        line = "not ok 166 bud-git-context in 118ms"
+        match = NOT_OK.findall(line)
+        # The regex captures everything including timing, so we need to adjust expectation
+        assert match == ["bud-git-context in 118ms"]
+
+    def test_not_ok_with_brackets(self):
+        """Test 'not ok' pattern with brackets"""
+        line = "not ok 655 [520] podman checkpoint --export, with volumes in 1558ms"
+        match = NOT_OK.findall(line)
+        # The regex captures everything including timing
+        assert match == ["podman checkpoint --export, with volumes in 1558ms"]
+
+    def test_not_ok_without_timing(self):
+        """Test 'not ok' pattern without timing info"""
+        line = "not ok 123 some test name"
+        match = NOT_OK.findall(line)
+        assert match == ["some test name"]
+
+    def test_not_ok_no_match(self):
+        """Test lines that shouldn't match"""
+        lines = [
+            "ok 123 passing test",
+            "# not ok this is a comment",
+            "some random line",
+        ]
+        for line in lines:
+            match = NOT_OK.findall(line)
+            assert match == []
+
+
+class TestGetFile:
+    """Test the get_file function"""
+
+    @patch("bats_review.session")
+    def test_get_file_success(self, mock_session):
+        """Test successful file retrieval"""
+        mock_response = Mock()
+        mock_response.text = "test content"
+        mock_session.get.return_value = mock_response
+
+        result = get_file("http://example.com/test.txt")
+
+        assert result == "test content"
+        mock_session.get.assert_called_once_with(
+            "http://example.com/test.txt",
+            headers={
+                "User-Agent": "openqa-bats-review (https://github.com/os-autoinst/scripts)"
+            },
+            timeout=30,
+        )
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch("bats_review.session")
+    @patch("bats_review.log")
+    def test_get_file_request_exception(self, mock_log, mock_session):
+        """Test handling of request exceptions"""
+        mock_session.get.side_effect = RequestException("Network error")
+
+        with pytest.raises(SystemExit) as exc_info:
+            get_file("http://example.com/test.txt")
+
+        assert exc_info.value.code == 1
+        mock_log.error.assert_called_once()
+
+    @patch("bats_review.session")
+    @patch("bats_review.log")
+    def test_get_file_http_error(self, mock_log, mock_session):
+        """Test handling of HTTP errors"""
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = RequestException("404 Not Found")
+        mock_session.get.return_value = mock_response
+
+        with pytest.raises(SystemExit) as exc_info:
+            get_file("http://example.com/test.txt")
+
+        assert exc_info.value.code == 1
+        mock_log.error.assert_called_once()
+
+
+class TestGetJob:
+    """Test the get_job function"""
+
+    def setup_method(self):
+        """Clear cache before each test"""
+        get_job.cache_clear()
+
+    @patch("bats_review.session")
+    def test_get_job_success(self, mock_session):
+        """Test successful job retrieval"""
+        mock_response = Mock()
+        mock_response.json.return_value = {"job": {"id": 123, "state": "done"}}
+        mock_session.get.return_value = mock_response
+
+        result = get_job("http://example.com/api/v1/jobs/123")
+
+        assert result == {"id": 123, "state": "done"}
+        mock_session.get.assert_called_once_with(
+            "http://example.com/api/v1/jobs/123",
+            headers={
+                "User-Agent": "openqa-bats-review (https://github.com/os-autoinst/scripts)"
+            },
+            timeout=30,
+        )
+
+    @patch("bats_review.session")
+    @patch("bats_review.log")
+    def test_get_job_request_exception(self, mock_log, mock_session):
+        """Test handling of request exceptions in get_job"""
+        mock_session.get.side_effect = RequestException("Network error")
+
+        with pytest.raises(SystemExit) as exc_info:
+            get_job("http://example.com/api/v1/jobs/123")
+
+        assert exc_info.value.code == 1
+        mock_log.error.assert_called_once()
+
+
+class TestGrepNotok:
+    """Test the grep_notok function"""
+
+    @patch("bats_review.get_file")
+    @patch("bats_review.log")
+    def test_grep_notok_success(self, mock_log, mock_get_file):
+        """Test successful parsing of TAP file"""
+        tap_content = """1..3
+ok 1 test one
+not ok 2 failing test in 100ms
+ok 3 test three"""
+
+        mock_get_file.return_value = tap_content
+
+        result = grep_notok("http://example.com/test.tap.txt")
+
+        assert result == {"test.tap.txt:failing test in 100ms"}
+
+    @patch("bats_review.get_file")
+    @patch("bats_review.log")
+    def test_grep_notok_with_brackets(self, mock_log, mock_get_file):
+        """Test parsing TAP file with bracketed test numbers"""
+        tap_content = """1..2
+ok 1 [100] passing test
+not ok 2 [200] failing test with brackets in 200ms"""
+
+        mock_get_file.return_value = tap_content
+
+        result = grep_notok("http://example.com/test.tap.txt")
+
+        assert result == {"test.tap.txt:failing test with brackets in 200ms"}
+
+    @patch("bats_review.get_file")
+    @patch("bats_review.log")
+    def test_grep_notok_no_plan(self, mock_log, mock_get_file):
+        """Test handling of TAP file without plan"""
+        tap_content = """ok 1 test one
+not ok 2 failing test"""
+
+        mock_get_file.return_value = tap_content
+
+        with pytest.raises(SystemExit) as exc_info:
+            grep_notok("http://example.com/test.tap.txt")
+
+        assert exc_info.value.code == 1
+        mock_log.error.assert_called_with(
+            "Malformed TAP file: %s", "http://example.com/test.tap.txt"
+        )
+
+    @patch("bats_review.get_file")
+    @patch("bats_review.log")
+    def test_grep_notok_truncated(self, mock_log, mock_get_file):
+        """Test handling of truncated TAP file"""
+        tap_content = """1..3
+ok 1 test one
+not ok 2 failing test"""
+        # Missing the third test
+
+        mock_get_file.return_value = tap_content
+
+        with pytest.raises(SystemExit) as exc_info:
+            grep_notok("http://example.com/test.tap.txt")
+
+        assert exc_info.value.code == 1
+        mock_log.error.assert_called_with(
+            "Truncated TAP file: %s", "http://example.com/test.tap.txt"
+        )
+
+    @patch("bats_review.get_file")
+    def test_grep_notok_comments_ignored(self, mock_get_file):
+        """Test that commented 'not ok' lines are ignored"""
+        tap_content = """1..2
+ok 1 test one
+#not ok this is a comment
+not ok 2 real failure"""
+
+        mock_get_file.return_value = tap_content
+
+        with pytest.raises(SystemExit):
+            result = grep_notok("http://example.com/test.tap.txt")
+            assert result == {"test.tap.txt:real failure"}
+
+
+class TestProcessFiles:
+    """Test the process_tap_files function"""
+
+    @patch("bats_review.grep_notok")
+    def test_process_tap_files_single_file(self, mock_grep_notok):
+        """Test processing single TAP file"""
+        mock_grep_notok.return_value = {"file1:test1", "file1:test2"}
+
+        result = process_tap_files(["http://example.com/file1.tap.txt"])
+
+        assert result == {"file1:test1", "file1:test2"}
+        mock_grep_notok.assert_called_once_with("http://example.com/file1.tap.txt")
+
+    @patch("bats_review.grep_notok")
+    @patch("bats_review.ThreadPoolExecutor")
+    def test_process_tap_files_multiple_files(
+        self, mock_executor_class, mock_grep_notok
+    ):
+        """Test processing multiple TAP files with ThreadPoolExecutor"""
+        # Mock the ThreadPoolExecutor
+        mock_executor = Mock()
+        mock_executor_class.return_value.__enter__.return_value = mock_executor
+        mock_executor.map.return_value = [
+            {"file1:test1", "file1:test2"},
+            {"file2:test3"},
+        ]
+
+        files = ["http://example.com/file1.tap.txt", "http://example.com/file2.tap.txt"]
+        result = process_tap_files(files)
+
+        assert result == {"file1:test1", "file1:test2", "file2:test3"}
+        mock_executor_class.assert_called_once_with(max_workers=2)
+        mock_executor.map.assert_called_once_with(mock_grep_notok, files)
+
+
+class TestGetCloneChain:
+    """Test the resolve_clone_chain function"""
+
+    def setup_method(self):
+        """Clear cache before each test"""
+        get_job.cache_clear()
+
+    @patch("bats_review.get_job")
+    @patch("bats_review.log")
+    def test_resolve_clone_chain_single_job(self, mock_log, mock_get_job):
+        """Test clone chain with single job (no origin)"""
+        mock_get_job.return_value = {"id": 123, "settings": {"BATS_PACKAGE": "test"}}
+
+        result = resolve_clone_chain("http://openqa.example.com", 123)
+
+        assert result == [123]
+        mock_get_job.assert_called_once_with(
+            "http://openqa.example.com/api/v1/jobs/123/details"
+        )
+
+    @patch("bats_review.get_job")
+    def test_resolve_clone_chain_multiple_jobs(self, mock_get_job):
+        """Test clone chain with multiple jobs"""
+
+        def mock_job_response(url):
+            job_id = int(url.split("/")[-2])  # Extract job ID from URL
+            if job_id == 123:
+                return {
+                    "id": 123,
+                    "settings": {
+                        "BATS_PACKAGE": "aardvark-dns"
+                    },  # Package with 1 expected log
+                    "origin_id": 122,
+                }
+            if job_id == 122:
+                return {
+                    "id": 122,
+                    "settings": {"BATS_PACKAGE": "test"},
+                    "origin_id": 121,
+                }
+            if job_id == 121:
+                return {"id": 121, "settings": {"BATS_PACKAGE": "test"}}
+            return None
+
+        mock_get_job.side_effect = mock_job_response
+
+        result = resolve_clone_chain("http://openqa.example.com", 123)
+
+        assert result == [123, 122, 121]
+
+    @patch("bats_review.get_job")
+    @patch("bats_review.log")
+    def test_resolve_clone_chain_not_bats_job(self, mock_log, mock_get_job):
+        """Test handling of non-BATS job"""
+        mock_get_job.return_value = {"id": 123, "settings": {"OTHER_SETTING": "value"}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            resolve_clone_chain("http://openqa.example.com", 123)
+
+        assert exc_info.value.code == 1
+        mock_log.error.assert_called_with("Not a BATS test: %d", 123)
+
+
+class TestMain:
+    """Test the main function"""
+
+    def setup_method(self):
+        """Clear cache before each test"""
+        get_job.cache_clear()
+
+    @patch("bats_review.resolve_clone_chain")
+    @patch("bats_review.log")
+    def test_main_no_clones(self, mock_log, mock_resolve_clone_chain):
+        """Test main function when no clones exist"""
+        mock_resolve_clone_chain.return_value = [123]
+
+        with pytest.raises(SystemExit) as exc_info:
+            main("http://openqa.example.com/tests/123")
+
+        assert exc_info.value.code == 0
+        mock_log.info.assert_called_with("No clones. Exiting")
+
+    @patch("bats_review.resolve_clone_chain")
+    @patch("bats_review.get_job")
+    @patch("bats_review.process_tap_files")
+    @patch("bats_review.log")
+    def test_main_no_common_failures(
+        self, mock_log, mock_process_tap_files, mock_get_job, mock_resolve_clone_chain
+    ):
+        """Test main function when no common failures exist"""
+        mock_resolve_clone_chain.return_value = [123, 122]
+
+        def mock_job_response(url):
+            return {
+                "id": int(url.split("/")[-2]),
+                "settings": {
+                    "BATS_PACKAGE": "aardvark-dns",
+                    "DISTRI": "opensuse",
+                },  # Package with 1 expected log
+                "ulogs": ["test.tap.txt"],
+            }
+
+        mock_get_job.side_effect = mock_job_response
+        mock_process_tap_files.side_effect = [
+            {"file1:test1", "file1:test2"},  # Job 123 failures
+            {"file1:test3", "file1:test4"},  # Job 122 failures (different)
+        ]
+
+        main("http://openqa.example.com/tests/123")
+
+        mock_log.info.assert_any_call("Processing clone chain: %s", "123 -> 122")
+        mock_log.info.assert_any_call(
+            "No common failures across clone chain. Tagging as PASSED."
+        )
+
+    @patch("bats_review.resolve_clone_chain")
+    @patch("bats_review.get_job")
+    @patch("bats_review.log")
+    def test_main_no_tap_logs(self, mock_log, mock_get_job, mock_resolve_clone_chain):
+        """Test main function when no TAP logs are found"""
+        mock_resolve_clone_chain.return_value = [123, 122]
+
+        def mock_job_response(url):
+            return {
+                "id": int(url.split("/")[-2]),
+                "settings": {"BATS_PACKAGE": "aardvark-dns"},
+                "ulogs": ["other.log"],  # No .tap.txt files
+            }
+
+        mock_get_job.side_effect = mock_job_response
+
+        with pytest.raises(SystemExit) as exc_info:
+            main("http://openqa.example.com/tests/123")
+
+        assert exc_info.value.code == 0
+        mock_log.info.assert_any_call("Job %s has no TAP logs, skipping", 123)
+        mock_log.info.assert_any_call("Job %s has no TAP logs, skipping", 122)
+        mock_log.info.assert_any_call("No logs found in chain. Exiting")
+
+    @patch("bats_review.resolve_clone_chain")
+    @patch("bats_review.get_job")
+    @patch("bats_review.log")
+    def test_main_insufficient_logs(
+        self, mock_log, mock_get_job, mock_resolve_clone_chain
+    ):
+        """Test main function when job has insufficient TAP logs"""
+        mock_resolve_clone_chain.return_value = [123, 122]
+
+        def mock_job_response(url):
+            return {
+                "id": int(url.split("/")[-2]),
+                "settings": {
+                    "BATS_PACKAGE": "podman",
+                    "DISTRI": "opensuse",
+                },  # Expects 4 logs
+                "ulogs": ["test1.tap.txt", "test2.tap.txt"],  # Only 2 logs
+            }
+
+        mock_get_job.side_effect = mock_job_response
+
+        with pytest.raises(SystemExit) as exc_info:
+            main("http://openqa.example.com/tests/123")
+
+        assert exc_info.value.code == 0
+        mock_log.info.assert_any_call("Job %s has only %d TAP logs, skipping", 123, 2)
+        mock_log.info.assert_any_call("Job %s has only %d TAP logs, skipping", 122, 2)
+        mock_log.info.assert_any_call("No logs found in chain. Exiting")
+
+    @patch("bats_review.resolve_clone_chain")
+    @patch("bats_review.get_job")
+    @patch("bats_review.process_tap_files")
+    @patch("bats_review.log")
+    def test_main_package_validation_all_packages(
+        self, mock_log, mock_process_tap_files, mock_get_job, mock_resolve_clone_chain
+    ):
+        """Test main function with all supported package types"""
+        test_cases = [
+            ("aardvark-dns", 1),
+            ("buildah", 2),
+            ("netavark", 1),
+            ("podman", 4),
+            ("runc", 2),
+            ("skopeo", 2),
+        ]
+
+        for package, expected_count in test_cases:
+            # Reset mocks for each test case
+            mock_log.reset_mock()
+            mock_process_tap_files.reset_mock()
+            mock_get_job.reset_mock()
+            mock_resolve_clone_chain.reset_mock()
+            get_job.cache_clear()
+
+            mock_resolve_clone_chain.return_value = [123, 122]
+
+            def mock_job_response(url):
+                return {
+                    "id": int(url.split("/")[-2]),
+                    "settings": {"BATS_PACKAGE": package, "DISTRI": "opensuse"},
+                    "ulogs": [f"test{i}.tap.txt" for i in range(1, expected_count + 1)],
+                }
+
+            mock_get_job.side_effect = mock_job_response
+            mock_process_tap_files.side_effect = [
+                {"file1:test1"},  # Job 123 failures
+                {"file1:test2"},  # Job 122 failures (different)
+            ]
+
+            main("http://openqa.example.com/tests/123")
+
+            mock_log.info.assert_any_call(
+                "No common failures across clone chain. Tagging as PASSED."
+            )
+
+    @patch("bats_review.resolve_clone_chain")
+    @patch("bats_review.get_job")
+    @patch("bats_review.log")
+    def test_main_no_logs(self, mock_log, mock_get_job, mock_resolve_clone_chain):
+        """Test main function when no TAP logs are found"""
+        mock_resolve_clone_chain.return_value = [123, 122]
+
+        def mock_job_response(url):
+            return {
+                "id": int(url.split("/")[-2]),
+                "settings": {"BATS_PACKAGE": "aardvark-dns"},
+                "ulogs": ["other.log"],  # No .tap.txt files
+            }
+
+        mock_get_job.side_effect = mock_job_response
+
+        with pytest.raises(SystemExit) as exc_info:
+            main("http://openqa.example.com/tests/123")
+
+        assert exc_info.value.code == 0
+        mock_log.info.assert_any_call("No logs found in chain. Exiting")
+
+    @patch("bats_review.resolve_clone_chain")
+    @patch("bats_review.get_job")
+    @patch("bats_review.process_tap_files")
+    @patch("bats_review.log")
+    def test_main_package_validation(
+        self, mock_log, mock_process_tap_files, mock_get_job, mock_resolve_clone_chain
+    ):
+        """Test main function with different package types and expected log counts"""
+        mock_resolve_clone_chain.return_value = [123, 122]
+
+        # Test buildah (expects 2 logs)
+        def mock_job_response(url):
+            return {
+                "id": int(url.split("/")[-2]),
+                "settings": {"BATS_PACKAGE": "buildah", "DISTRI": "opensuse"},
+                "ulogs": ["test1.tap.txt", "test2.tap.txt"],  # Correct count
+            }
+
+        mock_get_job.side_effect = mock_job_response
+        mock_process_tap_files.side_effect = [
+            {"file1:test1"},  # Job 123 failures
+            {"file1:test2"},  # Job 122 failures (different)
+        ]
+
+        main("http://openqa.example.com/tests/123")
+
+        mock_log.info.assert_any_call(
+            "No common failures across clone chain. Tagging as PASSED."
+        )
+
+    def test_main_url_normalization(self):
+        """Test URL normalization in main function"""
+        with patch("bats_review.resolve_clone_chain") as mock_resolve_clone_chain:
+            mock_resolve_clone_chain.return_value = [123]
+
+            with pytest.raises(SystemExit):
+                main("openqa.example.com/tests/123")  # No scheme
+
+            # Verify that the URL was normalized to include https://
+            mock_resolve_clone_chain.assert_called_with(
+                "https://openqa.example.com", 123
+            )
+
+
+class TestParseArgs:
+    """Test the parse_args function"""
+
+    @patch("sys.argv", ["script.py", "http://example.com/tests/123"])
+    def test_parse_args_success(self):
+        """Test successful argument parsing"""
+        args = parse_args()
+        assert args.url == "http://example.com/tests/123"
+
+    @patch("sys.argv", ["script.py"])
+    def test_parse_args_missing_url(self):
+        """Test argument parsing with missing URL"""
+        with pytest.raises(SystemExit):
+            parse_args()
+
+
+# Integration test
+class TestIntegration:
+    """Integration tests"""
+
+    @patch("bats_review.session")
+    def test_full_workflow_no_common_failures(self, mock_session):
+        """Test full workflow with no common failures"""
+
+        # Mock the HTTP responses
+        def mock_get(url, **kwargs):
+            mock_response = Mock()
+
+            if "/api/v1/jobs/123/details" in url:
+                mock_response.json.return_value = {
+                    "job": {
+                        "id": 123,
+                        "settings": {
+                            "BATS_PACKAGE": "aardvark-dns",
+                            "DISTRI": "opensuse",
+                        },  # Package with 1 expected log
+                        "origin_id": 122,
+                        "ulogs": ["test.tap.txt"],
+                    }
+                }
+            elif "/api/v1/jobs/122/details" in url:
+                mock_response.json.return_value = {
+                    "job": {
+                        "id": 122,
+                        "settings": {
+                            "BATS_PACKAGE": "aardvark-dns",
+                            "DISTRI": "opensuse",
+                        },  # Package with 1 expected log
+                        "ulogs": ["test.tap.txt"],
+                    }
+                }
+            elif "/tests/123/file/test.tap.txt" in url:
+                mock_response.text = """1..2
+ok 1 passing test
+not ok 2 failing test A"""
+            elif "/tests/122/file/test.tap.txt" in url:
+                mock_response.text = """1..2
+ok 1 passing test
+not ok 2 failing test B"""
+
+            return mock_response
+
+        mock_session.get.side_effect = mock_get
+
+        with patch("bats_review.log") as mock_log:
+            main("http://openqa.example.com/tests/123")
+            mock_log.info.assert_any_call(
+                "No common failures across clone chain. Tagging as PASSED."
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/openqa_bats_review_test.py
+++ b/tests/openqa_bats_review_test.py
@@ -61,7 +61,7 @@ class TestPackageExpectations:
         mock_get_job.side_effect = mock_job_response
 
         with pytest.raises(KeyError):
-            main("http://openqa.example.com/tests/123")
+            main("http://openqa.example.com/tests/123", dry_run=True)
 
 
 class TestRegexPattern:
@@ -381,7 +381,7 @@ class TestMain:
         mock_resolve_clone_chain.return_value = [123]
 
         with pytest.raises(SystemExit) as exc_info:
-            main("http://openqa.example.com/tests/123")
+            main("http://openqa.example.com/tests/123", dry_run=True)
 
         assert exc_info.value.code == 0
         mock_log.info.assert_called_with("No clones. Exiting")
@@ -412,7 +412,7 @@ class TestMain:
             {"file1:test3", "file1:test4"},  # Job 122 failures (different)
         ]
 
-        main("http://openqa.example.com/tests/123")
+        main("http://openqa.example.com/tests/123", dry_run=True)
 
         mock_log.info.assert_any_call("Processing clone chain: %s", "123 -> 122")
         mock_log.info.assert_any_call(
@@ -436,7 +436,7 @@ class TestMain:
         mock_get_job.side_effect = mock_job_response
 
         with pytest.raises(SystemExit) as exc_info:
-            main("http://openqa.example.com/tests/123")
+            main("http://openqa.example.com/tests/123", dry_run=True)
 
         assert exc_info.value.code == 0
         mock_log.info.assert_any_call("Job %s has no TAP logs, skipping", 123)
@@ -465,7 +465,7 @@ class TestMain:
         mock_get_job.side_effect = mock_job_response
 
         with pytest.raises(SystemExit) as exc_info:
-            main("http://openqa.example.com/tests/123")
+            main("http://openqa.example.com/tests/123", dry_run=True)
 
         assert exc_info.value.code == 0
         mock_log.info.assert_any_call("Job %s has only %d TAP logs, skipping", 123, 2)
@@ -512,7 +512,7 @@ class TestMain:
                 {"file1:test2"},  # Job 122 failures (different)
             ]
 
-            main("http://openqa.example.com/tests/123")
+            main("http://openqa.example.com/tests/123", dry_run=True)
 
             mock_log.info.assert_any_call(
                 "No common failures across clone chain. Tagging as PASSED."
@@ -535,7 +535,7 @@ class TestMain:
         mock_get_job.side_effect = mock_job_response
 
         with pytest.raises(SystemExit) as exc_info:
-            main("http://openqa.example.com/tests/123")
+            main("http://openqa.example.com/tests/123", dry_run=True)
 
         assert exc_info.value.code == 0
         mock_log.info.assert_any_call("No logs found in chain. Exiting")
@@ -564,7 +564,7 @@ class TestMain:
             {"file1:test2"},  # Job 122 failures (different)
         ]
 
-        main("http://openqa.example.com/tests/123")
+        main("http://openqa.example.com/tests/123", dry_run=True)
 
         mock_log.info.assert_any_call(
             "No common failures across clone chain. Tagging as PASSED."
@@ -576,7 +576,7 @@ class TestMain:
             mock_resolve_clone_chain.return_value = [123]
 
             with pytest.raises(SystemExit):
-                main("openqa.example.com/tests/123")  # No scheme
+                main("openqa.example.com/tests/123", dry_run=True)  # No scheme
 
             # Verify that the URL was normalized to include https://
             mock_resolve_clone_chain.assert_called_with(
@@ -649,7 +649,7 @@ not ok 2 failing test B"""
         mock_session.get.side_effect = mock_get
 
         with patch("bats_review.log") as mock_log:
-            main("http://openqa.example.com/tests/123")
+            main("http://openqa.example.com/tests/123", dry_run=True)
             mock_log.info.assert_any_call(
                 "No common failures across clone chain. Tagging as PASSED."
             )


### PR DESCRIPTION
This script is a post-processing fail-hook for BATS tests.  It fetches previous cloned BATS jobs to check whether we can tag a job as passed by doing a set intersection of all failed tests.

Related ticket: https://progress.opensuse.org/issues/186786

TODO
- [x] Plug into [openqa-label-known-issues-and-investigate-hook](https://github.com/os-autoinst/scripts/blob/master/openqa-label-known-issues-and-investigate-hook) when the job failed.
- [x] Exit early in the above script if not a BATS test (BATS_PACKAGE not in settings).
- [x] Actually tag the job as passed or soft-failed with a ticket: https://progress.opensuse.org/issues/187980

Example runs:

```
$ openqa-bats-review -n https://openqa.suse.de/tests/18971940
INFO: Processing clone chain: 18971940 -> 18971789 -> 18969737
INFO: Job 18971940 has no .tap.txt logs, skipping
INFO: No common failures across clone chain. Tagging as PASSED.
```

```
$ openqa-bats-review -n https://openqa.suse.de/tests/18971796
INFO: Processing clone chain: 18971796 -> 18971172 -> 18969587
INFO: Job 18969587 has no .tap.txt logs, skipping
INFO: No common failures across clone chain. Tagging as PASSED.
```

```
$ openqa-bats-review -n https://openqa.opensuse.org/tests/5277036
INFO: Processing clone chain: 5277036 -> 5276893
INFO: No common failures across clone chain. Tagging as PASSED.
```

```
$ openqa-bats-review -n https://openqa.opensuse.org/tests/5278048
INFO: Processing clone chain: 5278048 -> 5277036 -> 5276893
INFO: No common failures across clone chain. Tagging as PASSED
```

```
$ openqa-bats-review -n https://openqa.suse.de/tests/19007064
INFO: Processing clone chain: 19007064 -> 19006783 -> 19006702 -> 19006031 -> 19001173
INFO: Job 19006783 has no TAP logs, skipping
INFO: Job 19006702 has no TAP logs, skipping
INFO: No common failures across clone chain. Tagging as PASSED.
```

```
$ openqa-bats-review -n https://openqa.suse.de/tests/19014878
INFO: Processing clone chain: 19014878 -> 19014581 -> 19014531 -> 19012771
INFO: Common failures found across clone chain: buildah-buildah-user.tap.txt:bud-implicit-no-history
```

```
$ openqa-bats-review -n https://openqa.suse.de/tests/19014900
INFO: Processing clone chain: 19014900 -> 19014592 -> 19014540 -> 19012854
ERROR: Common failures found across clone chain: buildah-buildah-user.tap.txt:bud-implicit-no-history
```
