### PR TITLE
Add script, service and timer to update certificates from OBS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,17 @@ clean: ## Clean up generated files
 	$(RM) -r .pytest_cache/
 	find . -name __pycache__ | xargs -r $(RM) -r
 
+install-systemd-local: ## Install contained systemd units for local use (not meant for packaging)
+	install -d -m 755 "$(DESTDIR)"/etc/systemd/system
+	for i in systemd/*.{service,timer}; do \
+		install -m 644 $$i "$(DESTDIR)"/etc/systemd/system ;\
+	done
+	install -d -m 755 "$(DESTDIR)"/etc/systemd/user
+	for i in systemd/user/*.{service,timer}; do \
+		install -m 644 $$i "$(DESTDIR)"/etc/systemd/user ;\
+	done
+	find "$(DESTDIR)"/etc/systemd -name '*.service' -exec sed -i -e "s|/opt/os-autoinst-scripts|$(PWD)|g" {} \+
+
 #------------------------------------------------------------------------------
 # Internal targets
 #------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -196,6 +196,39 @@ environment variables:
 * `from_email` - The From address for notification emails
 * `force_result` - If set to `1` tickets in the [tracker openqa-force-result](https://progress.opensuse.org/projects/openqav3/issues?query_id=700) can override job results
 
+## Update certificates from OBS
+The script `openqa-update-cert-from-obs` allows downloading the certificate of
+an OBS project. These certificates are so far used to run SecureBoot-enabled
+tests with images that are signed with them. The directory `config/obs-certs`
+contains configurations for this script.
+
+There are also systemd units/timers provided which can be installed locally. Run
+these commands with the user that should execute the updates regularly:
+
+```
+$ make install-systemd-local DESTDIR=/tmp/install
+$ cp -vR /tmp/install/etc/systemd/user/ ~/.config/systemd/
+$ systemctl --user daemon-reload
+```
+
+The user needs an osc configuration and write permissions under the openQA assets
+directory.
+
+The timer units can be enabled like that:
+```
+$ loginctl enable-linger
+$ systemctl --user enable --now os-autoinst-scripts-update-factory-staging-cert.timer
+```
+
+The service units can be started out of schedule like that:
+```
+$ systemctl --user start os-autoinst-scripts-update-cert-from-obs@factory-staging.service
+$ journalctl --user -u os-autoinst-scripts-update-cert-from-obs@factory-staging.service
+Starting Update a certificate from OBS...
+certificate from '…' written to '…/openqa/share/factory/other/fixed/openSUSE-Factory-Staging.crt'
+Finished Update a certificate from OBS.
+```
+
 ## Contribute
 
 This project lives in https://github.com/os-autoinst/os-autoinst-scripts

--- a/config/obs-certs/factory-staging.conf
+++ b/config/obs-certs/factory-staging.conf
@@ -1,0 +1,2 @@
+OBS_PROJECT=openSUSE:Factory:Staging
+CRT_NAME=openSUSE-Factory-Staging.crt

--- a/config/obs-certs/suse-unsupported.conf
+++ b/config/obs-certs/suse-unsupported.conf
@@ -1,0 +1,3 @@
+OBS_API_URL=https://api.suse.de
+OBS_PROJECT=SUSE:SLE-15-SP7:GA:Staging:A
+CRT_NAME=suse-unsupported.crt

--- a/openqa-update-cert-from-obs
+++ b/openqa-update-cert-from-obs
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+config=${1:?Path to config file needs to be specified as first argument}
+# shellcheck source=config/obs-certs/factory-staging.conf
+source "$config"
+
+src=${OBS_PROJECT:?OBS_PROJECT needs to be set in $config}
+dst=${OPENQA_BASEDIR:-/var/lib}/openqa/share/factory/other/fixed
+dst_file=$dst/${CRT_NAME:?CRT_NAME needs to be set in $config}
+dst_file_tmp=$dst_file.tmp
+
+mkdir -p "$dst"
+osc --apiurl "${OBS_API_URL:-https://api.opensuse.org}" signkey --sslcert "$src" > "$dst_file_tmp"
+mv "$dst_file_tmp" "$dst_file"
+echo "certificate from '$src' written to '$dst_file'"

--- a/systemd/user/os-autoinst-scripts-update-cert-from-obs@.service
+++ b/systemd/user/os-autoinst-scripts-update-cert-from-obs@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Update a certificate from OBS
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/bash /opt/os-autoinst-scripts/openqa-update-cert-from-obs /opt/os-autoinst-scripts/config/obs-certs/%i.conf
+Restart=on-failure
+RestartSec=10m
+
+[Install]
+WantedBy=default.target

--- a/systemd/user/os-autoinst-scripts-update-factory-staging-cert.timer
+++ b/systemd/user/os-autoinst-scripts-update-factory-staging-cert.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Update the certificate of openSUSE Factory staging builds needed for SecureBoot
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+Unit=os-autoinst-scripts-update-cert-from-obs@factory-staging.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/user/os-autoinst-scripts-update-suse-unsupported-cert.timer
+++ b/systemd/user/os-autoinst-scripts-update-suse-unsupported-cert.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Update the certificate of SUSE-internal builds needed for SecureBoot
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+Unit=os-autoinst-scripts-update-cert-from-obs@suse-unsupported.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
These certificates are not published somewhere so we need to use `osc` to download them.

This change adds a systemd unit and timer that are supposed to be used in user mode. It also contains an install target for the systemd units. It is not suited for packaging and mainly to make it clear where the unit should be placed to use them locally. It is also useful for local testing:
```
$ make install-systemd-local DESTDIR=/tmp/install
$ cp -vR /tmp/install/etc/systemd/user/ ~/.config/systemd/
$ systemctl --user daemon-reload
```

Then the timer unit can be tested via:
```
$ systemctl --user start os-autoinst-scripts-update-factory-staging-cert.timer
```

The service units can be tested via:
```
$ systemctl --user start os-autoinst-scripts-update-cert-from-obs@factory-staging.service
$ journalctl --user -u os-autoinst-scripts-update-cert-from-obs@factory-staging.service
Starting Update a certificate from OBS...
certificate written to /home/martchus/dev/openqa/openqa/share/factory/other/fixed/openSUSE-Factory-Staging.crt
Finished Update a certificate from OBS.
```

```
$ systemctl --user start os-autoinst-scripts-update-cert-from-obs@suse-unsupported.service
$ journalctl --user -u os-autoinst-scripts-update-cert-from-obs@suse-unsupported.service
Starting Update a certificate from OBS...
certificate written to /home/martchus/dev/openqa/openqa/share/factory/other/fixed/suse-unsupported.crt
Finished Update a certificate from OBS.
```

This works on my system. On the production hosts we should probably create a dedicated user account with the required osc config and write permissions in the assets directory.

Related ticket: https://progress.opensuse.org/issues/200075