### PR TITLE
Avoid conflicts in PRs created via `os-autoinst-obs-auto-submit`

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -115,6 +115,10 @@ make_git_submit_request() {
     cd "$package"
     $git switch "$branch"
 
+    # base our changes on the latest state of the target repository (which is added as remote "parent" by git-obs)
+    $git fetch parent || return $?
+    $git reset --hard "parent/$branch"
+
     # remove everything and replace it with the updated files we have just created (in the calling function)
     rm -v ./*
     cp -v ../../"$package"/* ./


### PR DESCRIPTION
Base the PRs always on the latest version of the target branch (e.g. on `parent/leap-16.0` where parent is the remote
`gitea@src.opensuse.org:pool/openQA.git` as configured by `git-obs`) to avoid creating PRs that are in conflict.

Tested by adding a dummy commit on my forks branch and running the script locally. It created a PR with the dummy commit. Then I ran with script again with the changes of this PR and now the dummy commit is removed resulting in a clean PR. This is visible in the history of https://src.opensuse.org/pool/openQA/pulls/7.