### PR TITLE
Fix reading build names

### DIFF
--- a/_common
+++ b/_common
@@ -284,7 +284,7 @@ get_image() {
 find_latest_published_tumbleweed_image() {
     local latest_builds build image=null assetname
     local tw_group_id=$1 arch=$2 machine=$3 type=$4
-    read -r -a latest_builds <<< "$(latest_published_tw_builds "$tw_group_id")"
+    read -r -d '' -a latest_builds <<< "$(latest_published_tw_builds "$tw_group_id")"
     if [[ "${#latest_builds[@]}" -eq 0 ]]; then
         warn "Unable to find latest published Tumbleweed builds."
         exit 1


### PR DESCRIPTION
Without the `-d` `read` will stop after the first line break. So we were only testing the latest build, which does not have a 64bit image.

Issue: https://progress.opensuse.org/issues/188136

I guess were just lucky for the last 3 years 1845c6d93026681eacfd0f02b46188f7d119a5a1 :four_leaf_clover: 