### PR TITLE
Print warning to stderr to avoid ending up in a variable

### DIFF
--- a/_common
+++ b/_common
@@ -300,7 +300,7 @@ find_latest_published_tumbleweed_image() {
         # This published build has an image available
         [[ "$image" != null ]] && break
         # Published but no image available, we'll try and continue
-        echo "Unable to determine $type image for Tumbleweed build '$build' (for architecture '$arch' and machine '$machine')."
+        warn "Unable to determine $type image for Tumbleweed build '$build' (for architecture '$arch' and machine '$machine')."
     done
     # No published image available
     if [[ "$image" = null ]]; then


### PR DESCRIPTION
The warning ended up in the setting:

    HDD_1: Unable to determine qcow image for Tumbleweed build '20250901' (for architecture 'x86_64' and machine '64bit'). opensuse-Tumbleweed-x86_64-20250829-minimalx@64bit.qcow2
https://openqa.opensuse.org/tests/5282086#settings

Issue: https://progress.opensuse.org/issues/188136