### PR TITLE
feat: Retry for over an hour if `osc` is not available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ check-conventions:
 
 .PHONY: check-ty
 check-ty: ## Run ty type checker
-	uv run ty check
+	ty check
 
 check-code-health:
 	@echo "Checking code health…"

--- a/_common
+++ b/_common
@@ -5,7 +5,7 @@
 
 errorlog=""
 prefix="${prefix:-""}"
-osc="${osc:-"$prefix retry -e -- osc"}"
+osc=${osc:-"$prefix retry -r 11 -e -- osc"}
 submit_target=${submit_target:-openSUSE:Factory}
 
 warn() { printf '%s\n' "$@" >&2; }

--- a/check-netbox-unused-machine-power.py
+++ b/check-netbox-unused-machine-power.py
@@ -80,10 +80,10 @@ def green(s: str) -> str:
     return f"\x1b[32m{s}\x1b[0m"
 
 
-def print_device(device: dcim.Devices, dev_pdu_power: dict[str, tuple[str, str]], watts: int) -> None:
+def print_device(device: dcim.Devices, dev_pdu_power: dict[tuple[str, int], tuple[int, bool]], watts: int) -> None:
     """Report device power consumption per PDU outlet for human review."""
     s = "  " if verbose else ""
-    pdu_power = " ".join([f"{h}:{green(p) if s else red(p)}={w}W" for (h, p), (w, s) in dev_pdu_power.items()])
+    pdu_power = " ".join([f"{h}:{green(str(p)) if s else red(str(p))}={w}W" for (h, p), (w, s) in dev_pdu_power.items()])
     print(f"{s}{device.name} status={device.status.value} {pdu_power} ∑{watts}W")
 
 


### PR DESCRIPTION
We so far only wait 21 seconds in total between retries. With this change we'll wait up to 102.35 minutes.

Related ticket: https://progress.opensuse.org/issues/201267