### PR TITLE
fix: allow to override PATH in hook script

### DIFF
--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -7,7 +7,7 @@ set -eo pipefail
 # on stdin and all left unknowns to "openqa-investigate"
 dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-PATH=$dir:$PATH
+PATH=$PATH:$dir
 
 # shellcheck source=/dev/null
 source "$dir"/_common


### PR DESCRIPTION
Overriding PATH with a hardcoded prefix to the current directory
prevents any further tweaking in the environment, e.g. as needed now on
o3 due to running an older Leap 15.6 environment where we can not easily
provide more recent needed Python dependencies. Moving the current
directory to the end of PATH ensures that we can still look-up local
applications if not already provided in the system context while still
allowing to override from the outside as necessary.

Related issue: https://progress.opensuse.org/issues/199907