### PR TITLE
openqa-investigate: Overwrite status of original job when needed

### DIFF
--- a/openqa-investigate
+++ b/openqa-investigate
@@ -308,6 +308,10 @@ post-investigate() {
     if is-ok "$retry_result"; then
         comment+=" $retry_result."$'\n\n'
         comment+="📋 **Likely a sporadic failure**."
+        force_status="$(echo "job_data" | runjq -r .job.settings._FORCE_STATUS_ON_RETRY)"
+        if [ "$force_status" != "null" ] && [ "$force_status" -gt 0 ]; then
+            comment+=$'\n'"label:force_result:$retry_result:retry_job_$retry_result"
+        fi
     else
         local product_issue=false
         local test_issue=false


### PR DESCRIPTION
The bare investigative retry job is a full clone of the failed job and should overwrite the status of the original job with its own status if it passed or softfailed to avoid manual intervention.

Introduce the `_FORCE_STATUS_ON_RETRY` variable to make this feature opt-in.



Related ticket: https://progress.opensuse.org/issues/186708