### PR TITLE
Improved Python style checks for other usual projects we maintain 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,19 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - run: |
-          pip install --upgrade pip
-          pip install .[dev]
-          python --version
-          pytest --version
+      - uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Setup enviroment
+        run: uv sync --extra dev
       - run: |
           sudo apt-get install cpanminus html-xml-utils xmlstarlet
           sudo cpanm -n -M https://cpan.metacpan.org --installdeps .
       - name: unit- and integration tests
-        run: |
-         make test-unit
+        run: uv run make test-unit
 
   style:
     runs-on: ubuntu-latest
@@ -28,7 +30,14 @@ jobs:
       image: registry.opensuse.org/home/okurz/container/containers/os-autoinst-scripts-devel
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
       - name: Static checks
         run: |
           git config --global --add safe.directory .
-          make checkstyle
+          uv sync --extra dev
+          uv run make checkstyle

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /tests/__pycache__/
 /__pycache__/
 .*.swp
+/uv.lock

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test-online:
 	# Invalid JSON causes the job to abort with an error
 	-tw_openqa_host=example.com dry_run=1 ./trigger-openqa_in_openqa
 
-checkstyle: test-shellcheck test-yaml checkstyle-python
+checkstyle: test-shellcheck test-yaml checkstyle-python check-code-health
 
 shfmt:
 	shfmt -w ${SH_FILES}
@@ -57,9 +57,22 @@ test-yaml:
 	@which yamllint >/dev/null 2>&1 || echo "Command 'yamllint' not found, can not execute YAML syntax checks"
 	yamllint --strict $$(git ls-files "*.yml" "*.yaml" ":!external/")
 
-checkstyle-python:
+checkstyle-python: check-ruff check-conventions
+check-ruff:
 	@which ruff >/dev/null 2>&1 || echo "Command 'ruff' not found, can not execute python style checks"
-	ruff format --check && ruff check
+	ruff check
+	ruff format --check
+
+check-conventions:
+	@if git grep -nE '^\s*@(unittest\.mock\.|mock\.)?patch' tests/; then \
+		echo "Error: @patch decorator detected. Avoid to prevent argument ordering bugs."; \
+		echo "   Fix: Use the 'mocker' fixture (pytest-mock) or a 'with patch():' context manager."; \
+		exit 1; \
+	fi
+
+check-code-health:
+	@echo "Checking code health…"
+	@vulture $$(git ls-files "**.py") --min-confidence 80
 
 update-deps:
 	tools/update-deps --cpanfile cpanfile --specfile dist/rpm/os-autoinst-scripts-deps.spec

--- a/check-netbox-machine-state.py
+++ b/check-netbox-machine-state.py
@@ -1,5 +1,11 @@
 #!/usr/bin/python3
 # Copyright SUSE LLC
+"""Verify qe-lsg NetBox machines with non-excluded statuses are not reachable via ping.
+
+Exits 1 if any such machine responds to ping, indicating it is unexpectedly powered on.
+By default machines with status active, unused, or staged are excluded from the check.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -16,6 +22,7 @@ ping_args = {"-c1", "-W1"}
 
 
 def check_ping(destination: str | pynetbox.models.ipam.IpAddresses) -> bool:
+    """Signal (True) that a machine is reachable when it should not be."""
     destination = str(destination).split("/")[0]
     try:
         _ = ping(destination, *ping_args)
@@ -26,6 +33,7 @@ def check_ping(destination: str | pynetbox.models.ipam.IpAddresses) -> bool:
 
 
 def check_machine(machine: pynetbox.models.dcim.Devices) -> bool:
+    """Detect reachability across all known addresses of a machine to avoid false negatives."""
     attributes_to_check = {"oob_ip", "primary_ip", "primary_ip4", "primary_ip6"}
     machine_attributes = [getattr(machine, attr) for attr in attributes_to_check if getattr(machine, attr) is not None]
     log.debug(
@@ -35,6 +43,7 @@ def check_machine(machine: pynetbox.models.dcim.Devices) -> bool:
 
 
 def main(args: argparse.Namespace) -> int:
+    """Fail if any non-excluded qe-lsg machine is still reachable, indicating it was not properly powered off."""
     nb = pynetbox.api(args.netbox_url, token=args.netbox_token)
 
     excluded_states = reduce(operator.add, args.exclude_status)
@@ -47,6 +56,7 @@ def main(args: argparse.Namespace) -> int:
 
 
 def loglevel_to_int(loglevel: str) -> int:
+    """Allow LOGLEVEL env var to set the default verbosity as if the user had passed that many -v flags."""
     loglevel_step = logging.CRITICAL - logging.ERROR
     max_loglevel = logging.CRITICAL / loglevel_step
     return max_loglevel - int(getattr(logging, loglevel.upper(), None) / loglevel_step)
@@ -78,6 +88,6 @@ if __name__ == "__main__":
         3: logging.INFO,
         4: logging.DEBUG,
     }
-    log.setLevel(logging.DEBUG if args.verbose > 4 else verbose_to_log[args.verbose])
+    log.setLevel(logging.DEBUG if args.verbose > max(verbose_to_log) else verbose_to_log[args.verbose])
     log.debug(args)
     sys.exit(main(args))

--- a/check-netbox-unused-machine-power.py
+++ b/check-netbox-unused-machine-power.py
@@ -1,10 +1,11 @@
 #!/usr/bin/python3
 # Copyright SUSE LLC
-
 # ruff: noqa: T201
+"""Report QE machines that draw unexpected power via SNMP PDU queries.
 
