### PR TITLE
fix(openqa-list-incidents): replace asserts with error handling

### DIFF
--- a/openqa-list-incidents
+++ b/openqa-list-incidents
@@ -213,13 +213,15 @@ def get_api_url(job: str) -> str:
             data = got.json()
         except RequestException as error:
             sys.exit(f"ERROR: {job}: {error}")
-        assert len(data) == 1
+        if len(data) != 1:
+            sys.exit(f"ERROR: {job}: expected 1 job, got {len(data)}")
         job = str(data[0]["id"])
     else:
         # Support both "/t1234" & "/tests/1234"
         job = pathlib.Path(url.path).name.removeprefix("t")
 
-    assert job.isdigit()
+    if not job.isdigit():
+        sys.exit(f"ERROR: {job}: invalid job ID")
     return f"https://{url.netloc}/api/v1/jobs/{job}"
 
 


### PR DESCRIPTION
Motivation:
Using 'assert' for runtime validation is discouraged as they can be optimized
away and provide poor error messages to the user.

Design Choices:
- Replaced 'assert' calls in 'get_api_url' with explicit checks that call
  'sys.exit' with descriptive error messages.

Benefits:
More robust error handling and improved user feedback when unexpected API
results occur.