### PR TITLE
feat: rewrite monitor-openqa_job in Python

### DIFF
--- a/monitor-openqa_job
+++ b/monitor-openqa_job
@@ -1,97 +1,275 @@
-#!/bin/bash -ex
+#!/usr/bin/env python3
+# Copyright SUSE LLC
+# ruff: noqa: D103, PLR0913, PLR0917, S404, S603, T201, TRY400
+"""Monitor an openQA job by polling the status of a job over the API."""
 
-set -euo pipefail
+import json
+import logging
+import os
+import pathlib
+import re
+import shlex
+import subprocess
+import sys
+import time
+from typing import Annotated, Any
 
-# configuration variables with defaults.
-color=${color:-auto}
-sleep_time="${sleep_time:-"10"}"
-openqa_cli="${openqa_cli:-"openqa-cli"}"
-host="${host:-"https://openqa.opensuse.org"}"
-openqa_groupid="${openqa_groupid:-"24"}"
-obs_component="${obs_component:-"package"}"
-obs_package_name="${1:-""}"
-staging_project=${staging_project:-devel:openQA:testing}
-comment_on_obs=${comment_on_obs:-}
-OPENQA_CLI_RETRIES="${openqa_cli_retries:-7}"
+import httpx
+import tenacity
+import typer
 
-export OPENQA_CLI_RETRIES
+log = logging.getLogger(__name__)
 