-# This script will exit 1 if QE machines that are marked as unused
-# in netbox still draw more than MAX_POWER Watts (default: 5).
+Exits 1 if any machine not marked active in NetBox draws more than MAX_POWER Watts (default: 5),
+indicating it may still be powered on despite being decommissioned or unused.
+"""
 
 import os
 import re
@@ -14,6 +15,8 @@ from urllib.parse import urlparse
 import netsnmp
 import pynetbox
 
+BACHMANN_RELAY_ON = 19  # Bachmann PDU relay status value for "on"
+
 verbose = os.environ.get("VERBOSE") == "1"
 debug = os.environ.get("DEBUG") == "1"
 netbox_token = os.environ["NETBOX_TOKEN"]
@@ -21,12 +24,14 @@ max_power = int(os.environ.get("MAX_POWER", "5"))
 
 
 def snmp_get(host: str, community: str, oid: str) -> int:
+    """Retrieve a single integer SNMP value by OID from the given host."""
     if debug:
         print(f"snmp_get({host=}, {community=}, {oid=})")
     return int(netsnmp.snmpget(oid, Version=1, DestHost=host, Community=community)[0])
 
 
 def pdu_get_power(host: str, outlet: int) -> tuple[int, bool]:
+    """Return watts and relay state for a PDU outlet, dispatching by PDU type and location."""
     if debug:
         print(f"get_pdu_power({host=}, {outlet=})")
     parsed = urlparse(host if "://" in host else f"//{host}")
@@ -46,8 +51,8 @@ def pdu_get_power(host: str, outlet: int) -> tuple[int, bool]:
             fuse = (outlet - 1) // 14
             port = (outlet - 1) % 14
             watts = snmp_get(snmp_proxy, community, f".1.3.6.1.4.1.31770.2.2.8.4.1.5.0.0.0.0.{fuse}.{port}.0.19") // 10
-            # 19=on, 20=off
-            relay = snmp_get(snmp_proxy, community, f".1.3.6.1.4.1.31770.2.2.9.1.1.5.0.0.0.0.{fuse}.{port}.0.0") == 19
+            relay_oid = f".1.3.6.1.4.1.31770.2.2.9.1.1.5.0.0.0.0.{fuse}.{port}.0.0"
+            relay = snmp_get(snmp_proxy, community, relay_oid) == BACHMANN_RELAY_ON
         elif host.startswith("pdu-j"):
             # PRG2-J PDUs are type Rittal and can be reached via SNMP proxy on qe-jumpy.prg2.suse.org
             var_index_watts = 175 + (outlet - 1) * 33
@@ -59,20 +64,24 @@ def pdu_get_power(host: str, outlet: int) -> tuple[int, bool]:
 
 
 def red(s: str) -> str:
+    """Wrap string in ANSI red color codes."""
     return f"\x1b[31m{s}\x1b[0m"
 
 
 def green(s: str) -> str:
+    """Wrap string in ANSI green color codes."""
     return f"\x1b[32m{s}\x1b[0m"
 
 
 def print_device(device: pynetbox.models.dcim.Devices, dev_pdu_power: dict, watts: int) -> None:
+    """Report device power consumption per PDU outlet for human review."""
     s = "  " if verbose else ""
     dev_pdu_power = " ".join([f"{h}:{green(p) if s else red(p)}={w}W" for (h, p), (w, s) in dev_pdu_power.items()])
     print(f"{s}{device.name} status={device.status.value} {dev_pdu_power} ∑{watts}W")
 
 
 def print_no_connection(device: pynetbox.models.dcim.Devices) -> None:
+    """Warn that power consumption for this device cannot be verified."""
     if verbose:
         print(f"No connection for {device.name} ({device.display_url})", file=sys.stderr)
 

--- a/openqa-powermanagement.py
+++ b/openqa-powermanagement.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 # Copyright SUSE LLC
+"""Power management for openQA worker machines based on scheduled job requirements."""
+
 import argparse
 import configparser
 import json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "coverage",
     "radon",
     "ruff",
+    "vulture",
 ]
 
 [build-system]
@@ -104,7 +105,7 @@ extend-select =[
     "PT", # https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt
     "SLOT", # https://docs.astral.sh/ruff/rules/#flake8-slots-slot
     "TID", # https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid
-    #"TC", # https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc
+    "TC", # https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc
     "PTH", # https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
     "FLY", # https://docs.astral.sh/ruff/rules/#flynt-fly
     "NPY", # https://docs.astral.sh/ruff/rules/#numpy-specific-rules-npy
@@ -118,45 +119,20 @@ extend-select =[
 ]
 
 ignore = [
-    "D100",   # missing-module-docstring
-    "D101",   # missing-class-docstring
-    "D102",   # missing-method-docstring
-    "D103",   # missing-function-docstring
-    "D104",   # missing-package-docstring
-    "D105",   # missing-magic-method-docstring
-    "D107",   # missing-init-docstring
     "D203",   # incorrect-blank-line-before-class
-    "N801",   # invalid-class-name
-    "N802",   # invalid-function-name
-    "N803",   # invalid-argument-name
-    "N806",   # invalid-variable-name
-    "UP032",
-    "PLC0415", # import-outside-toplevel
     "PLC1802", # use-implicit-booleaness-not-len
-    "F821",
-    "PLR0912", # too-many-branches
-    "PLR0913", # too-many-arguments
-    "PLR0914", # too-many-locals
-    "PLR0915", # too-many-statements
-    "PLR2004", # magic-value-comparison
     "D213", # multi-line-summary-second-line
-    "PLW2901", # redefined-loop-name
-    "PLW0127", # self-assigning-variable
-    "PLW0128", # redeclared-assigned-name
-    "PLW0129", # assert-on-string-literal
-    "B019",
-    "ANN401", # any-type
-    "S101",
-    "PLR6301", # no-self-use
-    "PLC1901", # compare-to-empty-string
+    "PLR0904", # too-many-public-methods
     "DOC201", # docstring-missing-returns
     "DOC501", # docstring-missing-exception
     "COM812", # missing-trailing-comma
-    "TC001", # typing-only-first-party-import
-    "TC002", # typing-only-third-party-import
-    "TC003", # typing-only-standard-library-import
-    "FURB140", # reimplemented-starmap: less efficient than comprehensions https://github.com/astral-sh/ruff/issues/7771
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 9
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["PLR2004", "ANN401", "PLR0913", "S101", "S105", "S106", "PLR0917", "D103"]
 
 [tool.ruff.format]
 # Enable reformatting of code snippets in docstrings.
@@ -165,3 +141,7 @@ docstring-code-format = true
 [tool.ruff.lint.flake8-copyright]
 author = "SUSE LLC"
 notice-rgx = "Copyright"
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"os.system".msg = "Use `subprocess.run` or `sh` library instead."
+"subprocess.call".msg = "Use `subprocess.run` with `check=True`."

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
 # Copyright SUSE LLC
+"""Test suite for os-autoinst-scripts."""

--- a/tests/test_openqa_bats_review.py
+++ b/tests/test_openqa_bats_review.py
@@ -9,7 +9,7 @@ import importlib.util
 import pathlib
 import sys
 from typing import Any
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from requests.exceptions import RequestException
@@ -29,292 +29,281 @@ loader.exec_module(bats_review)
 #
 
 
-class TestGetFile:
-    @patch("bats_review.session")
-    def test_get_file_success(self, mock_session: MagicMock) -> None:
-        resp = Mock()
-        resp.text = "hello"
-        resp.raise_for_status = Mock()
-        mock_session.get.return_value = resp
+def test_get_file_success(mocker: pytest.MockerFixture) -> None:
+    mock_session = mocker.patch("bats_review.session")
+    resp = Mock()
+    resp.text = "hello"
+    resp.raise_for_status = Mock()
+    mock_session.get.return_value = resp
 
-        got = bats_review.get_file("http://example.com/foo.xml")
-        assert got == "hello"
-        mock_session.get.assert_called_once_with(
-            "http://example.com/foo.xml",
-            headers={"User-Agent": bats_review.USER_AGENT},
-            timeout=bats_review.TIMEOUT,
-        )
-        resp.raise_for_status.assert_called_once()
-
-    @patch("bats_review.session")
-    @patch("bats_review.log")
-    def test_get_file_request_exception(self, mock_log: MagicMock, mock_session: MagicMock) -> None:
-        mock_session.get.side_effect = RequestException("network")
-        with pytest.raises(SystemExit) as exc:
-            bats_review.get_file("http://example.com/foo.xml")
-        assert exc.value.code == 1
-        mock_log.exception.assert_called_once()
+    got = bats_review.get_file("http://example.com/foo.xml")
+    assert got == "hello"
+    mock_session.get.assert_called_once_with(
+        "http://example.com/foo.xml",
+        headers={"User-Agent": bats_review.USER_AGENT},
+        timeout=bats_review.TIMEOUT,
+    )
+    resp.raise_for_status.assert_called_once()
 
 
-class TestGetJob:
-    def setup_method(self) -> None:
-        # clear lru cache between tests
-        with contextlib.suppress(Exception):
-            bats_review.get_job.cache_clear()
-
-    @patch("bats_review.session")
-    def test_get_job_success(self, mock_session: MagicMock) -> None:
-        resp = Mock()
-        resp.json.return_value = {"job": {"id": 123, "state": "done"}}
-        resp.raise_for_status = Mock()
-        mock_session.get.return_value = resp
-
-        job = bats_review.get_job("http://host/api/v1/jobs/123")
-        assert job == {"id": 123, "state": "done"}
-        mock_session.get.assert_called_once_with(
-            "http://host/api/v1/jobs/123",
-            headers={"User-Agent": bats_review.USER_AGENT},
-            timeout=bats_review.TIMEOUT,
-        )
-
-    @patch("bats_review.session")
-    @patch("bats_review.log")
-    def test_get_job_request_exception(self, mock_log: MagicMock, mock_session: MagicMock) -> None:
-        mock_session.get.side_effect = RequestException("boom")
-        with pytest.raises(SystemExit) as exc:
-            bats_review.get_job("http://host/api/v1/jobs/123")
-        assert exc.value.code == 1
-        mock_log.exception.assert_called_once()
+def test_get_file_request_exception(mocker: pytest.MockerFixture) -> None:
+    mock_session = mocker.patch("bats_review.session")
+    mock_log = mocker.patch("bats_review.log")
+    mock_session.get.side_effect = RequestException("network")
+    with pytest.raises(SystemExit) as exc:
+        bats_review.get_file("http://example.com/foo.xml")
+    assert exc.value.code == 1
+    mock_log.exception.assert_called_once()
 
 
-class TestGrepFailures:
-    @patch("bats_review.get_file")
-    def test_grep_failures_success(self, mock_get_file: MagicMock) -> None:
-        # one passing, one failing testcase (with classname)
-        xml = """
-        <testsuite>
-          <testcase classname="suite1" name="ok"/>
-          <testcase classname="suite1" name="failing_test">
-            <failure>some failure</failure>
-          </testcase>
-        </testsuite>
-        """
-        mock_get_file.return_value = xml
-        result = bats_review.grep_failures("http://example.com/test.xml")
-        assert result == {"suite1:failing_test"}
+def test_get_job_success(mocker: pytest.MockerFixture) -> None:
+    with contextlib.suppress(Exception):
+        bats_review.get_job.cache_clear()
+    mock_session = mocker.patch("bats_review.session")
+    resp = Mock()
+    resp.json.return_value = {"job": {"id": 123, "state": "done"}}
+    resp.raise_for_status = Mock()
+    mock_session.get.return_value = resp
 
-    @patch("bats_review.get_file")
-    @patch("bats_review.log")
-    def test_grep_failures_malformed(self, mock_log: MagicMock, mock_get_file: MagicMock) -> None:
-        mock_get_file.return_value = "<this is not xml"
-        # script currently exits with code 1 on parse errors
-        with pytest.raises(SystemExit) as exc:
-            bats_review.grep_failures("http://example.com/test.xml")
-        assert exc.value.code == 1
-        mock_log.exception.assert_called_once()
+    job = bats_review.get_job("http://host/api/v1/jobs/123")
+    assert job == {"id": 123, "state": "done"}
+    mock_session.get.assert_called_once_with(
+        "http://host/api/v1/jobs/123",
+        headers={"User-Agent": bats_review.USER_AGENT},
+        timeout=bats_review.TIMEOUT,
+    )
 
 
-class TestProcessLogs:
-    @patch("bats_review.grep_failures")
-    def test_process_logs_single_file(self, mock_grep: MagicMock) -> None:
-        mock_grep.return_value = {"a", "b"}
-        res = bats_review.process_logs(["http://example.com/a.xml"])
-        assert res == {"a", "b"}
-        mock_grep.assert_called_once_with("http://example.com/a.xml")
-
-    @patch("bats_review.ThreadPoolExecutor")
-    def test_process_logs_multiple_files(self, mock_executor_class: MagicMock) -> None:
-        # build fake executor that returns map -> iterator of sets
-        fake_executor = Mock()
-        fake_executor.map.return_value = iter([{"f1"}, {"f2"}])
-        mock_executor_class.return_value.__enter__.return_value = fake_executor
-
-        files = ["one.xml", "two.xml"]
-        res = bats_review.process_logs(files)
-        assert res == {"f1", "f2"}
-        mock_executor_class.assert_called_once_with(max_workers=2)
-        fake_executor.map.assert_called_once()
+def test_get_job_request_exception(mocker: pytest.MockerFixture) -> None:
+    with contextlib.suppress(Exception):
+        bats_review.get_job.cache_clear()
+    mock_session = mocker.patch("bats_review.session")
+    mock_log = mocker.patch("bats_review.log")
+    mock_session.get.side_effect = RequestException("boom")
+    with pytest.raises(SystemExit) as exc:
+        bats_review.get_job("http://host/api/v1/jobs/123")
+    assert exc.value.code == 1
+    mock_log.exception.assert_called_once()
 
 
-class TestResolveCloneChain:
-    def setup_method(self) -> None:
-        with contextlib.suppress(Exception):
-            bats_review.get_job.cache_clear()
-
-    @patch("bats_review.get_job")
-    def test_resolve_clone_chain_single(self, mock_get_job: MagicMock) -> None:
-        mock_get_job.return_value = {"id": 123}
-        chain = bats_review.resolve_clone_chain("http://openqa", 123)
-        assert chain == [123]
-        mock_get_job.assert_called_once_with("http://openqa/api/v1/jobs/123/details")
-
-    @patch("bats_review.get_job")
-    def test_resolve_clone_chain_multiple(self, mock_get_job: MagicMock) -> None:
-        def side(url: str) -> dict[str, Any] | None:
-            jid = int(url.split("/")[-2])
-            if jid == 123:
-                return {"id": 123, "origin_id": 122}
-            if jid == 122:
-                return {"id": 122, "origin_id": 121}
-            if jid == 121:
-                return {"id": 121}
-            return None
-
-        mock_get_job.side_effect = side
-        chain = bats_review.resolve_clone_chain("http://openqa", 123)
-        assert chain == [123, 122, 121]
+def test_grep_failures_success(mocker: pytest.MockerFixture) -> None:
+    mock_get_file = mocker.patch("bats_review.get_file")
+    # one passing, one failing testcase (with classname)
+    mock_get_file.return_value = """
+    <testsuite>
+      <testcase classname="suite1" name="ok"/>
+      <testcase classname="suite1" name="failing_test">
+        <failure>some failure</failure>
+      </testcase>
+    </testsuite>
+    """
+    result = bats_review.grep_failures("http://example.com/test.xml")
+    assert result == {"suite1:failing_test"}
 
 
-class TestMain:
-    """Tests for the main function of openqa-bats-review."""
-
-    def setup_method(self) -> None:
-        with contextlib.suppress(Exception):
-            bats_review.get_job.cache_clear()
-
-    @patch("bats_review.resolve_clone_chain")
-    @patch("bats_review.log")
-    def test_main_no_clones(self, mock_log: MagicMock, mock_resolve: MagicMock) -> None:
-        mock_resolve.return_value = [123]  # single element -> "No clones"
-        with pytest.raises(SystemExit) as exc:
-            bats_review.main("http://openqa.example.com/tests/123", dry_run=True)
-        assert exc.value.code == 0
-        mock_log.info.assert_called_with("No clones. Exiting")
-
-    @patch("bats_review.resolve_clone_chain")
-    @patch("bats_review.get_job")
-    @patch("bats_review.process_logs")
-    def test_main_no_common_failures(
-        self,
-        mock_process_logs: MagicMock,
-        mock_get_job: MagicMock,
-        mock_resolve: MagicMock,
-    ) -> None:
-        """Two jobs in chain; each produces different failures -> no common failures.
-
-        main should log Tagging as PASSED.
-        """
-        mock_resolve.return_value = [123, 122]
-
-        def job_resp(url: str) -> dict[str, Any]:
-            jid = int(url.split("/")[-2])
-            return {
-                "id": jid,
-                "settings": {"TEST": "aardvark_testsuite", "DISTRI": "opensuse"},
-                "ulogs": ["test.xml"],
-            }
-
-        mock_get_job.side_effect = job_resp
-        # different failure sets for each job -> empty intersection
-        mock_process_logs.side_effect = [{"a"}, {"b"}]
-        # should return normally (no SystemExit) because script logs comment and returns
-        with patch("bats_review.log") as mock_log:
-            res = bats_review.main("http://openqa.example.com/tests/123", dry_run=True)
-        assert res is None
-        mock_log.info.assert_called_with("No common failures across clone chain. Tagging as PASSED.")
-
-    @patch("bats_review.resolve_clone_chain")
-    @patch("bats_review.get_job")
-    @patch("bats_review.log")
-    def test_main_insufficient_logs(
-        self, mock_log: MagicMock, mock_get_job: MagicMock, mock_resolve: MagicMock
-    ) -> None:
-        """If jobs do not have the expected number of logs (e.g. podman expects 4 but provides 2).
-
-        main should log the 'only X logs' messages for each job and eventually exit(0).
-        """
-        mock_resolve.return_value = [123, 122]
-
-        def job_resp(url: str) -> dict[str, Any]:
-            jid = int(url.split("/")[-2])
-            return {
-                "id": jid,
-                "settings": {"TEST": "podman_testsuite", "DISTRI": "opensuse"},
-                "ulogs": ["a.xml", "b.xml"],  # only 2, but podman expects 4
-            }
-
-        mock_get_job.side_effect = job_resp
-        with pytest.raises(SystemExit) as exc:
-            bats_review.main("http://openqa.example.com/tests/123", dry_run=True)
-        assert exc.value.code == 0
-        mock_log.info.assert_any_call("No logs found in chain. Exiting")
+def test_grep_failures_malformed(mocker: pytest.MockerFixture) -> None:
+    mock_get_file = mocker.patch("bats_review.get_file")
+    mock_log = mocker.patch("bats_review.log")
+    mock_get_file.return_value = "<this is not xml"
+    # script currently exits with code 1 on parse errors
+    with pytest.raises(SystemExit) as exc:
+        bats_review.grep_failures("http://example.com/test.xml")
+    assert exc.value.code == 1
+    mock_log.exception.assert_called_once()
 
 
-class TestParseArgs:
-    """Tests for the parse_args function."""
+def test_process_logs_single_file(mocker: pytest.MockerFixture) -> None:
+    mock_grep = mocker.patch("bats_review.grep_failures")
+    mock_grep.return_value = {"a", "b"}
+    res = bats_review.process_logs(["http://example.com/a.xml"])
+    assert res == {"a", "b"}
+    mock_grep.assert_called_once_with("http://example.com/a.xml")
 
-    @patch("sys.argv", ["script.py", "http://example.com/tests/123"])
-    def test_parse_args_success(self) -> None:
-        args = bats_review.parse_args()
-        assert args.url == "http://example.com/tests/123"
 
-    @patch("sys.argv", ["script.py"])
-    def test_parse_args_missing_url(self) -> None:
-        with pytest.raises(SystemExit):
-            bats_review.parse_args()
+def test_process_logs_multiple_files(mocker: pytest.MockerFixture) -> None:
+    mock_executor_class = mocker.patch("bats_review.ThreadPoolExecutor")
+    # build fake executor that returns map -> iterator of sets
+    fake_executor = Mock()
+    fake_executor.map.return_value = iter([{"f1"}, {"f2"}])
+    mock_executor_class.return_value.__enter__.return_value = fake_executor
+
+    files = ["one.xml", "two.xml"]
+    res = bats_review.process_logs(files)
+    assert res == {"f1", "f2"}
+    mock_executor_class.assert_called_once_with(max_workers=2)
+    fake_executor.map.assert_called_once()
+
+
+def test_resolve_clone_chain_single(mocker: pytest.MockerFixture) -> None:
+    with contextlib.suppress(Exception):
+        bats_review.get_job.cache_clear()
+    mock_get_job = mocker.patch("bats_review.get_job")
+    mock_get_job.return_value = {"id": 123}
+    chain = bats_review.resolve_clone_chain("http://openqa", 123)
+    assert chain == [123]
+    mock_get_job.assert_called_once_with("http://openqa/api/v1/jobs/123/details")
+
+
+def test_resolve_clone_chain_multiple(mocker: pytest.MockerFixture) -> None:
+    with contextlib.suppress(Exception):
+        bats_review.get_job.cache_clear()
+    mock_get_job = mocker.patch("bats_review.get_job")
+
+    def side(url: str) -> dict[str, Any] | None:
+        jid = int(url.split("/")[-2])
+        if jid == 123:
+            return {"id": 123, "origin_id": 122}
+        if jid == 122:
+            return {"id": 122, "origin_id": 121}
+        if jid == 121:
+            return {"id": 121}
+        return None
+
+    mock_get_job.side_effect = side
+    chain = bats_review.resolve_clone_chain("http://openqa", 123)
+    assert chain == [123, 122, 121]
+
+
+# main
+
+
+def test_main_no_clones(mocker: pytest.MockerFixture) -> None:
+    with contextlib.suppress(Exception):
+        bats_review.get_job.cache_clear()
+    mock_resolve = mocker.patch("bats_review.resolve_clone_chain")
+    mock_log = mocker.patch("bats_review.log")
+    mock_resolve.return_value = [123]  # single element -> "No clones"
+    with pytest.raises(SystemExit) as exc:
+        bats_review.main("http://openqa.example.com/tests/123", dry_run=True)
+    assert exc.value.code == 0
+    mock_log.info.assert_called_with("No clones. Exiting")
+
+
+def test_main_no_common_failures(mocker: pytest.MockerFixture) -> None:
+    """Two jobs in chain; each produces different failures -> no common failures.
+
+    main should log Tagging as PASSED.
+    """
+    with contextlib.suppress(Exception):
+        bats_review.get_job.cache_clear()
+    mock_resolve = mocker.patch("bats_review.resolve_clone_chain")
+    mock_get_job = mocker.patch("bats_review.get_job")
+    mock_process_logs = mocker.patch("bats_review.process_logs")
+    mock_log = mocker.patch("bats_review.log")
+    mock_resolve.return_value = [123, 122]
+
+    def job_resp(url: str) -> dict[str, Any]:
+        jid = int(url.split("/")[-2])
+        return {
+            "id": jid,
+            "settings": {"TEST": "aardvark_testsuite", "DISTRI": "opensuse"},
+            "ulogs": ["test.xml"],
+        }
+
+    mock_get_job.side_effect = job_resp
+    # different failure sets for each job -> empty intersection
+    mock_process_logs.side_effect = [{"a"}, {"b"}]
+    res = bats_review.main("http://openqa.example.com/tests/123", dry_run=True)
+    assert res is None
+    mock_log.info.assert_called_with("No common failures across clone chain. Tagging as PASSED.")
+
+
+def test_main_insufficient_logs(mocker: pytest.MockerFixture) -> None:
+    """If jobs do not have the expected number of logs (e.g. podman expects 4 but provides 2).
+
+    main should log the 'only X logs' messages for each job and eventually exit(0).
+    """
+    with contextlib.suppress(Exception):
+        bats_review.get_job.cache_clear()
+    mock_resolve = mocker.patch("bats_review.resolve_clone_chain")
+    mock_get_job = mocker.patch("bats_review.get_job")
+    mock_log = mocker.patch("bats_review.log")
+    mock_resolve.return_value = [123, 122]
+
+    def job_resp(url: str) -> dict[str, Any]:
+        jid = int(url.split("/")[-2])
+        return {
+            "id": jid,
+            "settings": {"TEST": "podman_testsuite", "DISTRI": "opensuse"},
+            "ulogs": ["a.xml", "b.xml"],  # only 2, but podman expects 4
+        }
+
+    mock_get_job.side_effect = job_resp
+    with pytest.raises(SystemExit) as exc:
+        bats_review.main("http://openqa.example.com/tests/123", dry_run=True)
+    assert exc.value.code == 0
+    mock_log.info.assert_any_call("No logs found in chain. Exiting")
+
+
+def test_parse_args_success(mocker: pytest.MockerFixture) -> None:
+    mocker.patch("sys.argv", ["script.py", "http://example.com/tests/123"])
+    args = bats_review.parse_args()
+    assert args.url == "http://example.com/tests/123"
+
+
+def test_parse_args_missing_url(mocker: pytest.MockerFixture) -> None:
+    mocker.patch("sys.argv", ["script.py"])
+    with pytest.raises(SystemExit):
+        bats_review.parse_args()
 
 
 # Integration test
 
 
-class TestIntegration:
-    """Integration tests for openqa-bats-review."""
+def test_full_workflow_no_common_failures(mocker: pytest.MockerFixture) -> None:
+    """Patch session.get to simulate two jobs each with a different failing testcase.
 
