### PR TITLE
feat: Add openqa-llm-investigate and integrate into auto-review hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v6
       - run: |
           pip install --upgrade pip
-          pip install pytest mocker pytest-mock
+          pip install .[dev]
           python --version
           pytest --version
       - run: |

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -36,6 +36,8 @@ main_requires:
   python3-requests:
   python3-sh:
   python3-tenacity:
+  python3-typer:
+  python3-httpx:
   retry:
   sed:
   sudo:

--- a/dist/rpm/os-autoinst-scripts-deps.spec
+++ b/dist/rpm/os-autoinst-scripts-deps.spec
@@ -31,7 +31,7 @@ BuildArch:      noarch
 Url:            https://github.com/os-autoinst/%{base_name}
 Source0:        %{base_name}-%{version}.tar.xz
 # The following line is generated from dependencies.yaml
-%define main_requires bash coreutils curl grep html-xml-utils iputils jq openQA-client openssh-clients osc perl >= 5.010 perl(Data::Dumper) perl(FindBin) perl(Getopt::Long) perl(Mojo::File) perl(Text::Markdown) perl(YAML::PP) python3-net-snmp python3-pynetbox python3-requests python3-sh python3-tenacity retry sed sudo xmlstarlet yq
+%define main_requires bash coreutils curl grep html-xml-utils iputils jq openQA-client openssh-clients osc perl >= 5.010 perl(Data::Dumper) perl(FindBin) perl(Getopt::Long) perl(Mojo::File) perl(Text::Markdown) perl(YAML::PP) python3-httpx python3-net-snmp python3-pynetbox python3-requests python3-sh python3-tenacity python3-typer retry sed sudo xmlstarlet yq
 # The following line is generated from dependencies.yaml
 %define test_requires perl(Test::MockModule) perl(Test::Most) perl(Test::Output) perl(Test::Warnings) python3-pytest python3-pytest-mock python3-radon
 # The following line is generated from dependencies.yaml

--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -21,9 +21,17 @@ investigate-and-bisect() {
     read -r test || rc=$?
     [[ -n "$test" ]] || return 0
     rc=0
-    openqa-investigate "$test" || rc=$?
+
+    # Call the new LLM investigation script first, which acts as a gatekeeper
+    # If it decides no further investigation is needed, it won't output the test URL.
+    local investigate_target
+    investigate_target=$(openqa-llm-investigate "$test" || true)
+
+    [[ -z "$investigate_target" ]] && return 0
+
+    openqa-investigate "$investigate_target" || rc=$?
     [[ "$rc" -eq 142 ]] && return "$rc"
-    openqa-trigger-bisect-jobs -v --url "$test" || rc=$?
+    openqa-trigger-bisect-jobs -v --url "$investigate_target" || rc=$?
     return "$rc"
 }
 

