### PR TITLE
No need to specify Unit for os-autoinst-scripts-update-git.timer

### DIFF
--- a/systemd/os-autoinst-scripts-update-git.timer
+++ b/systemd/os-autoinst-scripts-update-git.timer
@@ -3,7 +3,6 @@ Description=Update git repository of os-autoinst-scripts
 
 [Timer]
 OnCalendar=*:0/3
-Unit=os-autoinst-scripts-update-git.service
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
If the names match the Unit is not implied.