-    @patch("bats_review.log")
-    def test_full_workflow_no_common_failures(self, mock_log: MagicMock) -> None:
-        """Integration-style test: patch session.get to return proper JSON for job details.
+    Asserts that the script decides to tag as PASSED (dry_run) when there are no common failures.
+    """
+    mock_log = mocker.patch("bats_review.log")
 
-        and JUnit XML for files, simulate two jobs that each have a different failing
-        testcase, and assert that the script decides to tag as PASSED (dry_run).
-        """
-
-        def fake_get(url: str, **kwargs: Any) -> Mock:  # noqa: ARG001
-            m = Mock()
-            if "/api/v1/jobs/123/details" in url:
-                m.json.return_value = {
-                    "job": {
-                        "id": 123,
-                        "settings": {
-                            "TEST": "aardvark_testsuite",
-                            "DISTRI": "opensuse",
-                        },
-                        "origin_id": 122,
-                        "ulogs": ["test.xml"],
-                    }
+    def fake_get(url: str, **_kwargs: Any) -> Mock:
+        m = Mock()
+        if "/api/v1/jobs/123/details" in url:
+            m.json.return_value = {
+                "job": {
+                    "id": 123,
+                    "settings": {
+                        "TEST": "aardvark_testsuite",
+                        "DISTRI": "opensuse",
+                    },
+                    "origin_id": 122,
+                    "ulogs": ["test.xml"],
                 }
-            elif "/api/v1/jobs/122/details" in url:
-                m.json.return_value = {
-                    "job": {
-                        "id": 122,
-                        "settings": {
-                            "TEST": "aardvark_testsuite",
-                            "DISTRI": "opensuse",
-                        },
-                        "ulogs": ["test.xml"],
-                    }
+            }
+        elif "/api/v1/jobs/122/details" in url:
+            m.json.return_value = {
+                "job": {
+                    "id": 122,
+                    "settings": {
+                        "TEST": "aardvark_testsuite",
+                        "DISTRI": "opensuse",
+                    },
+                    "ulogs": ["test.xml"],
                 }
-            elif "/tests/123/file/test.xml" in url:
-                m.text = """
-                    <testsuite>
-                      <testcase classname="c" name="ok"/>
-                      <testcase classname="c" name="failA"><failure>err</failure></testcase>
-                    </testsuite>
-                """
-            elif "/tests/122/file/test.xml" in url:
-                m.text = """
-                    <testsuite>
-                      <testcase classname="c" name="ok"/>
-                      <testcase classname="c" name="failB"><failure>err</failure></testcase>
-                    </testsuite>
-                """
-            else:
-                # default (should not happen in this test)
-                m.json.return_value = {"job": {"id": 999, "ulogs": []}}
-            return m
+            }
+        elif "/tests/123/file/test.xml" in url:
+            m.text = """
+                <testsuite>
+                  <testcase classname="c" name="ok"/>
+                  <testcase classname="c" name="failA"><failure>err</failure></testcase>
+                </testsuite>
+            """
+        elif "/tests/122/file/test.xml" in url:
+            m.text = """
+                <testsuite>
+                  <testcase classname="c" name="ok"/>
+                  <testcase classname="c" name="failB"><failure>err</failure></testcase>
+                </testsuite>
+            """
+        else:
+            # default (should not happen in this test)
+            m.json.return_value = {"job": {"id": 999, "ulogs": []}}
+        return m
 
-        # patch the session used by the module
-        bats_review.session.get = fake_get
-        # run main and assert successful path (no SystemExit); openqa_comment should be called
-        res = bats_review.main("http://openqa.example.com/tests/123", dry_run=True)
-        assert res is None
-        mock_log.info.assert_called_with("No common failures across clone chain. Tagging as PASSED.")
+    # patch the session used by the module
+    bats_review.session.get = fake_get
+    # run main and assert successful path (no SystemExit)
+    res = bats_review.main("http://openqa.example.com/tests/123", dry_run=True)
+    assert res is None
+    mock_log.info.assert_called_with("No common failures across clone chain. Tagging as PASSED.")

--- a/tests/test_openqa_llm_investigate.py
+++ b/tests/test_openqa_llm_investigate.py
@@ -9,7 +9,7 @@ import logging
 import pathlib
 import sys
 from typing import Any
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock
 
 import httpx
 import pytest
@@ -24,51 +24,51 @@ sys.modules[loader.name] = llm_investigate
 loader.exec_module(llm_investigate)
 
 
-class TestFetchJson:
-    def test_fetch_json_success(self) -> None:
-        mock_client = MagicMock(spec=httpx.Client)
-        mock_response = Mock()
-        mock_response.json.return_value = {"foo": "bar"}
-        mock_client.get.return_value = mock_response
+def test_fetch_json_success() -> None:
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_response = Mock()
+    mock_response.json.return_value = {"foo": "bar"}
+    mock_client.get.return_value = mock_response
 
-        res = llm_investigate.fetch_json(mock_client, "http://example.com")
-        assert res == {"foo": "bar"}
-        mock_client.get.assert_called_once_with("http://example.com")
-        mock_response.raise_for_status.assert_called_once()
-
-    def test_fetch_json_failure(self) -> None:
-        mock_client = MagicMock(spec=httpx.Client)
-        mock_response = Mock()
-        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError("error", request=Mock(), response=Mock())
-        mock_client.get.return_value = mock_response
-
-        res = llm_investigate.fetch_json(mock_client, "http://example.com")
-        assert res == {}
+    res = llm_investigate.fetch_json(mock_client, "http://example.com")
+    assert res == {"foo": "bar"}
+    mock_client.get.assert_called_once_with("http://example.com")
+    mock_response.raise_for_status.assert_called_once()
 
 
-class TestFetchText:
-    def test_fetch_text_success(self) -> None:
-        mock_client = MagicMock(spec=httpx.Client)
-        mock_response = Mock()
-        # Create 300 lines of text
-        mock_response.text = "\n".join(f"line {i}" for i in range(300))
-        mock_client.get.return_value = mock_response
+def test_fetch_json_failure() -> None:
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_response = Mock()
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError("error", request=Mock(), response=Mock())
+    mock_client.get.return_value = mock_response
 
-        res = llm_investigate.fetch_text(mock_client, "http://example.com", max_lines=200)
-        lines = res.splitlines()
-        assert len(lines) == 200
-        assert lines[-1] == "line 299"
-
-    def test_fetch_text_failure(self) -> None:
-        mock_client = MagicMock(spec=httpx.Client)
-        mock_client.get.side_effect = httpx.RequestError("error")
-
-        res = llm_investigate.fetch_text(mock_client, "http://example.com")
-        assert res == ""
+    res = llm_investigate.fetch_json(mock_client, "http://example.com")
+    assert res == {}
 
 
-@patch("llm_investigate.subprocess.run")
-def test_post_comment(mock_run: MagicMock) -> None:
+def test_fetch_text_success() -> None:
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_response = Mock()
+    # Create 300 lines of text
+    mock_response.text = "\n".join(f"line {i}" for i in range(300))
+    mock_client.get.return_value = mock_response
+
+    res = llm_investigate.fetch_text(mock_client, "http://example.com", max_lines=200)
+    lines = res.splitlines()
+    assert len(lines) == 200
+    assert lines[-1] == "line 299"
+
+
+def test_fetch_text_failure() -> None:
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.get.side_effect = httpx.RequestError("error")
+
+    res = llm_investigate.fetch_text(mock_client, "http://example.com")
+    assert not res
+
+
+def test_post_comment(mocker: pytest.MockerFixture) -> None:
+    mock_run = mocker.patch("llm_investigate.subprocess.run")
     llm_investigate.post_comment("http://base", "123", "test comment")
     mock_run.assert_called_once()
     args = mock_run.call_args[0][0]
@@ -77,10 +77,10 @@ def test_post_comment(mock_run: MagicMock) -> None:
     assert "text=test comment" in args
 
 
-@patch("llm_investigate.httpx.Client")
-@patch("llm_investigate.post_comment")
-@patch("builtins.print")
-def test_investigate_cmd(mock_print: MagicMock, mock_post: MagicMock, mock_client_class: MagicMock) -> None:
+def test_investigate_cmd(mocker: pytest.MockerFixture) -> None:
+    mock_client_class = mocker.patch("llm_investigate.httpx.Client")
+    mock_post = mocker.patch("llm_investigate.post_comment")
+    mock_print = mocker.patch("builtins.print")
     mock_client = MagicMock()
     mock_client_class.return_value.__enter__.return_value = mock_client
 
@@ -118,9 +118,9 @@ def test_investigate_cmd(mock_print: MagicMock, mock_post: MagicMock, mock_clien
     assert "INVESTIGATE: YES" in mock_post.call_args[0][2]
 
 
-@patch("llm_investigate.httpx.Client")
-@patch("builtins.print")
-def test_investigate_cmd_passed_job(mock_print: MagicMock, mock_client_class: MagicMock) -> None:
+def test_investigate_cmd_passed_job(mocker: pytest.MockerFixture) -> None:
+    mock_client_class = mocker.patch("llm_investigate.httpx.Client")
+    mock_print = mocker.patch("builtins.print")
     mock_client = MagicMock()
     mock_client_class.return_value.__enter__.return_value = mock_client
 
@@ -140,10 +140,10 @@ def test_investigate_cmd_passed_job(mock_print: MagicMock, mock_client_class: Ma
     mock_print.assert_not_called()
 
 
-@patch("llm_investigate.httpx.Client")
-@patch("llm_investigate.post_comment")
-@patch("builtins.print")
-def test_investigate_cmd_dry_run(mock_print: MagicMock, mock_post: MagicMock, mock_client_class: MagicMock) -> None:
+def test_investigate_cmd_dry_run(mocker: pytest.MockerFixture) -> None:
+    mock_client_class = mocker.patch("llm_investigate.httpx.Client")
+    mock_post = mocker.patch("llm_investigate.post_comment")
+    mock_print = mocker.patch("builtins.print")
     mock_client = MagicMock()
     mock_client_class.return_value.__enter__.return_value = mock_client
 
@@ -181,9 +181,9 @@ def test_investigate_cmd_dry_run(mock_print: MagicMock, mock_post: MagicMock, mo
     mock_print.assert_any_call("**LLM Investigation summary:**\n\nINVESTIGATE: NO. Already known.")
 
 
-@patch("llm_investigate.httpx.Client")
-@patch("llm_investigate.log")
-def test_investigate_cmd_connection_error(mock_log: MagicMock, mock_client_class: MagicMock) -> None:
+def test_investigate_cmd_connection_error(mocker: pytest.MockerFixture) -> None:
+    mock_client_class = mocker.patch("llm_investigate.httpx.Client")
+    mock_log = mocker.patch("llm_investigate.log")
     mock_client = MagicMock()
     mock_client_class.return_value.__enter__.return_value = mock_client
 
@@ -207,36 +207,36 @@ def test_investigate_cmd_connection_error(mock_log: MagicMock, mock_client_class
     assert "Could not connect to LLM server" in mock_log.error.call_args[0][0]
 
 
-@patch("llm_investigate.logging.basicConfig")
-def test_investigate_logging_levels(mock_basic_config: MagicMock) -> None:
-    # We need to mock httpx.Client to avoid real network calls during investigate() call
-    with patch("llm_investigate.httpx.Client"), patch("llm_investigate.fetch_json") as mock_fetch:
-        mock_fetch.return_value = {"job": {"id": 123, "result": "passed"}}
+def test_investigate_logging_levels(mocker: pytest.MockerFixture) -> None:
+    mock_basic_config = mocker.patch("llm_investigate.logging.basicConfig")
+    mocker.patch("llm_investigate.httpx.Client")
+    mock_fetch = mocker.patch("llm_investigate.fetch_json")
+    mock_fetch.return_value = {"job": {"id": 123, "result": "passed"}}
 
-        # Test default: warning
-        with pytest.raises(SystemExit):
-            llm_investigate.investigate("123", verbose=0, quiet=False)
-        mock_basic_config.assert_called_with(
-            level=logging.WARNING, format="%(levelname)s: %(message)s", stream=sys.stderr, force=True
-        )
+    # Test default: warning
+    with pytest.raises(SystemExit):
+        llm_investigate.investigate("123", verbose=0, quiet=False)
+    mock_basic_config.assert_called_with(
+        level=logging.WARNING, format="%(levelname)s: %(message)s", stream=sys.stderr, force=True
+    )
 
-        # Test verbose 1: info
-        with pytest.raises(SystemExit):
-            llm_investigate.investigate("123", verbose=1, quiet=False)
-        mock_basic_config.assert_called_with(
-            level=logging.INFO, format="%(levelname)s: %(message)s", stream=sys.stderr, force=True
-        )
+    # Test verbose 1: info
+    with pytest.raises(SystemExit):
+        llm_investigate.investigate("123", verbose=1, quiet=False)
+    mock_basic_config.assert_called_with(
+        level=logging.INFO, format="%(levelname)s: %(message)s", stream=sys.stderr, force=True
+    )
 
-        # Test verbose 2: debug
-        with pytest.raises(SystemExit):
-            llm_investigate.investigate("123", verbose=2, quiet=False)
-        mock_basic_config.assert_called_with(
-            level=logging.DEBUG, format="%(levelname)s: %(message)s", stream=sys.stderr, force=True
-        )
+    # Test verbose 2: debug
+    with pytest.raises(SystemExit):
+        llm_investigate.investigate("123", verbose=2, quiet=False)
+    mock_basic_config.assert_called_with(
+        level=logging.DEBUG, format="%(levelname)s: %(message)s", stream=sys.stderr, force=True
+    )
 
-        # Test quiet: error
-        with pytest.raises(SystemExit):
-            llm_investigate.investigate("123", verbose=0, quiet=True)
-        mock_basic_config.assert_called_with(
-            level=logging.ERROR, format="%(levelname)s: %(message)s", stream=sys.stderr, force=True
-        )
+    # Test quiet: error
+    with pytest.raises(SystemExit):
+        llm_investigate.investigate("123", verbose=0, quiet=True)
+    mock_basic_config.assert_called_with(
+        level=logging.ERROR, format="%(levelname)s: %(message)s", stream=sys.stderr, force=True
+    )

--- a/tests/test_trigger_bisect_jobs.py
+++ b/tests/test_trigger_bisect_jobs.py
@@ -7,6 +7,7 @@ import importlib.util
 import json
 import pathlib
 import re
+import subprocess  # noqa: S404
 from argparse import Namespace
 from typing import Any
 from unittest.mock import MagicMock, call, patch
@@ -61,9 +62,7 @@ cmds = [
 ]
 
 
-def test_catch_CalledProcessError(caplog: pytest.LogCaptureFixture) -> None:
-    import subprocess  # noqa: S404
-
+def test_catch_called_process_error(caplog: pytest.LogCaptureFixture) -> None:
     args = args_factory()
     args.url = "https://openqa.opensuse.org/tests/7848818"
     openqa.fetch_url = MagicMock(side_effect=mocked_fetch_url)


### PR DESCRIPTION
`ty` was initially included to match qem-bot's setup, but the minimum Python version it supports as a check target is 3.7.  production systems seems still on Leap 15.6 default to Python 3.6.  `ty` has been removed from this PR and left for a separate one where the scope and approach can be properly defined.

Initial I tried to copy exactly what is in qem-bot so all the ruff rules should apply the same. 
minor changes in Makefile.
Added uv.lock

https://progress.opensuse.org/issues/191575