--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -25,7 +25,10 @@ investigate-and-bisect() {
     # Call the new LLM investigation script first, which acts as a gatekeeper
     # If it decides no further investigation is needed, it won't output the test URL.
     local investigate_target
-    investigate_target=$(openqa-llm-investigate "$test" || true)
+    if ! investigate_target=$(openqa-llm-investigate "$test"); then
+        warn "WARNING: openqa-llm-investigate failed, falling back to standard investigation"
+        investigate_target="$test"
+    fi
 
     [[ -z "$investigate_target" ]] && return 0
 

--- a/openqa-llm-investigate
+++ b/openqa-llm-investigate
@@ -1,0 +1,189 @@
+#!/usr/bin/python3
+# Copyright SUSE LLC
+# ruff: noqa: BLE001, E501, S404, S603, T201, TRY300, TRY400
+"""Investigates an openQA job failure using an LLM."""
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from typing import Annotated, Any
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+import typer
+
+USER_AGENT = "openqa-llm-investigate (https://github.com/os-autoinst/os-autoinst-scripts)"
+
+log = logging.getLogger(__name__)
+
+app = typer.Typer(add_completion=False)
+
+
+def fetch_json(client: httpx.Client, url: str) -> dict[str, Any]:
+    try:
+        response = client.get(url)
+        response.raise_for_status()
+        return response.json()
+    except Exception as e:
+        log.warning("Failed to fetch JSON from %s: %s", url, e)
+        return {}
+
+
+def fetch_text(client: httpx.Client, url: str, max_lines: int = 200) -> str:
+    try:
+        response = client.get(url)
+        response.raise_for_status()
+        text = response.text
+        lines = text.splitlines()
+        if len(lines) > max_lines:
+            return "\n".join(lines[-max_lines:])
+        return text
+    except Exception as e:
+        log.warning("Failed to fetch text from %s: %s", url, e)
+        return ""
+
+
+def post_comment(base_url: str, job_id: str, comment: str) -> None:
+    cmd = [
+        "openqa-cli",
+        "api",
+        "--header",
+        f"User-Agent: {USER_AGENT}",
+        "--host",
+        base_url,
+        "-X",
+        "POST",
+        f"jobs/{job_id}/comments",
+        f"text={comment}",
+    ]
+    try:
+        res = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        log.debug("Posted comment to %s/t%s: %s", base_url, job_id, res.stdout)
+    except subprocess.CalledProcessError as e:
+        log.error("Failed to post comment: %s", e.stderr)
+
+
+def setup_logging(verbose: int, quiet: bool) -> None:  # noqa: FBT001
+    if quiet:
+        level = logging.ERROR
+    elif verbose >= 2:
+        level = logging.DEBUG
+    elif verbose >= 1:
+        level = logging.INFO
+    else:
+        level = logging.WARNING
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s", stream=sys.stderr, force=True)
+
+
+def parse_job_url(job_url: str) -> tuple[str, str]:
+    parsed_url = urlparse(job_url)
+    if parsed_url.scheme:
+        base_url = urlunparse((parsed_url.scheme, parsed_url.netloc, "", "", "", ""))
+        job_id = parsed_url.path.replace("/tests/", "", 1)
+    else:
+        base_url = os.environ.get("OPENQA_URL", "https://openqa.opensuse.org")
+        job_id = job_url
+    return base_url, job_id
+
+
+@app.command()
+def investigate(
+    job_url: str = typer.Argument(..., help="The openQA test URL or job ID for which to trigger LLM investigation"),
+    verbose: Annotated[int, typer.Option("--verbose", "-v", count=True, help="Increase verbosity")] = 0,
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Quiet mode")] = False,  # noqa: FBT002
+    dry: Annotated[  # noqa: FBT002
+        bool, typer.Option("--dry", help="Dry run mode: output summary instead of posting a comment")
+    ] = False,
+) -> None:
+    setup_logging(verbose, quiet)
+    base_url, job_id = parse_job_url(job_url)
+
+    if not job_id.isdigit():
+        log.error("Invalid job ID: %s", job_id)
+        sys.exit(1)
+
+    llm_url = os.environ.get("LLM_API_URL", "http://localhost:8080/v1/chat/completions")
+    llm_model = os.environ.get("LLM_MODEL", "gemma-4-26B-A4B-it")
+
+    with httpx.Client(headers={"User-Agent": USER_AGENT}) as client:
+        # Fetch job details
+        job_data = fetch_json(client, f"{base_url}/api/v1/jobs/{job_id}")
+        if not job_data or "job" not in job_data:
+            log.error("Could not retrieve job data for job %s from %s", job_id, base_url)
+            sys.exit(1)
+        job = job_data["job"]
+
+        if job.get("result") == "passed":
+            log.info("Job %s passed, skipping investigation.", job_id)
+            sys.exit(0)
+
+        log_text = fetch_text(client, f"{base_url}/tests/{job_id}/file/autoinst-log.txt")
+        investigation = fetch_json(client, f"{base_url}/tests/{job_id}/investigation_ajax")
+
+        test_name = job.get("test", "unknown")
+        build = job.get("settings", {}).get("BUILD", "unknown")
+
+        # Search for similar failures in same build
+        search_query = f"{base_url}/api/v1/jobs?build={build}&test={test_name}&result=failed"
+        history_data = fetch_json(client, search_query)
+        other_failures = len(history_data.get("jobs", []))
+
+        prompt = f"""You are analyzing an openQA test run failure.
+Job details:
+- Test: {test_name}
+- Group: {job.get("group", "unknown")}
+- Build: {build}
+- Result: {job.get("result", "unknown")}
+- Number of times this failed in the same build: {other_failures}
+
+Investigation info (diff to last good):
+{json.dumps(investigation.get("diff_to_last_good", "None available"))}
+
+Log tail (last 200 lines):
+{log_text}
+
+Provide exactly 3 sentences answering:
+1. Is it a new or existing issue? Is it likely a product regression, test regression, or infrastructure problem?
+2. Does the same issue appear in other tests in the same build, and did it appear in the history of the same build?
+3. Should 'openqa-investigate' be triggered to schedule further bisect tests? Start your 3rd sentence EXACTLY with "INVESTIGATE: YES" or "INVESTIGATE: NO" followed by the reason.
+"""
+
+        req = {
+            "model": llm_model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.3,
+        }
+
+        try:
+            res = client.post(llm_url, json=req, timeout=300)
+            res.raise_for_status()
+            res_json = res.json()
+            llm_response = res_json["choices"][0]["message"]["content"]
+        except httpx.ConnectError:
+            log.error(
+                "Could not connect to LLM server at %s. Please check if the server is running or the LLM_API_URL environment variable is correct.",
+                llm_url,
+            )
+            sys.exit(1)
+        except httpx.HTTPStatusError as e:
+            log.error("LLM API returned an error status: %s. Detail: %s", e.response.status_code, e.response.text)
+            sys.exit(1)
+        except Exception as e:
+            log.error("LLM API request failed: %s", e)
+            sys.exit(1)
+
+        # Print the job URL to stdout ONLY if INVESTIGATE: YES is recommended
+        # This makes the script act as a gatekeeper, similar to `openqa-label-known-issues`
+        if "INVESTIGATE: YES" in llm_response.upper():
+            print(f"{base_url}/tests/{job_id}")
+
+        if dry:
+            print(f"**LLM Investigation summary:**\n\n{llm_response}")
+        else:
+            post_comment(base_url, job_id, f"**LLM Investigation summary:**\n\n{llm_response}")
+
+
+if __name__ == "__main__":
+    app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "tenacity",
 ]
 
