### PR TITLE
openqa-bats-review: Make it Python 3.6 compatible

### DIFF
--- a/openqa-bats-review
+++ b/openqa-bats-review
@@ -15,8 +15,9 @@ import re
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from functools import cache
+from functools import lru_cache
 from urllib.parse import urlparse
+from typing import List, Set
 
 import requests
 from requests.exceptions import RequestException
@@ -46,7 +47,7 @@ client_args = [
 ]
 
 
-def call(cmds: list[str], dry_run: bool = False) -> str:
+def call(cmds: List[str], dry_run: bool = False) -> str:
     """
     Call openqa-cli
     """
@@ -94,7 +95,8 @@ def get_file(url: str) -> str:
     return got.text
 
 
-@cache
+# Note: We use lru_cache instead of cache to support Python 3.6
+@lru_cache(maxsize=None)
 def get_job(url: str) -> dict:
     """
     Get a job from openQA
@@ -112,7 +114,7 @@ def get_job(url: str) -> dict:
     return data["job"]
 
 
-def grep_notok(url: str) -> set[str]:
+def grep_notok(url: str) -> Set[str]:
     """
     Grep for "not ok" lines and return a set with the failing tests
     prefixed by the filename
@@ -148,7 +150,7 @@ def grep_notok(url: str) -> set[str]:
     return notok
 
 
-def process_tap_files(files: list[str]) -> set[str]:
+def process_tap_files(files: List[str]) -> Set[str]:
     """
     Process TAP files
     """
@@ -160,7 +162,7 @@ def process_tap_files(files: list[str]) -> set[str]:
         return set(itertools.chain.from_iterable(executor.map(grep_notok, files)))
 
 
-def resolve_clone_chain(openqa_host: str, job_id: int) -> list[int]:
+def resolve_clone_chain(openqa_host: str, job_id: int) -> List[int]:
     """
     Follow clones recursively and return the full chain:
     [job_id, origin_id, origin_id_of_origin, ...]
@@ -239,7 +241,7 @@ def main(url: str, dry_run: bool = False) -> None:
         log.info("No logs found in chain. Exiting")
         sys.exit(0)
 
-    common_failures: set[str] = set.intersection(*all_failures)
+    common_failures: Set[str] = set.intersection(*all_failures)
 
     if not common_failures:
         if not dry_run:


### PR DESCRIPTION
- [functools.cache](https://docs.python.org/3/library/functools.html#functools.cache) was added in version 3.9. Use `lru_cache(maxsize=None)` instead.
- Use typing.List & typing.Set

Tested with:
 `podman run --rm -it -v $PWD:/python registry.suse.com/bci/python:3.6 sh -c 'pip install requests ; /python/openqa-bats-review -h'`

Supersedes https://github.com/os-autoinst/scripts/pull/462