-usage() {
-    cat << EOF
-Usage: $0 [OPTIONS]
 
+def load_job_ids(path: str = "job_post_response") -> list[int]:
+    try:
+        with pathlib.Path(path).open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        ids = data.get("ids", [])
+        return [int(jid) for jid in ids]
+    except FileNotFoundError as e:
+        print(f"Need job response status file '{path}'", file=sys.stderr)
+        raise typer.Exit(code=2) from e
+    except Exception as e:
+        log.error("Failed to read or parse '%s': %s", path, e)
+        raise typer.Exit(code=2) from e
+
+
+def fetch_job_api(client: httpx.Client, url: str, params: dict[str, Any], retries: int) -> dict[str, Any]:
+    for attempt in tenacity.Retrying(
+        stop=tenacity.stop_after_attempt(retries),
+        wait=tenacity.wait_exponential(multiplier=1, min=1, max=10),
+        reraise=True,
+    ):
+        with attempt:
+            response = client.get(url, params=params, timeout=30.0)
+            response.raise_for_status()
+            return response.json()
+    return {}  # pragma: no cover
+
+
+def get_err_msg(e: subprocess.CalledProcessError) -> str:
+    return e.stderr.strip() if e.stderr else str(e)
+
+
+def delete_packages_from_obs_project(obs_project: str, osc_cmd_str: str) -> None:
+    log.info("delete_packages_from_obs_project()")
+    cmd_ls = [*shlex.split(osc_cmd_str), "ls", obs_project]
+    try:
+        res = subprocess.run(cmd_ls, check=True, capture_output=True, text=True)
+        packages = []
+        for line in res.stdout.splitlines():
+            pkg = line.strip()
+            if pkg and not pkg.endswith("-test"):
+                packages.append(pkg)
+    except subprocess.CalledProcessError as e:
+        log.debug("osc ls failed or project is empty: %s", get_err_msg(e))
+        packages = []
+
+    for package in packages:
+        log.info("Deleting %s from %s", package, obs_project)
+        cmd_del = [
+            *shlex.split(osc_cmd_str),
+            "rdelete",
+            "-m",
+            f"Cleaning up {package} to allow triggering new jobs",
+            obs_project,
+            package,
+        ]
+        try:
+            subprocess.run(cmd_del, check=True, capture_output=True, text=True)
+        except subprocess.CalledProcessError as e:
+            log.error("Failed to delete package %s from %s: %s", package, obs_project, get_err_msg(e))
+
+
+def extract_comment_ids(api_output: str) -> list[str]:
+    comment_ids = []
+    for line in api_output.splitlines():
+        match = re.search(r'id="([^"]*)">.*test.*failed', line)
+        if match:
+            comment_ids.append(match.group(1))
+    return comment_ids
+
+
+def delete_old_comments(osc_cmd_str: str, obs_component: str, obs_package_name: str) -> None:
+    cmd = [*shlex.split(osc_cmd_str), "api", f"/comments/{obs_component}/{obs_package_name}"]
+    try:
+        res = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        log.warning("Failed to query comments for %s: %s", obs_package_name, get_err_msg(e))
+        return
+
+    comment_ids = extract_comment_ids(res.stdout)
+    for cid in comment_ids:
+        log.info("Deleting comment ID %s", cid)
+        cmd_del = [*shlex.split(osc_cmd_str), "api", "-X", "DELETE", f"/comment/{cid}"]
+        try:
+            subprocess.run(cmd_del, check=True, capture_output=True, text=True)
+        except subprocess.CalledProcessError as e:
+            log.warning("Failed to delete comment %s: %s", cid, get_err_msg(e))
+
+
+def post_comment(osc_cmd_str: str, obs_component: str, obs_package_name: str, comment_text: str) -> None:
+    cmd_post = [
+        *shlex.split(osc_cmd_str),
+        "api",
+        f"--data={comment_text}",
+        "-X",
+        "POST",
+        f"/comments/{obs_component}/{obs_package_name}",
+    ]
+    try:
+        subprocess.run(cmd_post, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        log.error("Failed to post comment to OBS: %s", get_err_msg(e))
+
+
+def comment_on_failed_jobs(
+    osc_cmd_str: str,
+    obs_component: str,
+    obs_package_name: str,
+    comment_on_obs: str,
+    failed_jobs: list[int],
+    failed_versions: dict[str, int],
+    openqa_groupid_val: str,
+    host_val: str,
+) -> None:
+    if not comment_on_obs or not obs_package_name:
+        raise typer.Exit(code=1)
+
+    log.info("Posting comment with failed jobs to OBS")
+    delete_old_comments(osc_cmd_str, obs_component, obs_package_name)
+
+    job_ids_str = " ".join(str(jid) for jid in failed_jobs)
+    comment_text = f"openQA-in-openQA test(s) failed (job IDs: {job_ids_str}), see {host_val}/tests/overview?"
+    for ver in sorted(failed_versions.keys()):
+        comment_text += f"version={ver}&"
+    comment_text += f"groupid={openqa_groupid_val}"
+
+    post_comment(osc_cmd_str, obs_component, obs_package_name, comment_text)
+    raise typer.Exit(code=1)
+
+
+def monitor_single_job(
+    client: httpx.Client,
+    job_id: int,
+    host_val: str,
+    retries: int,
+    sleep_time_val: int,
+) -> tuple[int, str, str]:
+    """Poll openQA job status until complete. Returns (final_id, result, version)."""
+    log.info("Waiting for job %d to finish", job_id)
+    url = f"{host_val}/api/v1/jobs/{job_id}"
+    params = {"follow": 1}
+    current_id = job_id
+    while True:
+        try:
+            res_json = fetch_job_api(client, url, params, retries)
+        except Exception as e:
+            log.warning("openqa-cli monitor failed with an unexpected error (%s)", e)
+            raise typer.Exit(code=1) from e
+
+        job = res_json.get("job", {})
+        state = job.get("state")
+
+        # job_id might have changed if it was restarted
+        followed_id = job.get("id", current_id)
+        if followed_id != current_id:
+            log.info("Job %d was restarted/cloned to %d", current_id, followed_id)
+            current_id = followed_id
+            url = f"{host_val}/api/v1/jobs/{current_id}"
+
+        if state in {"done", "cancelled"}:
+            result = job.get("result", "")
+            version = job.get("settings", {}).get("VERSION", "")
+            return current_id, result, version
+
+        time.sleep(sleep_time_val)
+
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command(
+    help="""
 Monitor an openQA job by polling the status of a job over the API.
 
 Continuously polls the openQA API for the status of the specified jobs until
 all jobs finish. After the jobs have finished this program exits with an exit
 code corresponding to the jobs' result. For example all jobs pass it would
 exit this program with exit code 0 for success; otherwise with 1.
+"""
+)
+def main(
+    obs_package_name: Annotated[str, typer.Argument(help="OBS package name to comment on if test failed.")] = "",
+    sleep_time: Annotated[int, typer.Option(envvar="sleep_time", help="Polling interval in seconds.")] = 10,
+    host: Annotated[str, typer.Option(envvar="host", help="openQA host URL.")] = "https://openqa.opensuse.org",
+    openqa_groupid: Annotated[str, typer.Option(envvar="openqa_groupid", help="openQA group ID.")] = "24",
+    obs_component: Annotated[
+        str, typer.Option(envvar="obs_component", help="OBS component type (package or project).")
+    ] = "package",
+    staging_project: Annotated[
+        str, typer.Option(envvar="staging_project", help="OBS staging project.")
+    ] = "devel:openQA:testing",
+    comment_on_obs: Annotated[str, typer.Option(envvar="comment_on_obs", help="Whether to comment on OBS.")] = "",
+    openqa_cli_retries: Annotated[
+        int, typer.Option(envvar="openqa_cli_retries", help="Number of openqa-cli retries.")
+    ] = 7,
+) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
-Options:
- -h, --help         display this help
-EOF
-    exit "$1"
-}
+    sleep_time_val = sleep_time if sleep_time is not None else 10
+    host_val = host or "https://openqa.opensuse.org"
+    openqa_groupid_val = openqa_groupid or "24"
+    obs_component_val = obs_component or "package"
+    staging_project_val = staging_project or "devel:openQA:testing"
 
-opts=$(getopt -o h -l help -n "$0" -- "$@") || usage 1
-eval set -- "$opts"
-while true; do
-    case "$1" in
-        -h | --help) usage 0 ;;
-        --)
-            shift
-            break
-            ;;
-        *) break ;;
-    esac
-done
+    # Check OPENQA_CLI_RETRIES or openqa_cli_retries env vars or defaults
+    retries_env = os.environ.get("OPENQA_CLI_RETRIES")
+    try:
+        retries = int(retries_env) if retries_env else openqa_cli_retries
+    except ValueError:
+        retries = 7
 
