### PR TITLE
fix(changelog): Avoid submitting unwanted changes in existing entries

### DIFF
--- a/_common
+++ b/_common
@@ -6,6 +6,7 @@
 errorlog=""
 prefix="${prefix:-""}"
 osc="${osc:-"$prefix retry -e -- osc"}"
+submit_target=${submit_target:-openSUSE:Factory}
 
 warn() { printf '%s\n' "$@" >&2; }
 
@@ -363,6 +364,26 @@ delete_packages_from_obs_project() {
         log-info "Deleting $package from $obs_project"
         $osc rdelete -m "Cleaning up $package to allow triggering new jobs" "$obs_project" "$package"
     done
+}
+
+last_revision() {
+    log-debug "last_revision $*"
+    local project=$1
+    local package=$2
+    local file=$package.changes
+    local service=obs_scm
+    if [[ $project != "$submit_target" ]]; then
+        file=_service:$service:$file
+    fi
+    local line
+    # prevent SIGPIPE triggering osc cat to fail with the command group piping
+    # exceeding output to /dev/null
+    line=$(debug_osc cat "$project/$package/$file" | {
+        grep -m1 'Update to version'
+        cat > /dev/null
+    })
+    # shellcheck disable=SC2001
+    echo "$line" | sed -e 's,.*\.\([^.]*\):$,\1,'
 }
 
 declare _COLOR_BOLD='\x1b[1m'

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -7,7 +7,6 @@ color=${color:-auto}
 src_project=${src_project:-devel:openQA}
 dst_project=${dst_project:-${src_project}:tested}
 staging_project=${staging_project:-${src_project}:testing}
-orig_src_project=
 submit_target="${submit_target:-"openSUSE:Factory"}"
 dry_run="${dry_run:-"0"}"
 osc_poll_interval="${osc_poll_interval:-2}"
@@ -208,26 +207,6 @@ update_package() {
     return $rc
 }
 
-last_revision() {
-    log-debug "last_revision $*"
-    local project=$1
-    local package=$2
-    local file=$package.changes
-    local service=obs_scm
-    if [[ $project != "$submit_target" ]]; then
-        file=_service:$service:$file
-    fi
-    local line
-    # prevent SIGPIPE triggering osc cat to fail with the command group piping
-    # exceeding output to /dev/null
-    line=$(debug_osc cat "$project/$package/$file" | {
-        grep -m1 'Update to version'
-        cat > /dev/null
-    })
-    # shellcheck disable=SC2001
-    echo "$line" | sed -e 's,.*\.\([^.]*\):$,\1,'
-}
-
 sync_changesrevision() {
     log-info "sync_changesrevision $*"
     local dir=$1
@@ -266,7 +245,7 @@ generate_os-autoinst-distri-opensuse-deps_changelog() {
 
 handle_auto_submit() {
     log-info "handle_auto_submit $*"
-    local package=$1 sync_project=
+    local package=$1
     debug_osc service wait "$src_project" "$package"
     debug_osc co --server-side-source-service-files "$src_project"/"$package"
     if [[ "$package" == "os-autoinst-distri-opensuse-deps" ]]; then
@@ -279,18 +258,8 @@ handle_auto_submit() {
             return
         fi
     else
-        target_rev=$(last_revision "$submit_target" "$package")
-
-        # synchronize changes back to $src_project (or $orig_src_project in case $staging_project is used)
-        if [[ $orig_src_project ]]; then
-            sync_project=$orig_src_project
-            debug_osc co --server-side-source-service-files "$sync_project"/"$package"
-        else
-            sync_project=$src_project
-        fi
-        sync_changesrevision "$sync_project" "$package" "$target_rev"
-
         # skip submission if there is nothing new to submit
+        target_rev=$(last_revision "$submit_target" "$package")
         if [[ "$target_rev" == "$(last_revision "$src_project" "$package")" ]]; then
             log-info "Latest revision already in $submit_target"
             return
@@ -350,7 +319,6 @@ submit() {
     # submit from staging project if specified
     local must_cleanup_staging=
     if [[ -n $staging_project && $staging_project != none && $staging_project != "$src_project" ]]; then
-        orig_src_project=$src_project
         src_project=$staging_project
         must_cleanup_staging=1
     fi

--- a/trigger-openqa_in_openqa
+++ b/trigger-openqa_in_openqa
@@ -25,6 +25,7 @@ osc=${osc:-retry -e -- osc}
 src_project=${src_project:-devel:openQA}
 staging_project=${staging_project:-${src_project}:testing}
 dst_project=${dst_project:-${src_project}:tested}
+submit_target=${submit_target:-openSUSE:Factory}
 scenario_definitions="${scenario_definitions:-"scenario-definitions.yaml"}"
 
 # shellcheck source=/dev/null
@@ -76,8 +77,23 @@ create_snapshots() {
     $osc release --no-delay --target-project "$staging_project" --target-repository=openSUSE_Tumbleweed -r openSUSE_Tumbleweed -a x86_64 "$src_project" "$package"
 }
 
+sync_changesrevision() {
+    log-info "sync_changesrevision $*"
+    local dir=$1
+    local package=$2
+    local target_rev=$3
+    path="$dir/$package"
+    $client_prefix xmlstarlet ed -L -u "//param[@name='changesrevision']" -v "$target_rev" "$path"/_servicedata
+    if ! diff -u "$path"/.osc/_servicedata "$path"/_servicedata; then
+        debug_osc up "$path"
+        debug_osc cat "$submit_target" "$package" "$package".changes > "$path/$package".changes
+        debug_osc ci -m "sync changesrevision with $submit_target" "$path"
+        debug_osc up --server-side-source-service-files "$path"
+    fi
+}
+
 create_devel_openqa_snapshot() {
-    local auto_submit_packages staged_packages
+    local auto_submit_packages staged_packages target_rev
     auto_submit_packages=$(list_packages "$dst_project")
     staged_packages=$(list_packages "$staging_project") || true # osc ls returns non-zero return code for empty projects
     if [[ $staged_packages ]]; then
@@ -97,6 +113,9 @@ create_devel_openqa_snapshot() {
             delete_packages_from_obs_project "$staging_project"
             return
         fi
+        target_rev=$(last_revision "$submit_target" "$package")
+        debug_osc co --server-side-source-service-files "$src_project"/"$package"
+        sync_changesrevision "$src_project" "$package" "$target_rev"
         create_snapshots "$package"
     done
     log-info "Wait until all packages are published under $staging_project"


### PR DESCRIPTION
* Move `last_revision` to `_common` without changing it.
* Move `sync_changesrevision` to `trigger-openqa_in_openqa` without changing it.
* Sync the changelog changes from `openSUSE:Factory` back to `openQA:devel` before triggering tests by moving that part from `os-autoinst-obs-auto-submit` to `trigger-openqa_in_openqa`:
    * So the syncing happens before the snap-shooting the staging packages in `devel:openQA:testing`.
    * So the changelog of the packages we submit from `devel:openQA:testing` is based on what is in `openSUSE:Factory` (and not one revision behind).
* Note that this might not fix all problems with the changelog entirely; especially the duplicate entries that are already present in very old entries might not be fixed.

Related ticket: https://progress.opensuse.org/issues/199433