### PR TITLE
docs: Add usage to os-autoinst-testapi-usage

### DIFF
--- a/os-autoinst-testapi-usage
+++ b/os-autoinst-testapi-usage
@@ -13,6 +13,9 @@ usage() {
     cat << EOF
 Usage: $0 path_to_testapi path_to_code_repository [path_to_another_repository] [...]
 
+For all testapi functions, lists the number of times the function is used in
+the code of the given directory
+
 Options:
  -h, --help         display this help
 EOF


### PR DESCRIPTION
Example output:

    /path/to/repo - assert_and_click : 620 matches
    /path/to/repo - assert_and_dclick : 20 matches
    /path/to/repo - assert_recorded_sound : 1 matches
    /path/to/repo - assert_screen : 1934 matches
    ...

It needs `ripgrep`, so theoretically this would be a new dependency, if we want to officially support it.