-[dependency-groups]
+[project.optional-dependencies]
 dev = [
     "pytest",
     "pytest-cov",
@@ -29,6 +29,10 @@ dev = [
     "radon",
     "ruff",
 ]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "os-autoinst-scripts"
 dynamic = ["version"]
-description = ""
-readme = "Readme.md"
+description = "Collection of scripts for os-autoinst and openQA"
+readme = "README.md"
 requires-python = ">=3.9"
 license = "MIT"
 authors = [
@@ -19,6 +19,9 @@ dependencies = [
     "pynetbox",
     "tenacity",
 ]
+
+[tool.setuptools]
+packages = []
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,12 @@ classifiers = [
 ]
 
 dependencies = [
+    "httpx",
     "requests",
     "sh",
     "pynetbox",
     "tenacity",
+    "typer",
 ]
 
 [tool.setuptools]

--- a/test/03-openqa-label-known-issues-and-investigate-hook.t
+++ b/test/03-openqa-label-known-issues-and-investigate-hook.t
@@ -2,7 +2,7 @@
 
 source test/init
 
-plan tests 31
+plan tests 36
 dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 source "$dir/../openqa-label-known-issues-and-investigate-hook"
@@ -17,9 +17,9 @@ export LLM_INVESTIGATE_SKIP=false
 
 openqa-llm-investigate() {
     local testurl=$1
+    warn "- openqa-llm-investigate $testurl"
     "$LLM_INVESTIGATE_FAIL" && return 1
     "$LLM_INVESTIGATE_SKIP" && return 0
-    warn "- openqa-llm-investigate $testurl"
     echo "$testurl"
 }
 
@@ -90,9 +90,9 @@ export INVESTIGATE_RETRIGGER_HOOK=true
 try hook 123
 is "$rc" 142 'openqa-investigate exit code for retriggering hook script'
 
+# Test: No unknown issue (label returns nothing)
 openqa-label-known-issues() {
-    testurl=$1
-    warn "- openqa-label-known-issues $testurl"
+    warn "- openqa-label-known-issues $1"
     echo "nothing"
 }
 export INVESTIGATE_RETRIGGER_HOOK=false
@@ -103,9 +103,24 @@ hasnt "$got" "- openqa-llm-investigate"
 hasnt "$got" "- openqa-investigate"
 hasnt "$got" "- openqa-trigger-bisect-jobs"
 
+# Test: LLM says NO (investigate skip)
+openqa-label-known-issues() {
+    warn "- openqa-label-known-issues $1"
+    echo "[$1]($1): Unknown test issue, to be reviewed -> $1/file/autoinst-log.txt"
+}
 export LLM_INVESTIGATE_SKIP=true
 try hook 123
 is "$rc" 0 'successful hook (LLM says NO) (123)'
 has "$got" "- openqa-label-known-issues"
+has "$got" "- openqa-llm-investigate"
 hasnt "$got" "- openqa-investigate"
 hasnt "$got" "- openqa-trigger-bisect-jobs"
+
+# Test: LLM fails (fallback to standard investigation)
+export LLM_INVESTIGATE_SKIP=false
+export LLM_INVESTIGATE_FAIL=true
+try hook 123
+is "$rc" 0 'successful hook (LLM fails, fallback) (123)'
+has "$got" "WARNING: openqa-llm-investigate failed"
+has "$got" "- openqa-investigate"
+has "$got" "- openqa-trigger-bisect-jobs"

--- a/test/03-openqa-label-known-issues-and-investigate-hook.t
+++ b/test/03-openqa-label-known-issues-and-investigate-hook.t
@@ -2,7 +2,7 @@
 
 source test/init
 
-plan tests 22
+plan tests 31
 dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 source "$dir/../openqa-label-known-issues-and-investigate-hook"
@@ -12,6 +12,17 @@ export INVESTIGATE_FAIL=false
 export INVESTIGATE_RETRIGGER_HOOK=false
 
 # Mocking
+export LLM_INVESTIGATE_FAIL=false
+export LLM_INVESTIGATE_SKIP=false
+
+openqa-llm-investigate() {
+    local testurl=$1
+    "$LLM_INVESTIGATE_FAIL" && return 1
+    "$LLM_INVESTIGATE_SKIP" && return 0
+    warn "- openqa-llm-investigate $testurl"
+    echo "$testurl"
+}
+
 openqa-trigger-bisect-jobs() {
     echo "openqa-trigger-bisect-jobs ($@)"
 }
@@ -45,24 +56,28 @@ openqa-api-get() {
 try hook 123
 is "$rc" 0 'successful hook (123)'
 has "$got" "- openqa-label-known-issues"
+has "$got" "- openqa-llm-investigate"
 has "$got" "- openqa-investigate"
 has "$got" "- openqa-trigger-bisect-jobs"
 
 try hook 124
 is "$rc" 0 'successful hook (124)'
 hasnt "$got" "- openqa-label-known-issues"
+has "$got" "- openqa-llm-investigate"
 has "$got" "- openqa-investigate"
 has "$got" "- openqa-trigger-bisect-jobs"
 
 try hook 125
 is "$rc" 0 'successful hook (125)'
 hasnt "$got" "- openqa-label-known-issues"
+has "$got" "- openqa-llm-investigate"
 has "$got" "- openqa-investigate"
 has "$got" "- openqa-trigger-bisect-jobs"
 
 try hook 126
 is "$rc" 0 'successful hook (126)'
 hasnt "$got" "- openqa-label-known-issues"
+has "$got" "- openqa-llm-investigate"
 has "$got" "- openqa-investigate"
 has "$got" "- openqa-trigger-bisect-jobs"
 
@@ -83,6 +98,14 @@ openqa-label-known-issues() {
 export INVESTIGATE_RETRIGGER_HOOK=false
 try hook 123
 is "$rc" 0 'successful hook (no unknown issue) (123)'
+has "$got" "- openqa-label-known-issues"
+hasnt "$got" "- openqa-llm-investigate"
+hasnt "$got" "- openqa-investigate"
+hasnt "$got" "- openqa-trigger-bisect-jobs"
+
+export LLM_INVESTIGATE_SKIP=true
+try hook 123
+is "$rc" 0 'successful hook (LLM says NO) (123)'
 has "$got" "- openqa-label-known-issues"
 hasnt "$got" "- openqa-investigate"
 hasnt "$got" "- openqa-trigger-bisect-jobs"

--- a/tests/test_openqa_llm_investigate.py
+++ b/tests/test_openqa_llm_investigate.py
@@ -1,0 +1,242 @@
+# Copyright SUSE LLC
+"""Unit tests for openqa-llm-investigate."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import logging
+import pathlib
+import sys
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+import httpx
+import pytest
+
+# Load the script as module "llm_investigate" (the file is named `openqa-llm-investigate`)
+rootpath = pathlib.Path(__file__).parent.parent.resolve()
+loader = importlib.machinery.SourceFileLoader("llm_investigate", f"{rootpath}/openqa-llm-investigate")
+spec = importlib.util.spec_from_loader(loader.name, loader)
+assert spec is not None
+llm_investigate = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = llm_investigate
+loader.exec_module(llm_investigate)
+
+
+class TestFetchJson:
+    def test_fetch_json_success(self) -> None:
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_response = Mock()
+        mock_response.json.return_value = {"foo": "bar"}
+        mock_client.get.return_value = mock_response
+
+        res = llm_investigate.fetch_json(mock_client, "http://example.com")
+        assert res == {"foo": "bar"}
+        mock_client.get.assert_called_once_with("http://example.com")
+        mock_response.raise_for_status.assert_called_once()
+
+    def test_fetch_json_failure(self) -> None:
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError("error", request=Mock(), response=Mock())
+        mock_client.get.return_value = mock_response
+
+        res = llm_investigate.fetch_json(mock_client, "http://example.com")
+        assert res == {}
+
+
+class TestFetchText:
+    def test_fetch_text_success(self) -> None:
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_response = Mock()
+        # Create 300 lines of text
+        mock_response.text = "\n".join(f"line {i}" for i in range(300))
+        mock_client.get.return_value = mock_response
+
+        res = llm_investigate.fetch_text(mock_client, "http://example.com", max_lines=200)
+        lines = res.splitlines()
+        assert len(lines) == 200
+        assert lines[-1] == "line 299"
+
+    def test_fetch_text_failure(self) -> None:
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.side_effect = httpx.RequestError("error")
+
+        res = llm_investigate.fetch_text(mock_client, "http://example.com")
+        assert res == ""
+
+
+@patch("llm_investigate.subprocess.run")
+def test_post_comment(mock_run: MagicMock) -> None:
+    llm_investigate.post_comment("http://base", "123", "test comment")
+    mock_run.assert_called_once()
+    args = mock_run.call_args[0][0]
+    assert "openqa-cli" in args
+    assert "jobs/123/comments" in args
+    assert "text=test comment" in args
+
+
+@patch("llm_investigate.httpx.Client")
+@patch("llm_investigate.post_comment")
+@patch("builtins.print")
+def test_investigate_cmd(mock_print: MagicMock, mock_post: MagicMock, mock_client_class: MagicMock) -> None:
+    mock_client = MagicMock()
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    def mock_get(url: str, *args: Any, **kwargs: Any) -> Mock:
+        _ = args, kwargs
+        resp = Mock()
+        if "api/v1/jobs" in url and "build=" not in url:
+            resp.json.return_value = {
+                "job": {"id": 123, "result": "failed", "test": "my_test", "settings": {"BUILD": "1.0"}}
+            }
+        elif "investigation_ajax" in url:
+            resp.json.return_value = {"diff_to_last_good": {}}
+        elif "api/v1/jobs?build" in url:
+            resp.json.return_value = {"jobs": [{"id": 123}, {"id": 124}]}
+        elif "autoinst-log.txt" in url:
+            resp.text = "failed log"
+        else:
+            resp.json.return_value = {}
+        return resp
+
+    mock_client.get.side_effect = mock_get
+
+    def mock_post_call(url: str, json: dict[str, Any] | None = None, *args: Any, **kwargs: Any) -> Mock:
+        _ = url, json, args, kwargs
+        resp = Mock()
+        resp.json.return_value = {"choices": [{"message": {"content": "INVESTIGATE: YES. It is broken."}}]}
+        return resp
+
+    mock_client.post.side_effect = mock_post_call
+
+    llm_investigate.investigate("123")
+
+    mock_print.assert_called_once_with("https://openqa.opensuse.org/tests/123")
+    mock_post.assert_called_once()
+    assert "INVESTIGATE: YES" in mock_post.call_args[0][2]
+
+
+@patch("llm_investigate.httpx.Client")
+@patch("builtins.print")
+def test_investigate_cmd_passed_job(mock_print: MagicMock, mock_client_class: MagicMock) -> None:
+    mock_client = MagicMock()
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    def mock_get(url: str, *args: Any, **kwargs: Any) -> Mock:
+        _ = args, kwargs
+        resp = Mock()
+        if "api/v1/jobs" in url:
+            resp.json.return_value = {"job": {"id": 123, "result": "passed"}}
+        return resp
+
+    mock_client.get.side_effect = mock_get
+
+    with pytest.raises(SystemExit) as exc:
+        llm_investigate.investigate("123")
+
+    assert exc.value.code == 0
+    mock_print.assert_not_called()
+
+
+@patch("llm_investigate.httpx.Client")
+@patch("llm_investigate.post_comment")
+@patch("builtins.print")
+def test_investigate_cmd_dry_run(mock_print: MagicMock, mock_post: MagicMock, mock_client_class: MagicMock) -> None:
+    mock_client = MagicMock()
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    def mock_get(url: str, *args: Any, **kwargs: Any) -> Mock:
+        _ = args, kwargs
+        resp = Mock()
+        if "api/v1/jobs" in url and "build=" not in url:
+            resp.json.return_value = {
+                "job": {"id": 123, "result": "failed", "test": "my_test", "settings": {"BUILD": "1.0"}}
+            }
+        elif "investigation_ajax" in url:
+            resp.json.return_value = {"diff_to_last_good": {}}
+        elif "api/v1/jobs?build" in url:
+            resp.json.return_value = {"jobs": []}
+        elif "autoinst-log.txt" in url:
+            resp.text = "failed log"
+        else:
+            resp.json.return_value = {}
+        return resp
+
+    mock_client.get.side_effect = mock_get
+
+    def mock_post_call(url: str, json: dict[str, Any] | None = None, *args: Any, **kwargs: Any) -> Mock:
+        _ = url, json, args, kwargs
+        resp = Mock()
+        resp.json.return_value = {"choices": [{"message": {"content": "INVESTIGATE: NO. Already known."}}]}
+        return resp
+
+    mock_client.post.side_effect = mock_post_call
+
+    llm_investigate.investigate("123", dry=True)
+
+    # In dry run, it should print the summary instead of posting
+    mock_post.assert_not_called()
+    mock_print.assert_any_call("**LLM Investigation summary:**\n\nINVESTIGATE: NO. Already known.")
+
+
+@patch("llm_investigate.httpx.Client")
+@patch("llm_investigate.log")
+def test_investigate_cmd_connection_error(mock_log: MagicMock, mock_client_class: MagicMock) -> None:
+    mock_client = MagicMock()
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    def mock_get(url: str, *args: Any, **kwargs: Any) -> Mock:
+        _ = args, kwargs
+        resp = Mock()
+        if "api/v1/jobs" in url and "build=" not in url:
+            resp.json.return_value = {"job": {"id": 123, "result": "failed", "test": "my_test"}}
+        else:
+            resp.json.return_value = {}
+        return resp
+
+    mock_client.get.side_effect = mock_get
+    mock_client.post.side_effect = httpx.ConnectError("Connection refused")
+
+    with pytest.raises(SystemExit) as exc:
+        llm_investigate.investigate("123")
+
+    assert exc.value.code == 1
+    mock_log.error.assert_called_once()
+    assert "Could not connect to LLM server" in mock_log.error.call_args[0][0]
+
+
+@patch("llm_investigate.logging.basicConfig")
+def test_investigate_logging_levels(mock_basic_config: MagicMock) -> None:
+    # We need to mock httpx.Client to avoid real network calls during investigate() call
+    with patch("llm_investigate.httpx.Client"), patch("llm_investigate.fetch_json") as mock_fetch:
+        mock_fetch.return_value = {"job": {"id": 123, "result": "passed"}}
+
+        # Test default: warning
+        with pytest.raises(SystemExit):
+            llm_investigate.investigate("123", verbose=0, quiet=False)
+        mock_basic_config.assert_called_with(
+            level=logging.WARNING, format="%(levelname)s: %(message)s", stream=sys.stderr, force=True
+        )
+
+        # Test verbose 1: info
+        with pytest.raises(SystemExit):
+            llm_investigate.investigate("123", verbose=1, quiet=False)
+        mock_basic_config.assert_called_with(
+            level=logging.INFO, format="%(levelname)s: %(message)s", stream=sys.stderr, force=True
+        )
+
+        # Test verbose 2: debug
+        with pytest.raises(SystemExit):
+            llm_investigate.investigate("123", verbose=2, quiet=False)
+        mock_basic_config.assert_called_with(
+            level=logging.DEBUG, format="%(levelname)s: %(message)s", stream=sys.stderr, force=True
+        )
+
+        # Test quiet: error
+        with pytest.raises(SystemExit):
+            llm_investigate.investigate("123", verbose=0, quiet=True)
+        mock_basic_config.assert_called_with(
+            level=logging.ERROR, format="%(levelname)s: %(message)s", stream=sys.stderr, force=True
+        )


### PR DESCRIPTION
Motivation:
We want to integrate LLM analysis into the openQA investigation workflow to
provide concise summaries of test failures. This helps reviewers quickly
understand if an issue is a new product regression, a test regression, or an
infrastructure problem, without scheduling potentially costly openqa-investigate
jobs prematurely.

Design Choices:
- Created a standalone Python script `openqa-llm-investigate` using `typer`
  and `httpx`.
- The script acts as a gatekeeper in
  `openqa-label-known-issues-and-investigate-hook`: it parses the LLM's response
  and only outputs the job URL to trigger further bisections if the LLM
  determines it is necessary.
- Fetches job details, test results, and test history from the openQA API to
  build a comprehensive prompt.
- Used `pytest` and `unittest.mock` for unit testing the Python script.
- Updated the existing Bash test suite to mock and assert the execution of
  `openqa-llm-investigate`.

Example run `openqa-llm-investigate -v https://openqa.opensuse.org/tests/5841514 --dry`:

```
INFO: HTTP Request: GET https://openqa.opensuse.org/api/v1/jobs/5841514 "HTTP/1.1 200 OK"
INFO: HTTP Request: GET https://openqa.opensuse.org/tests/5841514/file/autoinst-log.txt "HTTP/1.1 200 OK"
INFO: HTTP Request: GET https://openqa.opensuse.org/tests/5841514/investigation_ajax "HTTP/1.1 200 OK"
INFO: HTTP Request: GET https://openqa.opensuse.org/api/v1/jobs?build=20260409-okurz-llm&test=extra_tests_gnome-okurz-llm&result=failed "HTTP/1.1 200 OK"
INFO: HTTP Request: POST http://localhost:8080/v1/chat/completions "HTTP/1.1 200 OK"
https://openqa.opensuse.org/tests/5841514
**LLM Investigation summary:**

The issue is an existing, recurring problem (failed 10 times in this build) that appears to be a product regression, as the failure is rooted in a low-level kernel panic/fatal page fault during the `multi_users_dm` test. Since the investigation info states "None available," we cannot determine if it is new compared to the last good build, but the high failure count suggests it is a persistent system instability. INVESTIGATE: YES, because the failure is a critical, low-level kernel crash affecting multiple runs in the current build, requiring deep system debugging.
```

Generated and posted example comment:
https://openqa.opensuse.org/tests/5841514#comment-887840

Benefits:
- Reduces the number of unnecessary and costly `openqa-investigate` jobs by
  filtering them through an LLM first.
- Provides immediate, actionable summaries of failures directly as openQA
  comments.
- Improves efficiency of test reviewers by providing context directly in the job
  page.

Related issue: https://progress.opensuse.org/issues/198056