### PR TITLE
feat: Add openqa-get-qem-bot-blocking-jobs

### DIFF
--- a/openqa-get-qem-bot-blocking-jobs
+++ b/openqa-get-qem-bot-blocking-jobs
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# Copyright SUSE LLC
+# ruff: noqa: PLR0913, PLR0917, T201, S107
+"""Find blocking SLE maintenance jobs based on parsing gitlab CI job logs of qem-bot.
+
+This script parses the gitlab CI job logs of qem-bot directly because they serve as
+the absolute source of truth for why qem-bot decides not to approve a submission,
+which cannot be determined by simply querying the high-level dashboard.
+"""
+
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import Annotated, Any
+
+import httpx
+import typer
+
+app = typer.Typer(add_completion=False)
+log = logging.getLogger(__name__)
+
+
+def setup_logging(verbose: int) -> None:
+    """Set up logging level based on verbosity count."""
+    verbose_to_level = {0: logging.WARNING, 1: logging.INFO}
+    level = verbose_to_level.get(verbose, logging.DEBUG)
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s", stream=sys.stderr, force=True)
+
+
+def get_gitlab_access_token(filename: str) -> str:
+    """Read the gitlab access token from the given filename."""
+    token_path = Path(filename).expanduser()
+    log.debug("Reading GitLab access token from %s", token_path)
+    try:
+        return token_path.read_text(encoding="utf-8").strip()
+    except Exception as e:
+        log.exception("Error reading gitlab access token file '%s'", filename)
+        raise typer.Exit(code=1) from e
+
+
+def get_gitlab_jobs(
+    client: httpx.Client, gitlab_url: str, project_id: int, headers: dict[str, str]
+) -> list[dict[str, Any]]:
+    """Fetch GitLab jobs for the project."""
+    jobs_url = f"{gitlab_url}/api/v4/projects/{project_id}/jobs"
+    log.info("Fetching GitLab jobs from project %d", project_id)
+    log.debug("GitLab jobs URL: %s", jobs_url)
+    response = client.get(jobs_url, headers=headers)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_gitlab_job_raw(
+    client: httpx.Client, gitlab_url: str, project_id: int, job_id: int, headers: dict[str, str]
+) -> str:
+    """Fetch the raw trace log of a GitLab job via the API."""
+    job_raw_url = f"{gitlab_url}/api/v4/projects/{project_id}/jobs/{job_id}/trace"
+    log.info("Fetching raw log of GitLab job %d", job_id)
+    log.debug("GitLab job raw URL: %s", job_raw_url)
+    response = client.get(job_raw_url, headers=headers)
+    response.raise_for_status()
+    return response.text
+
+
+def extract_openqa_job_ids(raw_content: str) -> list[str]:
+    """Extract unique openQA job IDs from the GitLab job log."""
+    log.debug("Parsing GitLab job log for openQA job IDs")
+    openqa_job_ids = list(
+        dict.fromkeys(
+            parts[1].split()[0]
+            for line in raw_content.splitlines()
+            if "not-ignored job" in line and len(parts := line.split("/t")) > 1
+        )
+    )
+    log.info("Extracted openQA job IDs: %s", openqa_job_ids)
+    return openqa_job_ids
+
+
+def get_openqa_job_info(client: httpx.Client, openqa_url: str, job_id: str) -> dict[str, Any]:
+    """Fetch details of an openQA job."""
+    openqa_job_url = f"{openqa_url}/api/v1/jobs/{job_id}"
+    log.info("Fetching openQA job info for %s", job_id)
+    log.debug("openQA job URL: %s", openqa_job_url)
+    response = client.get(openqa_job_url)
+    response.raise_for_status()
+    return response.json()
+
+
+def process_openqa_job(client: httpx.Client, openqa_url: str, job_id: str, compiled_regex: re.Pattern[str]) -> None:
+    """Fetch openQA job, format output, and print if matched by regex."""
+    log.debug("Processing openQA job %s", job_id)
+    job_info = get_openqa_job_info(client, openqa_url, job_id).get("job", {})
+    output = f"{openqa_url}/t{job_info.get('id')}: {job_info.get('group')} / {job_info.get('parent_group')}"
+    if compiled_regex.search(output):
+        log.info("Job matched regex: %s", output)
+        print(output)
+    else:
+        log.debug("Job did not match regex: %s", output)
+
+
+def find_blocking_jobs(
+    client: httpx.Client,
+    project_id: int,
+    job_name: str,
+    gitlab_url: str,
+    openqa_url: str,
+    filter_regex: str,
+    headers: dict[str, str],
+) -> None:
+    """Find and print blocking SLE maintenance jobs from GitLab and openQA."""
+    log.info("Starting blocking jobs search")
+    log.debug("Filter regex pattern: %s", filter_regex)
+    jobs = get_gitlab_jobs(client, gitlab_url, project_id, headers)
+    filtered_job = next((job for job in jobs if job.get("name") == job_name), None)
+    if not filtered_job:
+        log.error("Job with name '%s' not found.", job_name)
+        raise typer.Exit(code=1)
+
+    raw_content = get_gitlab_job_raw(client, gitlab_url, project_id, filtered_job["id"], headers)
+    openqa_job_ids = extract_openqa_job_ids(raw_content)
+    compiled_regex = re.compile(filter_regex)
+
+    for job_id in openqa_job_ids:
+        process_openqa_job(client, openqa_url, job_id, compiled_regex)
+
+
+@app.command()
+def main(
+    project_id: Annotated[int, typer.Option(help="GitLab project ID")] = 6096,
+    job_name: Annotated[str, typer.Option(help="Name of the GitLab job to filter")] = "approve submissions",
+    gitlab_url: Annotated[str, typer.Option(help="GitLab API URL")] = "https://gitlab.suse.de",
+    openqa_url: Annotated[str, typer.Option(help="openQA API URL")] = "https://openqa.suse.de",
+    filter_regex: Annotated[
+        str, typer.Option(help="Regex to filter openQA job groups")
+    ] = r"(Container|Cloud|SLEM|Minimal.*VM)",
+    gitlab_access_token_file: Annotated[
+        str, typer.Option(help="Path to GitLab access token file")
+    ] = "~/.gitlab_access_token_suse_de",
+    verbose: Annotated[int, typer.Option("--verbose", "-v", count=True, help="Increase verbosity")] = 0,
+) -> None:
+    """Find blocking SLE maintenance jobs based on parsing gitlab CI job logs of qem-bot.
+
+    This script parses the gitlab CI job logs of qem-bot directly because they serve as
+    the absolute source of truth for why qem-bot decides not to approve a submission,
+    which cannot be determined by simply querying the high-level dashboard.
+    """
+    setup_logging(verbose)
+    private_token = get_gitlab_access_token(gitlab_access_token_file)
+    headers = {"PRIVATE-TOKEN": private_token}
+
+    with httpx.Client() as client:
+        find_blocking_jobs(
+            client=client,
+            project_id=project_id,
+            job_name=job_name,
+            gitlab_url=gitlab_url,
+            openqa_url=openqa_url,
+            filter_regex=filter_regex,
+            headers=headers,
+        )
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/test_openqa_get_qem_bot_blocking_jobs.py
+++ b/tests/test_openqa_get_qem_bot_blocking_jobs.py
@@ -1,0 +1,200 @@
+# Copyright SUSE LLC
+"""Unit tests for openqa-get-qem-bot-blocking-jobs."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import logging
+import pathlib
+import re
+import sys
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, Mock
+
+import httpx
+import pytest
+import typer
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+# Load the script dynamically as a module
+rootpath = pathlib.Path(__file__).parent.parent.resolve()
+path = rootpath / "openqa-get-qem-bot-blocking-jobs"
+spec = importlib.util.spec_from_file_location(
+    "blocking_jobs",
+    path,
+    loader=importlib.machinery.SourceFileLoader("blocking_jobs", str(path)),
+)
+assert spec is not None
+assert spec.loader is not None
+blocking_jobs = importlib.util.module_from_spec(spec)
+sys.modules["blocking_jobs"] = blocking_jobs
+spec.loader.exec_module(blocking_jobs)
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    client = MagicMock(spec=httpx.Client)
+    client.get.return_value = Mock(spec=httpx.Response)
+    return client
+
+
+def test_get_gitlab_access_token(tmp_path: pathlib.Path) -> None:
+    f = tmp_path / "gitlab_token"
+    f.write_text("my-secret-token\n", encoding="utf-8")
+    assert blocking_jobs.get_gitlab_access_token(str(f)) == "my-secret-token"
+
+    with pytest.raises(typer.Exit) as exc:
+        blocking_jobs.get_gitlab_access_token("non_existent_file")
+    assert exc.value.exit_code == 1
+
+
+def test_get_gitlab_jobs(mock_client: MagicMock) -> None:
+    mock_client.get.return_value.json.return_value = [{"id": 1, "name": "approve submissions"}]
+
+    result = blocking_jobs.get_gitlab_jobs(mock_client, "http://gitlab", 6096, {})
+    assert result == [{"id": 1, "name": "approve submissions"}]
+    mock_client.get.assert_called_once_with("http://gitlab/api/v4/projects/6096/jobs", headers={})
+
+
+def test_get_gitlab_job_raw(mock_client: MagicMock) -> None:
+    mock_client.get.return_value.text = "raw logs"
+
+    result = blocking_jobs.get_gitlab_job_raw(mock_client, "http://gitlab", 6096, 1, {})
+    assert result == "raw logs"
+    mock_client.get.assert_called_once_with("http://gitlab/api/v4/projects/6096/jobs/1/trace", headers={})
+
+
+@pytest.mark.parametrize(
+    ("raw_content", "expected"),
+    [
+        (
+            (
+                "2026-06-17 INFO Found not-ok, not-ignored job https://o.de/t22778588 for submission git:5254\n"
+                "2026-06-17 INFO Found not-ok, not-ignored job https://o.de/t22871672 for submission smelt:44345\n"
+                "2026-06-17 INFO Found not-ok, not-ignored job https://o.de/t22871672 for submission smelt:44495"
+            ),
+            ["22778588", "22871672"],
+        ),
+        ("2026-06-17 INFO Ignoring not-ok job https://openqa.suse.de/t123 (manually marked)", []),
+        ("", []),
+    ],
+)
+def test_extract_openqa_job_ids(raw_content: str, expected: list[str]) -> None:
+    assert blocking_jobs.extract_openqa_job_ids(raw_content) == expected
+
+
+def test_get_openqa_job_info(mock_client: MagicMock) -> None:
+    mock_client.get.return_value.json.return_value = {"job": {"id": 12345, "group": "Container"}}
+
+    result = blocking_jobs.get_openqa_job_info(mock_client, "http://openqa", "12345")
+    assert result == {"job": {"id": 12345, "group": "Container"}}
+    mock_client.get.assert_called_once_with("http://openqa/api/v1/jobs/12345")
+
+
+@pytest.mark.parametrize(
+    ("job_info", "regex_str", "should_print"),
+    [
+        ({"id": 12345, "group": "Container", "parent_group": "SLE"}, r"Container", True),
+        ({"id": 12345, "group": "Other", "parent_group": "SLE"}, r"Container", False),
+    ],
+)
+def test_process_openqa_job(
+    mocker: MockerFixture,
+    capsys: pytest.CaptureFixture[str],
+    mock_client: MagicMock,
+    job_info: dict[str, Any],
+    regex_str: str,
+    *,
+    should_print: bool,
+) -> None:
+    mocker.patch("blocking_jobs.get_openqa_job_info", return_value={"job": job_info})
+
+    compiled_regex = re.compile(regex_str)
+
+    blocking_jobs.process_openqa_job(mock_client, "http://openqa", "12345", compiled_regex)
+    captured = capsys.readouterr().out
+    expected_output = f"http://openqa/t{job_info.get('id')}: {job_info.get('group')} / {job_info.get('parent_group')}\n"
+    if should_print:
+        assert captured == expected_output
+    else:
+        assert not captured
+
+
+def test_find_blocking_jobs_success(mocker: MockerFixture, mock_client: MagicMock) -> None:
+    mock_get_jobs = mocker.patch(
+        "blocking_jobs.get_gitlab_jobs",
+        return_value=[{"id": 1, "name": "approve submissions"}],
+    )
+    mock_get_raw = mocker.patch("blocking_jobs.get_gitlab_job_raw", return_value="logs")
+    mock_extract = mocker.patch("blocking_jobs.extract_openqa_job_ids", return_value=["12345"])
+    mock_process = mocker.patch("blocking_jobs.process_openqa_job")
+
+    blocking_jobs.find_blocking_jobs(
+        mock_client,
+        6096,
+        "approve submissions",
+        "http://gitlab",
+        "http://openqa",
+        "Container",
+        {},
+    )
+
+    mock_get_jobs.assert_called_once()
+    mock_get_raw.assert_called_once_with(mock_client, "http://gitlab", 6096, 1, {})
+    mock_extract.assert_called_once_with("logs")
+    mock_process.assert_called_once()
+
+
+def test_find_blocking_jobs_not_found(mocker: MockerFixture, mock_client: MagicMock) -> None:
+    mocker.patch("blocking_jobs.get_gitlab_jobs", return_value=[])
+
+    with pytest.raises(typer.Exit) as exc:
+        blocking_jobs.find_blocking_jobs(
+            mock_client,
+            6096,
+            "approve submissions",
+            "http://gitlab",
+            "http://openqa",
+            "Container",
+            {},
+        )
+    assert exc.value.exit_code == 1
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_exception"),
+    [
+        (None, None),
+        (httpx.HTTPStatusError("error", request=Mock(), response=Mock()), httpx.HTTPStatusError),
+        (ValueError("error"), ValueError),
+    ],
+)
+def test_main_flow(mocker: MockerFixture, side_effect: Any, expected_exception: Any) -> None:
+    mocker.patch("blocking_jobs.get_gitlab_access_token", return_value="token")
+    mock_find = mocker.patch("blocking_jobs.find_blocking_jobs")
+    if side_effect:
+        mock_find.side_effect = side_effect
+
+    if expected_exception:
+        with pytest.raises(expected_exception):
+            blocking_jobs.main(gitlab_access_token_file="foo")
+    else:
+        blocking_jobs.main(gitlab_access_token_file="foo")
+        mock_find.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("verbose", "expected_level"),
+    [
+        (0, logging.WARNING),
+        (1, logging.INFO),
+        (2, logging.DEBUG),
+        (3, logging.DEBUG),
+    ],
+)
+def test_setup_logging(verbose: int, expected_level: int) -> None:
+    blocking_jobs.setup_logging(verbose)
+    assert logging.getLogger().getEffectiveLevel() == expected_level


### PR DESCRIPTION
Motivation:
Provide a CLI utility to find blocking SLE maintenance jobs in openQA. It
parses GitLab CI logs as the source of truth for qem-bot's rejection decisions.

Design Choices:
Implemented using Python and Typer. It fetches and parses raw GitLab CI traces
rather than relying on high-level dashboards which lack rejection details.

Benefits:
Ensures a reliable, detailed, and consistent view of active blocking jobs.