-# shellcheck source=/dev/null
-. "$(dirname "$0")"/_common
+    prefix = os.environ.get("PREFIX", "")
+    osc_cmd_str = os.environ.get("OSC", "")
+    if not osc_cmd_str:
+        osc_cmd_str = f"{prefix} retry -r 11 -e -- osc" if prefix else "retry -r 11 -e -- osc"
 
-[[ -f job_post_response ]] || (echo "Need job response status file 'job_post_response'" && exit 2)
-declare -A failed_versions
-failed_jobs=()
-for job_id in $(job_ids job_post_response); do
-    log-info "Waiting for job $job_id to finish"
-    rc=0
-    $openqa_cli monitor --host "$host" --follow --poll-interval "$sleep_time" "$job_id" || rc=$?
-    if [[ $rc != 0 && $rc != 2 ]]; then
-        log-warn "openqa-cli monitor failed with an unexpected error ($rc)"
-        exit "$rc"
-    fi
-    response=$($openqa_cli api --host "$host" jobs/"$job_id" follow=1)
-    result=$(echo "$response" | jq -r '.job.result')
-    # job_id might have changed if it was restarted
-    job_id=$(echo "$response" | jq -r '.job.id')
-    log-info "Result of job $job_id: $result"
-    if [[ $result != 'passed' ]] && [[ -n $obs_package_name ]]; then
-        version=$(echo "$response" | jq -r '.job.settings.VERSION')
-        failed_versions[$version]=1
-        failed_jobs+=("$job_id")
-    fi
-done
+    job_ids = load_job_ids("job_post_response")
+    failed_jobs: list[int] = []
+    failed_versions: dict[str, int] = {}
 
