### PR TITLE
Submit new files via Git in os-autoinst-obs-auto-submit

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -120,7 +120,8 @@ make_git_submit_request() {
     cp -v ../../"$package"/* ./
 
     # commit and force push
-    $git commit --all --message "$title"
+    $git add --all
+    $git commit --message "$title"
     $git push -f || return $?
 
     # create PR


### PR DESCRIPTION
The `--all` flag of `git commit` does not add so far untracked files. Only the `--all` flag of `git add` does.