### PR TITLE
Enable retries in all `curl` commands (done via `runcurl`)

### DIFF
--- a/_common
+++ b/_common
@@ -96,11 +96,11 @@ shorten_string() {
 
 # Wrapper around curl that reports the HTTP status if it is not 200, and the
 # calling command and line
-# exp_retries: number of total tries - 0/unset for no retries. Sleep before each retry will double.
+# exp_retries: number of total tries - 0 for no retries. Sleep before each retry will double.
 runcurl() {
     local rc status_code body response
     local verbose="${verbose:-"false"}"
-    local exp_retries="${exp_retries:-"0"}"
+    local exp_retries="${exp_retries:-12}"
     for retry_exponent in $(seq 0 "$exp_retries"); do
         $verbose && warn "[debug] curl: Fetching ($*)"
         set +e

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -184,7 +184,7 @@ label_issue() {
         fi
     fi
     # search for issues with a subject search term
-    issues=${issues:-$(exp_retries=12 runcurl "${curl_args[@]}" -sS "$issue_query" | runjq -r '.issues | .[] | (.id,.subject,.tracker.name)')}
+    issues=${issues:-$(runcurl "${curl_args[@]}" -sS "$issue_query" | runjq -r '.issues | .[] | (.id,.subject,.tracker.name)')}
     investigate_issue "$testurl"
 }
 


### PR DESCRIPTION
This is about querying data from o3 for triggering openQA-in-openQA tests. However, it probably makes always sense to retry. Hence this change enables the retry behavior we already have in one place for all `curl` invocations via `runcurl`.

Related ticket: https://progress.opensuse.org/issues/187875