### PR TITLE
Improve matching of machine

### DIFF
--- a/_common
+++ b/_common
@@ -293,7 +293,7 @@ find_latest_published_tumbleweed_image() {
         if [[ "$type" = iso ]]; then
             assetname="Tumbleweed-NET-$arch-Snapshot$build-Media.iso$"
         else
-            assetname="Tumbleweed-$arch-$build-minimalx\\\\@$machine.*.qcow"
+            assetname="Tumbleweed-$arch-$build-minimalx\\\\@$machine.qcow"
         fi
         image=$(get_image "$assetname")
 


### PR DESCRIPTION
when machine=uefi, then uefi-uefi-vars.qcow2 will also match, which we don't want.

Issue: https://progress.opensuse.org/issues/188310