### PR TITLE
feat(openqa-llm-investigate): include host and model in LLM API error messages

### DIFF
--- a/openqa-llm-investigate
+++ b/openqa-llm-investigate
@@ -230,10 +230,10 @@ Provide exactly 3 sentences answering:
         )
         sys.exit(1)
     except httpx.HTTPStatusError as e:
-        log.error("LLM API returned an error status: %s. Detail: %s", e.response.status_code, e.response.text)
+        log.error("LLM API %s (%s) status %d: %s", llm_url, llm_model, e.response.status_code, e.response.text)
         sys.exit(1)
     except Exception as e:
-        log.error("LLM API request failed: %s", e)
+        log.error("LLM API %s (%s) failed: %s", llm_url, llm_model, e)
         sys.exit(1)
 
     # Print the job URL to stdout ONLY if BISECT: YES is recommended

--- a/tests/test_openqa_llm_investigate.py
+++ b/tests/test_openqa_llm_investigate.py
@@ -230,6 +230,27 @@ def test_investigate_cmd_connection_error(mocker: MockerFixture) -> None:
     assert "Could not connect to LLM server" in mock_log.error.call_args[0][0]
 
 
+def test_investigate_cmd_http_status_error(mocker: MockerFixture) -> None:
+    mock_log = mocker.patch("llm_investigate.log")
+    client = setup_mock_client(mocker)
+    mock_resp = Mock()
+    mock_resp.status_code = 500
+    mock_resp.text = "Internal Server Error"
+    client.post.side_effect = httpx.HTTPStatusError("error", request=Mock(), response=mock_resp)
+
+    with pytest.raises(SystemExit) as exc:
+        llm_investigate.investigate("123")
+
+    assert exc.value.code == 1
+    mock_log.error.assert_called_once()
+    error_msg = mock_log.error.call_args[0][0]
+    assert error_msg == "LLM API %s (%s) status %d: %s"
+    assert mock_log.error.call_args[0][1] == "http://localhost:8080/v1/chat/completions"
+    assert mock_log.error.call_args[0][2] == "gemma-4-26B-A4B-it"
+    assert mock_log.error.call_args[0][3] == 500
+    assert mock_log.error.call_args[0][4] == "Internal Server Error"
+
+
 def test_investigate_logging_levels(mocker: MockerFixture) -> None:
     mock_basic_config = mocker.patch("llm_investigate.logging.basicConfig")
     mocker.patch("llm_investigate.httpx.Client")


### PR DESCRIPTION
Motivation:
The current error message for LLM API failures lacked details about the target
host and model, which made troubleshooting connectivity and configuration
issues difficult for users.

Design Choices:
- Updated the error logging in _perform_investigation to include llm_url and
  llm_model in both HTTPStatusError and general Exception blocks.
- Re-formatted the HTTPStatusError log call for better readability.
- Added a new unit test case in tests/test_openqa_llm_investigate.py to verify
  the detailed error message format.

Benefits:
- Provides immediate context (host and model) when an LLM API call fails.
- Improves debuggability and user experience by identifying the source of error.