### PR TITLE
refactor: rewrite cert updater script to Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,17 @@ clean:
 	$(RM) -r .pytest_cache/
 	find . -name __pycache__ | xargs -r $(RM) -r
 
+install-systemd-local: ## Install contained systemd units for local use (not meant for packaging)
+	install -d -m 755 "$(DESTDIR)"/etc/systemd/system
+	for i in systemd/*.{service,timer}; do \
+		install -m 644 $$i "$(DESTDIR)"/etc/systemd/system ;\
+	done
+	install -d -m 755 "$(DESTDIR)"/etc/systemd/user
+	for i in systemd/user/*.{service,timer}; do \
+		install -m 644 $$i "$(DESTDIR)"/etc/systemd/user ;\
+	done
+	find "$(DESTDIR)"/etc/systemd -name '*.service' -exec sed -i -e "s|/opt/os-autoinst-scripts|$(PWD)|g" {} \+
+
 #------------------------------------------------------------------------------
 # Internal targets
 #------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -196,6 +196,39 @@ environment variables:
 * `from_email` - The From address for notification emails
 * `force_result` - If set to `1` tickets in the [tracker openqa-force-result](https://progress.opensuse.org/projects/openqav3/issues?query_id=700) can override job results
 
+## Update certificates from OBS
+The script `openqa-update-cert-from-obs` allows downloading the certificate of
+an OBS project. These certificates are so far used to run SecureBoot-enabled
+tests with images that are signed with them. The directory `config/obs-certs`
+contains configurations for this script.
+
+There are also systemd units/timers provided which can be installed locally. Run
+these commands with the user that should execute the updates regularly:
+
+```
+$ make install-systemd-local DESTDIR=/tmp/install
+$ cp -vR /tmp/install/etc/systemd/user/ ~/.config/systemd/
+$ systemctl --user daemon-reload
+```
+
+The user needs an osc configuration and write permissions under the openQA assets
+directory.
+
+The timer units can be enabled like that:
+```
+$ loginctl enable-linger
+$ systemctl --user enable --now os-autoinst-scripts-update-factory-staging-cert.timer
+```
+
+The service units can be started out of schedule like that:
+```
+$ systemctl --user start os-autoinst-scripts-update-cert-from-obs@factory-staging.service
+$ journalctl --user -u os-autoinst-scripts-update-cert-from-obs@factory-staging.service
+Starting Update a certificate from OBS...
+certificate written to …/openqa/share/factory/other/fixed/openSUSE-Factory-Staging.crt
+Finished Update a certificate from OBS.
+```
+
 ## Contribute
 
 This project lives in https://github.com/os-autoinst/os-autoinst-scripts

--- a/README.md
+++ b/README.md
@@ -198,35 +198,11 @@ environment variables:
 
 ## Update certificates from OBS
 The script `openqa-update-cert-from-obs` allows downloading the certificate of
-an OBS project. These certificates are so far used to run SecureBoot-enabled
-tests with images that are signed with them. The directory `config/obs-certs`
-contains configurations for this script.
+an OBS project.
 
-There are also systemd units/timers provided which can be installed locally. Run
-these commands with the user that should execute the updates regularly:
-
-```
-$ make install-systemd-local DESTDIR=/tmp/install
-$ cp -vR /tmp/install/etc/systemd/user/ ~/.config/systemd/
-$ systemctl --user daemon-reload
-```
-
-The user needs an osc configuration and write permissions under the openQA assets
-directory.
-
-The timer units can be enabled like that:
-```
-$ loginctl enable-linger
-$ systemctl --user enable --now os-autoinst-scripts-update-factory-staging-cert.timer
-```
-
-The service units can be started out of schedule like that:
-```
-$ systemctl --user start os-autoinst-scripts-update-cert-from-obs@factory-staging.service
-$ journalctl --user -u os-autoinst-scripts-update-cert-from-obs@factory-staging.service
-Starting Update a certificate from OBS...
-certificate written to …/openqa/share/factory/other/fixed/openSUSE-Factory-Staging.crt
-Finished Update a certificate from OBS.
+For more details on how to use, configure, and install systemd units/timers for it, run:
+```bash
+./openqa-update-cert-from-obs --help
 ```
 
 ## Contribute

--- a/config/obs-certs/factory-staging.conf
+++ b/config/obs-certs/factory-staging.conf
@@ -1,0 +1,2 @@
+OBS_PROJECT=openSUSE:Factory:Staging
+CRT_NAME=openSUSE-Factory-Staging.crt

--- a/config/obs-certs/suse-unsupported.conf
+++ b/config/obs-certs/suse-unsupported.conf
@@ -1,0 +1,3 @@
+OBS_API_URL=https://api.suse.de
+OBS_PROJECT=SUSE:SLE-15-SP7:GA:Staging:A
+CRT_NAME=suse-unsupported.crt

--- a/openqa-update-cert-from-obs
+++ b/openqa-update-cert-from-obs
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+config=${1:?Path to config file needs to be specified as first argument}
+# shellcheck source=config/obs-certs/factory-staging.conf
+source "$config"
+
+src=${OBS_PROJECT:?OBS_PROJECT needs to be set in $config}
+dst=${OPENQA_BASEDIR:-/var/lib}/openqa/share/factory/other/fixed
+dst_file=$dst/${CRT_NAME:?CRT_NAME needs to be set in $config}
+dst_file_tmp=$dst_file.tmp
+
+mkdir -p "$dst"
+osc --apiurl "${OBS_API_URL:-https://api.opensuse.org}" signkey --sslcert "$src" > "$dst_file_tmp"
+mv "$dst_file_tmp" "$dst_file"
+echo "certificate written to $dst_file"

--- a/openqa-update-cert-from-obs
+++ b/openqa-update-cert-from-obs
@@ -1,16 +1,152 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env python3
+# Copyright SUSE LLC
+# ruff: noqa: D103, S404, S603, T201
+"""Update certificates from OBS."""
 
-config=${1:?Path to config file needs to be specified as first argument}
-# shellcheck source=config/obs-certs/factory-staging.conf
-source "$config"
+import pathlib
+import shlex
+import subprocess
+import sys
+from typing import Annotated
 
-src=${OBS_PROJECT:?OBS_PROJECT needs to be set in $config}
-dst=${OPENQA_BASEDIR:-/var/lib}/openqa/share/factory/other/fixed
-dst_file=$dst/${CRT_NAME:?CRT_NAME needs to be set in $config}
-dst_file_tmp=$dst_file.tmp
+import typer
 
-mkdir -p "$dst"
-osc --apiurl "${OBS_API_URL:-https://api.opensuse.org}" signkey --sslcert "$src" > "$dst_file_tmp"
-mv "$dst_file_tmp" "$dst_file"
-echo "certificate written to $dst_file"
+app = typer.Typer(add_completion=False)
+
+
+def parse_config(config_path: pathlib.Path) -> dict[str, str]:
+    config_vars = {}
+    try:
+        with config_path.open("r", encoding="utf-8") as f:
+            lines = f.readlines()
+    except Exception as e:
+        print(f"Error reading config file {config_path}: {e}", file=sys.stderr)
+        raise typer.Exit(code=2) from e
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            key, value = line.split("=", 1)
+            config_vars[key.strip()] = value.strip().strip("'\"")
+
+    return config_vars
+
+
+@app.command(
+    help="""
+Update openQA SecureBoot certificates from OBS.
+
+Downloads the certificate of an OBS project. These certificates are used to run
+SecureBoot-enabled tests with images that are signed with them.
+
+The configuration file (e.g. config/obs-certs/factory-staging.conf) should define:
+* OBS_PROJECT: The OBS project name (required)
+* CRT_NAME: The output certificate filename (required)
+* OBS_API_URL: Custom OBS API URL (optional, defaults to https://api.opensuse.org)
+
+Prerequisites:
+* The user needs an osc configuration (`~/.config/osc/oscrc`) and write
+  permissions under the openQA assets directory.
+
+Systemd Setup (to run the updates regularly):
+1. Install systemd units/timers locally:
+   $ make install-systemd-local DESTDIR=/tmp/install
+   $ cp -vR /tmp/install/etc/systemd/user/ ~/.config/systemd/
+   $ systemctl --user daemon-reload
+
+2. Enable the timer units:
+   $ loginctl enable-linger
+   $ systemctl --user enable --now os-autoinst-scripts-update-factory-staging-cert.timer
+
+3. Start service units manually:
+   $ systemctl --user start os-autoinst-scripts-update-cert-from-obs@factory-staging.service
+   $ journalctl --user -u os-autoinst-scripts-update-cert-from-obs@factory-staging.service
+"""
+)
+def main(
+    config: Annotated[
+        pathlib.Path,
+        typer.Argument(
+            help="Path to configuration file.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+        ),
+    ],
+    openqa_basedir: Annotated[
+        pathlib.Path,
+        typer.Option(
+            envvar="OPENQA_BASEDIR",
+            help="Base directory for openQA assets.",
+        ),
+    ] = pathlib.Path("/var/lib"),
+    osc_program: Annotated[
+        str,
+        typer.Option(
+            envvar="OSC",
+            help="osc command or wrapper.",
+        ),
+    ] = "osc",
+) -> None:
+    config_vars = parse_config(config)
+
+    obs_project = config_vars.get("OBS_PROJECT")
+    if not obs_project:
+        print(f"Error: OBS_PROJECT needs to be set in {config}", file=sys.stderr)
+        raise typer.Exit(code=1)
+
+    crt_name = config_vars.get("CRT_NAME")
+    if not crt_name:
+        print(f"Error: CRT_NAME needs to be set in {config}", file=sys.stderr)
+        raise typer.Exit(code=1)
+
+    obs_api_url = config_vars.get("OBS_API_URL", "https://api.opensuse.org")
+
+    dst_dir = openqa_basedir / "openqa" / "share" / "factory" / "other" / "fixed"
+    dst_file = dst_dir / crt_name
+    dst_file_tmp = dst_dir / f"{crt_name}.tmp"
+
+    try:
+        dst_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        print(f"Error creating directory {dst_dir}: {e}", file=sys.stderr)
+        raise typer.Exit(code=1) from e
+
+    cmd = [
+        *shlex.split(osc_program),
+        "--apiurl",
+        obs_api_url,
+        "signkey",
+        "--sslcert",
+        obs_project,
+    ]
+
+    try:
+        with dst_file_tmp.open("w", encoding="utf-8") as f_tmp:
+            subprocess.run(cmd, check=True, stdout=f_tmp, stderr=subprocess.PIPE, text=True)
+    except subprocess.CalledProcessError as e:
+        if dst_file_tmp.exists():
+            dst_file_tmp.unlink()
+        err_msg = e.stderr.strip() if e.stderr else str(e)
+        print(f"Error executing osc command: {err_msg}", file=sys.stderr)
+        raise typer.Exit(code=e.returncode) from e
+    except Exception as e:
+        if dst_file_tmp.exists():
+            dst_file_tmp.unlink()
+        print(f"Unexpected error running osc: {e}", file=sys.stderr)
+        raise typer.Exit(code=1) from e
+
+    try:
+        dst_file_tmp.replace(dst_file)
+    except Exception as e:
+        print(f"Error moving temporary file to {dst_file}: {e}", file=sys.stderr)
+        raise typer.Exit(code=1) from e
+
+    print(f"certificate written to {dst_file}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/systemd/user/os-autoinst-scripts-update-cert-from-obs@.service
+++ b/systemd/user/os-autoinst-scripts-update-cert-from-obs@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Update a certificate from OBS
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/bash /opt/os-autoinst-scripts/openqa-update-staging-cert /opt/os-autoinst-scripts/config/obs-certs/%i.conf
+Restart=on-failure
+RestartSec=1m

--- a/systemd/user/os-autoinst-scripts-update-factory-staging-cert.timer
+++ b/systemd/user/os-autoinst-scripts-update-factory-staging-cert.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Update the certificate of openSUSE Factory staging builds needed for SecureBoot
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+Unit=os-autoinst-scripts-update-cert-from-obs@factory-staging.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/user/os-autoinst-scripts-update-suse-unsupported-cert.timer
+++ b/systemd/user/os-autoinst-scripts-update-suse-unsupported-cert.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Update the certificate of SUSE-internal builds needed for SecureBoot
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+Unit=os-autoinst-scripts-update-cert-from-obs@suse-unsupported.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_openqa_update_cert_from_obs.py
+++ b/tests/test_openqa_update_cert_from_obs.py
@@ -1,0 +1,196 @@
+# Copyright SUSE LLC
+# ruff: noqa: S404, TRY002, TRY003, EM101, FBT001, ARG005, RUF059
+"""Unit tests for openqa-update-cert-from-obs."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import pathlib
+import subprocess
+import sys
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import typer
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+# Load the script dynamically as a module
+rootpath = pathlib.Path(__file__).parent.parent.resolve()
+path = rootpath / "openqa-update-cert-from-obs"
+spec = importlib.util.spec_from_file_location(
+    "update_cert",
+    path,
+    loader=importlib.machinery.SourceFileLoader("update_cert", str(path)),
+)
+assert spec is not None
+assert spec.loader is not None
+update_cert = importlib.util.module_from_spec(spec)
+sys.modules["update_cert"] = update_cert
+spec.loader.exec_module(update_cert)
+
+
+def test_parse_config_success(tmp_path: pathlib.Path) -> None:
+    config_file = tmp_path / "test.conf"
+    config_file.write_text(
+        "# This is a comment\n"
+        "\n"
+        "OBS_PROJECT=openSUSE:Factory:Staging\n"
+        "CRT_NAME = 'openSUSE-Factory-Staging.crt'\n"
+        'OBS_API_URL = "https://api.opensuse.org"\n'
+        "INVALID_LINE\n"
+    )
+    res = update_cert.parse_config(config_file)
+    assert res == {
+        "OBS_PROJECT": "openSUSE:Factory:Staging",
+        "CRT_NAME": "openSUSE-Factory-Staging.crt",
+        "OBS_API_URL": "https://api.opensuse.org",
+    }
+
+
+def test_parse_config_error(tmp_path: pathlib.Path) -> None:
+    missing_file = tmp_path / "does_not_exist.conf"
+    with pytest.raises(typer.Exit) as exc:
+        update_cert.parse_config(missing_file)
+    assert exc.value.exit_code == 2
+
+
+def unlink_and_raise_called_process_error(tmp_path: pathlib.Path) -> None:
+    tmp_file = tmp_path / "var_lib" / "openqa" / "share" / "factory" / "other" / "fixed" / "cert.crt.tmp"
+    tmp_file.unlink()
+    raise subprocess.CalledProcessError(5, "osc", stderr="error")
+
+
+def unlink_and_raise_exception(tmp_path: pathlib.Path) -> None:
+    tmp_file = tmp_path / "var_lib" / "openqa" / "share" / "factory" / "other" / "fixed" / "cert.crt.tmp"
+    tmp_file.unlink()
+    raise Exception("generic error")
+
+
+@pytest.mark.parametrize(
+    ("config_content", "mkdir_raises", "sub_raises", "replace_raises", "expected_exit"),
+    [
+        (
+            {"OBS_PROJECT": "proj"},
+            False,
+            None,
+            False,
+            1,  # CRT_NAME missing
+        ),
+        (
+            {"CRT_NAME": "cert.crt"},
+            False,
+            None,
+            False,
+            1,  # OBS_PROJECT missing
+        ),
+        (
+            {"OBS_PROJECT": "proj", "CRT_NAME": "cert.crt"},
+            True,  # mkdir raises OSError
+            None,
+            False,
+            1,
+        ),
+        (
+            {"OBS_PROJECT": "proj", "CRT_NAME": "cert.crt"},
+            False,
+            subprocess.CalledProcessError(5, "osc", stderr="some error"),
+            False,
+            5,  # CalledProcessError exit code
+        ),
+        (
+            {"OBS_PROJECT": "proj", "CRT_NAME": "cert.crt"},
+            False,
+            subprocess.CalledProcessError(5, "osc", stderr=None),
+            False,
+            5,  # CalledProcessError with stderr=None
+        ),
+        (
+            {"OBS_PROJECT": "proj", "CRT_NAME": "cert.crt"},
+            False,
+            unlink_and_raise_called_process_error,
+            False,
+            5,  # CalledProcessError with file already unlinked
+        ),
+        (
+            {"OBS_PROJECT": "proj", "CRT_NAME": "cert.crt"},
+            False,
+            Exception("generic subprocess exception"),
+            False,
+            1,  # Generic exception
+        ),
+        (
+            {"OBS_PROJECT": "proj", "CRT_NAME": "cert.crt"},
+            False,
+            unlink_and_raise_exception,
+            False,
+            1,  # Generic exception with file already unlinked
+        ),
+        (
+            {"OBS_PROJECT": "proj", "CRT_NAME": "cert.crt"},
+            False,
+            None,
+            True,  # replace raises OSError
+            1,
+        ),
+        (
+            {"OBS_PROJECT": "proj", "CRT_NAME": "cert.crt", "OBS_API_URL": "https://api.custom.org"},
+            False,
+            None,
+            False,
+            0,  # success path
+        ),
+    ],
+)
+def test_main_flow(
+    mocker: MockerFixture,
+    tmp_path: pathlib.Path,
+    config_content: dict[str, str],
+    mkdir_raises: bool,
+    sub_raises: Any,
+    replace_raises: bool,
+    expected_exit: int,
+) -> None:
+    config_file = tmp_path / "test.conf"
+    config_lines = [f"{k}={v}" for k, v in config_content.items()]
+    config_file.write_text("\n".join(config_lines))
+
+    # Mock parse_config to return config_content
+    mocker.patch("update_cert.parse_config", return_value=config_content)
+
+    if mkdir_raises:
+        mock_mkdir = mocker.patch("pathlib.Path.mkdir")
+        mock_mkdir.side_effect = OSError("Permission denied")
+
+    if replace_raises:
+        mock_replace = mocker.patch("pathlib.Path.replace")
+        mock_replace.side_effect = OSError("Replace failed")
+
+    mock_run = mocker.patch("subprocess.run")
+    if sub_raises:
+        if callable(sub_raises):
+            mock_run.side_effect = lambda *args, **kwargs: sub_raises(tmp_path)
+        else:
+            mock_run.side_effect = sub_raises
+
+    openqa_basedir = tmp_path / "var_lib"
+
+    if expected_exit == 0:
+        update_cert.main(config_file, openqa_basedir=openqa_basedir)
+        mock_run.assert_called_once()
+        args, kwargs = mock_run.call_args
+        cmd = args[0]
+        assert cmd == [
+            "osc",
+            "--apiurl",
+            config_content.get("OBS_API_URL", "https://api.opensuse.org"),
+            "signkey",
+            "--sslcert",
+            config_content["OBS_PROJECT"],
+        ]
+    else:
+        with pytest.raises(typer.Exit) as exc:
+            update_cert.main(config_file, openqa_basedir=openqa_basedir)
+        assert exc.value.exit_code == expected_exit


### PR DESCRIPTION
Motivation:
Provide a robust command-line interface with proper --help documentation for
the certificate updating script.

Design Choices:
Port the bash script to Python using typer for argument parsing. Relocate
installation and usage documentation from README.md to the typer --help
block. Add unit tests with 100% statement and branch coverage.

Benefits:
Easier maintenance, better command-line documentation, and rigorous test
coverage.

After:
* #603