### PR TITLE
chore(ci): bump checkout to v6

### DIFF
--- a/.github/workflows/backlog.yml
+++ b/.github/workflows/backlog.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check SUSE QE Tools WIP-Limit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: sudo apt-get install curl jq
       - name: Check SUSE QE Tools WIP-Limit
@@ -35,7 +35,7 @@ jobs:
     name: Set SUSE QE Tools due dates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: sudo apt-get install curl jq
       - name: Set SUSE QE Tools due dates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: |
           pip install --upgrade pip
           pip install pytest mocker pytest-mock
@@ -23,7 +23,7 @@ jobs:
     container:
       image: registry.opensuse.org/home/okurz/container/containers/os-autoinst-scripts-devel
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Static checks
         run: |
           git config --global --add safe.directory .

--- a/.github/workflows/obs-list-dependencies.yml
+++ b/.github/workflows/obs-list-dependencies.yml
@@ -11,7 +11,7 @@ jobs:
     container:
       image: registry.opensuse.org/opensuse/tumbleweed:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Enable source repositories and install script dependencies
         run: |
           zypper -n mr --enable repo-source

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -18,6 +18,6 @@ jobs:
       OPENQA_API_KEY: ${{ secrets.OPENQA_API_KEY }}
       OPENQA_API_SECRET: ${{ secrets.OPENQA_API_SECRET }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - run: |
           ./trigger-pflash-test

--- a/actions/clone-job/action.yaml
+++ b/actions/clone-job/action.yaml
@@ -5,7 +5,7 @@ description: 'Clone openQA job mentioned in PR description'
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         repository: os-autoinst/os-autoinst-scripts
         path: scripts


### PR DESCRIPTION
This also fixes a warning about outdated nodejs