-((${#failed_jobs[@]} > 0)) || exit 0
-log-warn "${#failed_jobs[@]} jobs did not pass:"
-for id in "${failed_jobs[@]}"; do
-    log-warn "$host/t$id"
-done
+    with httpx.Client() as client:
+        for job_id in job_ids:
+            final_id, result, version = monitor_single_job(client, job_id, host_val, retries, sleep_time_val)
+            log.info("Result of job %d: %s", final_id, result)
+            if result != "passed":
+                failed_jobs.append(final_id)
+                if obs_package_name and version:
+                    failed_versions[version] = 1
 
-# delete packages from staging project in error case as we will not continue submitting those packages
-delete_packages_from_obs_project "$staging_project"
+    if not failed_jobs:
+        raise typer.Exit(code=0)
 
-# comment on failed jobs
-[[ $comment_on_obs ]] || exit 1
+    log.warning("%d jobs did not pass:", len(failed_jobs))
+    for fid in failed_jobs:
+        log.warning("%s/t%d", host_val, fid)
 
-log-info "Posting comment with failed jobs to OBS"
-osc api "/comments/$obs_component/$obs_package_name" | grep id= | sed -n 's/.*id="\([^"]*\)">.*test.* failed.*/\1/p' | while read -r id; do
-    osc api -X DELETE /comment/"$id"
-done
-comment="openQA-in-openQA test(s) failed (job IDs: ${failed_jobs[*]}), see https://openqa.opensuse.org/tests/overview?"
-for version in "${!failed_versions[@]}"; do
-    comment+="version=${version}&"
-done
-comment+="groupid=$openqa_groupid"
-osc api --data="$comment" -X POST "/comments/${obs_component}/$obs_package_name"
-exit 1
+    # delete packages from staging project in error case as we will not continue submitting those packages
+    delete_packages_from_obs_project(staging_project_val, osc_cmd_str)
+
+    comment_on_failed_jobs(
+        osc_cmd_str=osc_cmd_str,
+        obs_component=obs_component_val,
+        obs_package_name=obs_package_name,
+        comment_on_obs=comment_on_obs,
+        failed_jobs=failed_jobs,
+        failed_versions=failed_versions,
+        openqa_groupid_val=openqa_groupid_val,
+        host_val=host_val,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/tests/test_monitor_openqa_job.py
+++ b/tests/test_monitor_openqa_job.py
@@ -1,0 +1,203 @@
+# Copyright SUSE LLC
+# ruff: noqa: S404, FBT001
+"""Unit tests for monitor-openqa_job."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import logging
+import pathlib
+import subprocess
+import sys
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, Mock
+
+import httpx
+import pytest
+import typer
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+# Load the script dynamically as a module
+rootpath = pathlib.Path(__file__).parent.parent.resolve()
+path = rootpath / "monitor-openqa_job"
+spec = importlib.util.spec_from_file_location(
+    "monitor_job",
+    path,
+    loader=importlib.machinery.SourceFileLoader("monitor_job", str(path)),
+)
+assert spec is not None
+assert spec.loader is not None
+monitor_job = importlib.util.module_from_spec(spec)
+sys.modules["monitor_job"] = monitor_job
+spec.loader.exec_module(monitor_job)
+
+
+def test_logging(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.DEBUG):
+        monitor_job.log.info("info")
+        monitor_job.log.warning("warn")
+        monitor_job.log.error("err")
+        monitor_job.log.debug("dbg")
+    for log_msg in ["info", "warn", "err", "dbg"]:
+        assert log_msg in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("content", "exists", "expected"),
+    [
+        ('{"ids": [100]}', True, [100]),
+        (None, False, typer.Exit),
+        ("bad json", True, typer.Exit),
+    ],
+)
+def test_load_job_ids(tmp_path: pathlib.Path, content: str | None, exists: bool, expected: Any) -> None:
+    f = tmp_path / "job_post_response"
+    if exists and content is not None:
+        f.write_text(content)
+    if expected is typer.Exit:
+        with pytest.raises(typer.Exit) as exc:
+            monitor_job.load_job_ids(str(f) if exists else "missing")
+        assert exc.value.exit_code == 2
+    else:
+        assert monitor_job.load_job_ids(str(f)) == expected
+
+
+def test_fetch_job_api() -> None:
+    client, resp = MagicMock(spec=httpx.Client), Mock()
+    resp.json.return_value = {"key": "val"}
+    client.get.return_value = resp
+    assert monitor_job.fetch_job_api(client, "http://host", {}, 2) == {"key": "val"}
+
+
+@pytest.mark.parametrize(
+    ("side_effects", "expected_calls"),
+    [
+        ([Mock(stdout="pkg1\npkg2-test\n"), Mock()], 2),
+        (subprocess.CalledProcessError(1, "ls"), 1),
+        ([Mock(stdout="pkg1\n"), subprocess.CalledProcessError(1, "del")], 2),
+    ],
+)
+def test_delete_packages(mocker: MockerFixture, side_effects: Any, expected_calls: int) -> None:
+    mock_run = mocker.patch("monitor_job.subprocess.run", side_effect=side_effects)
+    monitor_job.delete_packages_from_obs_project("proj", "osc")
+    assert mock_run.call_count == expected_calls
+
+
+def test_extract_comment_ids() -> None:
+    xml = '<comment id="12">test failed</comment>\n<comment id="34">ok</comment>'
+    assert monitor_job.extract_comment_ids(xml) == ["12"]
+
+
+@pytest.mark.parametrize(
+    ("side_effects", "expected_calls"),
+    [
+        ([Mock(stdout='<comment id="9">test failed</comment>'), Mock()], 2),
+        (subprocess.CalledProcessError(1, "api"), 1),
+        ([Mock(stdout='<comment id="9">test failed</comment>'), subprocess.CalledProcessError(1, "del")], 2),
+    ],
+)
+def test_delete_old_comments(mocker: MockerFixture, side_effects: Any, expected_calls: int) -> None:
+    mock_run = mocker.patch("monitor_job.subprocess.run", side_effect=side_effects)
+    monitor_job.delete_old_comments("osc", "pkg", "name")
+    assert mock_run.call_count == expected_calls
+
+
+@pytest.mark.parametrize("fails", [False, True])
+def test_post_comment(mocker: MockerFixture, fails: bool) -> None:
+    mock_run = mocker.patch("monitor_job.subprocess.run")
+    if fails:
+        mock_run.side_effect = subprocess.CalledProcessError(1, "post")
+    monitor_job.post_comment("osc", "pkg", "name", "comment")
+    mock_run.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("side_effects", "expected_id", "expected_res", "expected_ver", "should_raise"),
+    [
+        ([{"job": {"id": 1, "state": "done", "result": "passed"}}], 1, "passed", "", False),
+        (
+            [
+                {"job": {"id": 2, "state": "running"}},
+                {"job": {"id": 2, "state": "done", "result": "failed", "settings": {"VERSION": "1"}}},
+            ],
+            2,
+            "failed",
+            "1",
+            False,
+        ),
+        (Exception("error"), 0, "", "", True),
+    ],
+)
+def test_monitor_single_job(
+    mocker: MockerFixture,
+    side_effects: Any,
+    expected_id: int,
+    expected_res: str,
+    expected_ver: str,
+    should_raise: bool,
+) -> None:
+    mocker.patch("time.sleep")
+    mock_fetch = mocker.patch("monitor_job.fetch_job_api", side_effect=side_effects)
+    client = MagicMock()
+    if should_raise:
+        with pytest.raises(typer.Exit) as exc:
+            monitor_job.monitor_single_job(client, 1, "http://host", 2, 0)
+        assert exc.value.exit_code == 1
+    else:
+        fid, res, ver = monitor_job.monitor_single_job(client, 1, "http://host", 2, 0)
+        assert (fid, res, ver) == (expected_id, expected_res, expected_ver)
+        assert mock_fetch.call_count == len(side_effects)
+
+
+@pytest.mark.parametrize(
+    ("job_res", "pkg_name", "comment_obs", "env_patch", "expected_exit"),
+    [
+        ((1, "passed", ""), "", "", {}, 0),
+        ((1, "failed", "15"), "", "", {}, 1),
+        ((1, "failed", "15"), "pkg", "1", {}, 1),
+        ((1, "passed", ""), "", "", {"OPENQA_CLI_RETRIES": "invalid"}, 0),
+        ((1, "passed", ""), "", "", {"PREFIX": "pre", "OSC": ""}, 0),
+        ((1, "passed", ""), "", "", {"OSC": "custom"}, 0),
+    ],
+)
+def test_main_flow(
+    mocker: MockerFixture,
+    job_res: tuple[int, str, str],
+    pkg_name: str,
+    comment_obs: str,
+    env_patch: dict[str, str],
+    expected_exit: int,
+) -> None:
+    mocker.patch("monitor_job.load_job_ids", return_value=[1])
+    mocker.patch("monitor_job.monitor_single_job", return_value=job_res)
+    mocker.patch("monitor_job.delete_packages_from_obs_project")
+    mocker.patch("monitor_job.delete_old_comments")
+    mocker.patch("monitor_job.post_comment")
+    mocker.patch("monitor_job.httpx.Client")
+    if env_patch:
+        mocker.patch.dict("os.environ", env_patch)
+
+    with pytest.raises(typer.Exit) as exc:
+        monitor_job.main(obs_package_name=pkg_name, comment_on_obs=comment_obs)
+    assert exc.value.exit_code == expected_exit
+
+
+@pytest.mark.parametrize(
+    ("pkg", "comment_obs", "expected_exit"),
+    [
+        ("pkg", "", 1),
+        ("pkg", "1", 1),
+    ],
+)
+def test_comment_on_failed_jobs(mocker: MockerFixture, pkg: str, comment_obs: str, expected_exit: int) -> None:
+    mock_del = mocker.patch("monitor_job.delete_old_comments")
+    mock_post = mocker.patch("monitor_job.post_comment")
+    with pytest.raises(typer.Exit) as exc:
+        monitor_job.comment_on_failed_jobs("osc", "package", pkg, comment_obs, [1], {"1": 1}, "24", "http://host")
+    assert exc.value.exit_code == expected_exit
+    if comment_obs:
+        mock_del.assert_called_once()
+        mock_post.assert_called_once()


### PR DESCRIPTION
## Motivation
Replace the bash script with a Python-based implementation to enhance
maintainability, logging, and error handling.

## Design Choices
Use typer for CLI arguments, httpx for API calls, and subprocess.run for
osc commands. Implement polling, retries, and standard logging in Python.

## Verification
Added unit test with complete coverage. Tested manually by downloading
the latest `job_post_response` from
http://jenkins.qa.suse.de/job/monitor-openQA_in_openQA-TW/
and executing `monitor-openqa_job` which shows

```
INFO: Waiting for job 6010424 to finish
…
INFO: Result of job 6010429: passed
```

## Hints to reviewers
`monitor-openqa_job` is likely only used within http://jenkins.qa.suse.de/job/monitor-openQA_in_openQA-TW/ and single-purpose. I see low risk of this rewrite PR for a drop-in replacement. If problems are encountered then we will likely soon observe them leading to pipeline failures.

## Benefits
Provides reliable, testable, and maintainable monitoring behavior with complete
unit test coverage.