### PR TITLE
feat: add retry limit to auto-review feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,25 @@ automatically labeled with the corresponding ticket and optionally retriggered
 where it makes sense.
 
 For this the subject line of a ticket must include text following the format
-`auto_review:"<search_term>"[:retry][:force_result:<result>]`
+`auto_review:"<search_term>"[:retry[:<limit>]][:force_result:<result>]`
 
 Note that the `force_result` feature is disabled by default.
 
 * `<search_term>`: the perl extended regex to search for
 * `:retry`: (optional) boolean switch after the quoted search term to instruct
   for retriggering the according openQA job.
+* `:retry:<limit>`: (optional) like `:retry`, but overrides the default limit of
+  7 retries with a custom `<limit>` number of retries.
 * `:force_result:<result>`: (optional) give the job a special label which
   forces the result to be the given string
 
 Examples:
 * `auto_review:"error 42 found"`.
 * `auto_review:"error 42 found":retry`.
+* `auto_review:"error 42 found":retry:3`.
 * `auto_review:"error 42 found":force_result:softfailed`.
 * `auto_review:"error 42 found":retry:force_result:softfailed`.
+* `auto_review:"error 42 found":retry:3:force_result:softfailed`.
 
 The search terms are crosschecked against the logfiles and "reason" field of
 the openQA jobs. A multi-line search is possible, for example using the

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -189,14 +189,49 @@ def label_on_issue(
     return True
 
 
+def get_default_retry_limit(default_limit: int = 7) -> int:
+    env_limit = os.environ.get("auto_review_retry_limit")
+    if env_limit is not None:
+        try:
+            return int(env_limit)
+        except ValueError:
+            pass
+    return default_limit
+
+
+def count_restarts(job: dict, client_call: list[str]) -> int:
+    restarts = 0
+    current_job = job
+    while restarts < 100:
+        cloned_from = current_job.get("cloned_from") or current_job.get("settings", {}).get("cloned_from")
+        if not cloned_from:
+            break
+        restarts += 1
+        current_id = str(cloned_from)
+        cmd_job = (
+            ["openqa-cli"] + [arg for arg in client_call if arg not in {"echo", "openqa-cli"}] + [f"jobs/{current_id}"]
+        )
+        try:
+            res = subprocess.run(cmd_job, check=True, capture_output=True, text=True)
+            job_data = json.loads(res.stdout)
+            current_job = job_data.get("job", {})
+        except Exception as e:
+            log.warning("Failed to fetch parent job %s: %s", current_id, e)
+            break
+    return restarts
+
+
 def label_on_issues_from_issue_tracker(
     job_id: str,
     issues_list: list[dict[str, str]],
     report_file: str,
     client_call: list[str],
+    job: dict | None = None,
+    default_retry_limit: int = 7,
 ) -> bool:
     min_search_term = int(os.environ.get("min_search_term", "16"))
     force_result_tracker = os.environ.get("force_result_tracker", "openqa-force-result")
+    job = job or {}
 
     for issue_info in issues_list:
         issue_id = issue_info["id"]
@@ -224,7 +259,21 @@ def label_on_issues_from_issue_tracker(
                         f'{label} (ignoring force result for ticket which is not in tracker "{force_result_tracker}")'
                     )
 
-            restart = "1" if '":retry' in after else ""
+            restart = ""
+            match_retry = re.search(r'":retry(?::(\d+))?', after)
+            if match_retry:
+                limit_str = match_retry.group(1)
+                limit = int(limit_str) if limit_str is not None else get_default_retry_limit(default_retry_limit)
+                restarts_count = count_restarts(job, client_call)
+                if restarts_count < limit:
+                    restart = "1"
+                else:
+                    log.info(
+                        "Job %s has already been restarted %s times, limit is %s. Skipping restart.",
+                        job_id,
+                        restarts_count,
+                        limit,
+                    )
 
             if label_on_issue(job_id, search, label, report_file, restart, force_result, client_call):
                 return True
@@ -457,6 +506,7 @@ def investigate_issue(
     client_call: list[str],
     issues_list: list[dict[str, str]],
     host_url: str,
+    default_retry_limit: int = 7,
 ) -> None:
     job_id = testurl.rstrip("/").split("/")[-1]
     if not job_id.isdigit():
@@ -520,7 +570,9 @@ def investigate_issue(
                 print(f"'{testurl}' does not have autoinst-log.txt or reason, cannot label", file=sys.stderr)
                 return
 
-        if label_on_issues_from_issue_tracker(job_id, issues_list, report_file, client_call):
+        if label_on_issues_from_issue_tracker(
+            job_id, issues_list, report_file, client_call, job=job, default_retry_limit=default_retry_limit
+        ):
             return
 
         if label_on_issues_without_tickets(job_id, report_file, client_call):
@@ -564,6 +616,11 @@ def main(
     ),
     dry: bool = typer.Option(False, "--dry", "-n", help="conduct dry-run without any labelling or restarting"),
     verbose: Annotated[int, typer.Option("--verbose", "-v", count=True, help="Increase verbosity")] = 0,
+    retry_limit: int = typer.Option(
+        int(os.environ.get("auto_review_retry_limit", "7")),
+        "--retry-limit",
+        help="Default retry limit for the auto-review feature.",
+    ),
 ) -> None:
     """Takes an openQA job URL, looks for matching "known issues", for example from progress.opensuse.org, labels the job and retriggers if specified in the issue (see the source code for details how to mark tickets)."""
     setup_logging(verbose)
@@ -607,6 +664,7 @@ def main(
             client_call=client_call,
             issues_list=issues_list,
             host_url=host_url_val,
+            default_retry_limit=retry_limit,
         )
 
 

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -20,6 +20,36 @@ from typing import Annotated, Any
 import httpx
 import typer
 
+
+class OpenQAClient:
+    """Encapsulates configuration and execution of the openQA CLI."""
+
+    def __init__(self, host_url: str, *, dry_run: bool = False, retries: str = "3") -> None:
+        """Initialize the OpenQAClient."""
+        self.host_url = host_url
+        self.dry_run = dry_run
+        self.retries = retries
+
+    @property
+    def base_args(self) -> list[str]:
+        """Base arguments for openqa-cli."""
+        return [
+            "api",
+            "--header",
+            "User-Agent: openqa-label-known-issues (https://github.com/os-autoinst/os-autoinst-scripts)",
+            "--host",
+            self.host_url,
+            f"--retries={self.retries}",
+        ]
+
+    def run_cmd(self, sub_args: list[str], *, force_no_dry: bool = False) -> subprocess.CompletedProcess[str]:
+        """Execute an openqa-cli command."""
+        cmd = ["openqa-cli", *self.base_args, *sub_args]
+        if self.dry_run and not force_no_dry:
+            cmd = ["echo", *cmd]
+        return subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+
 app = typer.Typer(add_completion=False)
 log = logging.getLogger(__name__)
 
@@ -131,26 +161,24 @@ def extract_excerpt(filepath: str) -> str:
     return "\n".join(f"    # {line}" for line in clean_lines)
 
 
-def comment_on_job(job_id: str, comment: str, force_result: str, client_call: list[str]) -> None:
+def comment_on_job(job_id: str, comment: str, force_result: str, openqa_client: OpenQAClient) -> None:
     enable_force_result = os.environ.get("enable_force_result", "false") == "true"
     if enable_force_result and force_result:
         comment = f"label:force_result:{force_result}:{comment}"
 
-    cmd = [*client_call, "-X", "POST", f"jobs/{job_id}/comments", f"text={comment}"]
-    if client_call and client_call[0] == "echo":
+    if openqa_client.dry_run:
         log.info("Would comment on job %s: %s", job_id, comment)
     try:
-        subprocess.run(cmd, check=True, capture_output=True, text=True)
+        openqa_client.run_cmd(["-X", "POST", f"jobs/{job_id}/comments", f"text={comment}"])
     except subprocess.CalledProcessError as e:
         print(f"Failed to comment on job {job_id}: {e.stderr}", file=sys.stderr)
 
 
-def restart_job(job_id: str, client_call: list[str]) -> None:
-    cmd = [*client_call, "-X", "POST", f"jobs/{job_id}/restart"]
-    if client_call and client_call[0] == "echo":
+def restart_job(job_id: str, openqa_client: OpenQAClient) -> None:
+    if openqa_client.dry_run:
         log.info("Would restart job %s", job_id)
     try:
-        subprocess.run(cmd, check=True, capture_output=True, text=True)
+        openqa_client.run_cmd(["-X", "POST", f"jobs/{job_id}/restart"])
     except subprocess.CalledProcessError as e:
         print(f"Failed to restart job {job_id}: {e.stderr}", file=sys.stderr)
 
@@ -177,15 +205,15 @@ def label_on_issue(
     report_file: str,
     restart: str,
     force_result: str,
-    client_call: list[str],
+    openqa_client: OpenQAClient,
 ) -> bool:
     log.debug("Searching for regex '%s' inside report file %s", search_term, report_file)
     if not search_log(search_term, report_file):
         return False
     log.info("Job %s matches issue/label: %s", job_id, label)
-    comment_on_job(job_id, label, force_result, client_call)
+    comment_on_job(job_id, label, force_result, openqa_client)
     if restart == "1":
-        restart_job(job_id, client_call)
+        restart_job(job_id, openqa_client)
     return True
 
 
@@ -199,7 +227,7 @@ def get_default_retry_limit(default_limit: int = 7) -> int:
     return default_limit
 
 
-def count_restarts(job: dict, client_call: list[str]) -> int:
+def count_restarts(job: dict, openqa_client: OpenQAClient) -> int:
     restarts = 0
     current_job = job
     while restarts < 100:
@@ -208,11 +236,8 @@ def count_restarts(job: dict, client_call: list[str]) -> int:
             break
         restarts += 1
         current_id = str(cloned_from)
-        cmd_job = (
-            ["openqa-cli"] + [arg for arg in client_call if arg not in {"echo", "openqa-cli"}] + [f"jobs/{current_id}"]
-        )
         try:
-            res = subprocess.run(cmd_job, check=True, capture_output=True, text=True)
+            res = openqa_client.run_cmd([f"jobs/{current_id}"], force_no_dry=True)
             job_data = json.loads(res.stdout)
             current_job = job_data.get("job", {})
         except Exception as e:
@@ -225,7 +250,7 @@ def label_on_issues_from_issue_tracker(
     job_id: str,
     issues_list: list[dict[str, str]],
     report_file: str,
-    client_call: list[str],
+    openqa_client: OpenQAClient,
     job: dict | None = None,
     default_retry_limit: int = 7,
 ) -> bool:
@@ -264,7 +289,7 @@ def label_on_issues_from_issue_tracker(
             if match_retry:
                 limit_str = match_retry.group(1)
                 limit = int(limit_str) if limit_str is not None else get_default_retry_limit(default_retry_limit)
-                restarts_count = count_restarts(job, client_call)
+                restarts_count = count_restarts(job, openqa_client)
                 if restarts_count < limit:
                     restart = "1"
                 else:
@@ -275,7 +300,9 @@ def label_on_issues_from_issue_tracker(
                         limit,
                     )
 
-            if label_on_issue(job_id, search, label, report_file, restart, force_result, client_call):
+            if label_on_issue(
+                    job_id, search, label, report_file, restart, force_result, openqa_client
+                ):
                 return True
     return False
 
@@ -283,7 +310,7 @@ def label_on_issues_from_issue_tracker(
 def label_on_issues_without_tickets(
     job_id: str,
     report_file: str,
-    client_call: list[str],
+    openqa_client: OpenQAClient,
 ) -> bool:
     patterns = [
         (
@@ -314,7 +341,7 @@ def label_on_issues_without_tickets(
     ]
 
     for regex, label, restart in patterns:
-        if label_on_issue(job_id, regex, label, report_file, restart, "", client_call):
+        if label_on_issue(job_id, regex, label, report_file, restart, "", openqa_client):
             return True
     return False
 
@@ -324,7 +351,7 @@ def handle_unreachable(
     job_id: str,
     client: httpx.Client,
     host_url: str,
-    client_call: list[str],
+    openqa_client: OpenQAClient,
 ) -> int:
     html_out = os.environ.get("JOB_HTML_FILE")
     temp_html_created = False
@@ -377,8 +404,8 @@ def handle_unreachable(
             comment = (
                 'poo#62456 test incompletes after failing in GRU download task on "Inactivity timeout" with no logs'
             )
-            comment_on_job(job_id, comment, "", client_call)
-            restart_job(job_id, client_call)
+            comment_on_job(job_id, comment, "", openqa_client)
+            restart_job(job_id, openqa_client)
             return 1
 
         timeago = extract_timeago(html_content)
@@ -407,8 +434,7 @@ def handle_unreviewed(
     from_email: str,
     notification_address: str,
     job_data: dict[str, Any],
-    dry_run: bool,
-    client_call: list[str],
+    openqa_client: OpenQAClient,
 ) -> None:
     snip_start = "    # --- 8< ---\n"
     snip_end = "    # --- >8 ---"
@@ -422,13 +448,8 @@ def handle_unreviewed(
     print(excerpt, file=sys.stderr)
 
     if email_unreviewed and group_id != "null":
-        cmd_group = (
-            ["openqa-cli"]
-            + [arg for arg in client_call if arg not in {"echo", "openqa-cli"}]
-            + [f"job_groups/{group_id}"]
-        )
         try:
-            res = subprocess.run(cmd_group, check=True, capture_output=True, text=True)
+            res = openqa_client.run_cmd([f"job_groups/{group_id}"], force_no_dry=True)
             group_data = json.loads(res.stdout)
         except Exception as e:
             print(f"Failed to load job group data for {group_id}: {e}", file=sys.stderr)
@@ -472,7 +493,7 @@ def handle_unreviewed(
             email_full = multipart_from_markdown(
                 email_body, group_mailto, f"openqa-label-known-issues <{from_email}>", subject
             )
-            send_email(group_mailto, email_full, dry_run)
+            send_email(group_mailto, email_full, openqa_client.dry_run)
 
 
 def fetch_issues(client: httpx.Client, issue_query: str) -> list[dict[str, str]]:
@@ -503,7 +524,7 @@ def fetch_issues(client: httpx.Client, issue_query: str) -> list[dict[str, str]]
 def investigate_issue(
     testurl: str,
     client: httpx.Client,
-    client_call: list[str],
+    openqa_client: OpenQAClient,
     issues_list: list[dict[str, str]],
     host_url: str,
     default_retry_limit: int = 7,
@@ -522,9 +543,7 @@ def investigate_issue(
 
     try:
         print(f"Requesting jobs/{job_id} via openqa-cli")
-        cmd_job = (
-            ["openqa-cli"] + [arg for arg in client_call if arg not in {"echo", "openqa-cli"}] + [f"jobs/{job_id}"]
-        )
+        cmd_job = ["openqa-cli", *openqa_client.base_args, f"jobs/{job_id}"]
         try:
             res = subprocess.run(cmd_job, check=True, capture_output=True, text=True)
             job_data = json.loads(res.stdout)
@@ -562,7 +581,7 @@ def investigate_issue(
             f.write("\n")
 
         if curl_output not in {200, 301}:
-            if handle_unreachable(testurl, job_id, client, host_url, client_call) == 1:
+            if handle_unreachable(testurl, job_id, client, host_url, openqa_client) == 1:
                 return
             if curl_output != 404:
                 return
@@ -571,17 +590,16 @@ def investigate_issue(
                 return
 
         if label_on_issues_from_issue_tracker(
-            job_id, issues_list, report_file, client_call, job=job, default_retry_limit=default_retry_limit
+            job_id, issues_list, report_file, openqa_client, job=job, default_retry_limit=default_retry_limit
         ):
             return
 
-        if label_on_issues_without_tickets(job_id, report_file, client_call):
+        if label_on_issues_without_tickets(job_id, report_file, openqa_client):
             return
 
         email_unreviewed = os.environ.get("email_unreviewed", "false").lower() == "true"
         from_email = os.environ.get("from_email", "openqa-label-known-issues@open.qa")
         notification_address = os.environ.get("notification_address", "")
-        dry_run = os.environ.get("dry_run", "0") == "1"
 
         handle_unreviewed(
             testurl=testurl,
@@ -592,8 +610,7 @@ def investigate_issue(
             from_email=from_email,
             notification_address=notification_address,
             job_data=job_data,
-            dry_run=dry_run,
-            client_call=client_call,
+            openqa_client=openqa_client,
         )
 
     finally:
@@ -637,18 +654,7 @@ def main(
         os.environ["dry_run"] = "1"
 
     retries = os.environ.get("retries", "3")
-    client_args = [
-        "api",
-        "--header",
-        "User-Agent: openqa-label-known-issues (https://github.com/os-autoinst/os-autoinst-scripts)",
-        "--host",
-        host_url_val,
-        f"--retries={retries}",
-    ]
-
-    client_call = ["openqa-cli", *client_args]
-    if dry_run_val:
-        client_call = ["echo", *client_call]
+    openqa_client = OpenQAClient(host_url=host_url_val, dry_run=dry_run_val, retries=retries)
 
     issue_marker = os.environ.get("issue_marker", "auto_review%3A")
     issue_query = os.environ.get(
@@ -661,7 +667,7 @@ def main(
         investigate_issue(
             testurl=job_url,
             client=client,
-            client_call=client_call,
+            openqa_client=openqa_client,
             issues_list=issues_list,
             host_url=host_url_val,
             default_retry_limit=retry_limit,

--- a/tests/test_openqa_label_known_issues.py
+++ b/tests/test_openqa_label_known_issues.py
@@ -161,45 +161,40 @@ def test_extract_excerpt(tmp_path: pathlib.Path) -> None:
 
 
 def test_comment_on_job(mocker: MockerFixture) -> None:
+    client = openqa_label_known_issues.OpenQAClient("http://localhost")
     # 1. Success without force_result
-    mock_run = mocker.patch("subprocess.run")
-    openqa_label_known_issues.comment_on_job("123", "my comment", "", ["openqa-cli"])
-    mock_run.assert_called_once_with(
-        ["openqa-cli", "-X", "POST", "jobs/123/comments", "text=my comment"], check=True, capture_output=True, text=True
-    )
+    mock_run = mocker.patch.object(client, "run_cmd")
+    openqa_label_known_issues.comment_on_job("123", "my comment", "", client)
+    mock_run.assert_called_once_with(["-X", "POST", "jobs/123/comments", "text=my comment"])
 
     # 2. Success with force_result and enable_force_result
     mock_run.reset_mock()
     mocker.patch.dict("os.environ", {"enable_force_result": "true"})
-    openqa_label_known_issues.comment_on_job("123", "my comment", "softfailed", ["openqa-cli"])
+    openqa_label_known_issues.comment_on_job("123", "my comment", "softfailed", client)
     mock_run.assert_called_once_with(
-        ["openqa-cli", "-X", "POST", "jobs/123/comments", "text=label:force_result:softfailed:my comment"],
-        check=True,
-        capture_output=True,
-        text=True,
+        ["-X", "POST", "jobs/123/comments", "text=label:force_result:softfailed:my comment"]
     )
 
     # 3. Failed subprocess
     mock_run.reset_mock()
     mock_run.side_effect = subprocess.CalledProcessError(1, "cmd", stderr="error string")
     with patch("builtins.print") as mock_print:
-        openqa_label_known_issues.comment_on_job("123", "comment", "", ["openqa-cli"])
+        openqa_label_known_issues.comment_on_job("123", "comment", "", client)
         mock_print.assert_called_once_with("Failed to comment on job 123: error string", file=sys.stderr)
 
 
 def test_restart_job(mocker: MockerFixture) -> None:
+    client = openqa_label_known_issues.OpenQAClient("http://localhost")
     # Success
-    mock_run = mocker.patch("subprocess.run")
-    openqa_label_known_issues.restart_job("123", ["openqa-cli"])
-    mock_run.assert_called_once_with(
-        ["openqa-cli", "-X", "POST", "jobs/123/restart"], check=True, capture_output=True, text=True
-    )
+    mock_run = mocker.patch.object(client, "run_cmd")
+    openqa_label_known_issues.restart_job("123", client)
+    mock_run.assert_called_once_with(["-X", "POST", "jobs/123/restart"])
 
     # Failure
     mock_run.reset_mock()
     mock_run.side_effect = subprocess.CalledProcessError(1, "cmd", stderr="restart error")
     with patch("builtins.print") as mock_print:
-        openqa_label_known_issues.restart_job("123", ["openqa-cli"])
+        openqa_label_known_issues.restart_job("123", client)
         mock_print.assert_called_once_with("Failed to restart job 123: restart error", file=sys.stderr)
 
 
@@ -222,6 +217,7 @@ def test_search_log(tmp_path: pathlib.Path) -> None:
 
 
 def test_label_on_issue(mocker: MockerFixture) -> None:
+    client = openqa_label_known_issues.OpenQAClient("http://localhost")
     # No match
     mocker.patch("openqa_label_known_issues.search_log", return_value=False)
     mock_comment = mocker.patch("openqa_label_known_issues.comment_on_job")
@@ -232,20 +228,21 @@ def test_label_on_issue(mocker: MockerFixture) -> None:
     mocker.patch("openqa_label_known_issues.search_log", return_value=True)
     mock_comment.reset_mock()
     mock_restart = mocker.patch("openqa_label_known_issues.restart_job")
-    assert openqa_label_known_issues.label_on_issue("123", "patt", "lbl", "file", "", "force", ["api"]) is True
-    mock_comment.assert_called_once_with("123", "lbl", "force", ["api"])
+    assert openqa_label_known_issues.label_on_issue("123", "patt", "lbl", "file", "", "force", client) is True
+    mock_comment.assert_called_once_with("123", "lbl", "force", client)
     mock_restart.assert_not_called()
 
     # Match with restart
     mock_comment.reset_mock()
-    assert openqa_label_known_issues.label_on_issue("123", "patt", "lbl", "file", "1", "force", ["api"]) is True
-    mock_comment.assert_called_once_with("123", "lbl", "force", ["api"])
-    mock_restart.assert_called_once_with("123", ["api"])
+    assert openqa_label_known_issues.label_on_issue("123", "patt", "lbl", "file", "1", "force", client) is True
+    mock_comment.assert_called_once_with("123", "lbl", "force", client)
+    mock_restart.assert_called_once_with("123", client)
 
 
 def test_label_on_issues_from_issue_tracker(mocker: MockerFixture) -> None:
     # Minimal setup
     mocker.patch.dict("os.environ", {"min_search_term": "5"})
+    client = openqa_label_known_issues.OpenQAClient("http://localhost")
     issues_list = [
         {
             "id": "1",
@@ -254,7 +251,7 @@ def test_label_on_issues_from_issue_tracker(mocker: MockerFixture) -> None:
         }
     ]
     mock_lbl = mocker.patch("openqa_label_known_issues.label_on_issue", return_value=True)
-    assert openqa_label_known_issues.label_on_issues_from_issue_tracker("123", issues_list, "file", ["api"]) is True
+    assert openqa_label_known_issues.label_on_issues_from_issue_tracker("123", issues_list, "file", client) is True
     mock_lbl.assert_called_once_with(
         "123",
         "match_me",
@@ -262,7 +259,7 @@ def test_label_on_issues_from_issue_tracker(mocker: MockerFixture) -> None:
         "file",
         "1",
         "softfailed",
-        ["api"],
+        client,
     )
 
     # match_force is False and restart is False (covers branches 213->221, restart=False, and 223->195 loop continue when label_on_issue returns False)
@@ -282,7 +279,7 @@ def test_label_on_issues_from_issue_tracker(mocker: MockerFixture) -> None:
     mock_lbl.side_effect = [False, True]
     assert (
         openqa_label_known_issues.label_on_issues_from_issue_tracker(
-            "123", issues_list_no_force_no_retry, "file", ["api"]
+            "123", issues_list_no_force_no_retry, "file", client
         )
         is True
     )
@@ -299,7 +296,7 @@ def test_label_on_issues_from_issue_tracker(mocker: MockerFixture) -> None:
     mock_lbl.reset_mock()
     mock_lbl.side_effect = None
     assert (
-        openqa_label_known_issues.label_on_issues_from_issue_tracker("123", issues_list_one_quote, "file", ["api"])
+        openqa_label_known_issues.label_on_issues_from_issue_tracker("123", issues_list_one_quote, "file", client)
         is False
     )
     mock_lbl.assert_not_called()
@@ -314,7 +311,7 @@ def test_label_on_issues_from_issue_tracker(mocker: MockerFixture) -> None:
     ]
     mock_lbl.reset_mock()
     mock_lbl.return_value = True
-    assert openqa_label_known_issues.label_on_issues_from_issue_tracker("123", issues_list2, "file", ["api"]) is True
+    assert openqa_label_known_issues.label_on_issues_from_issue_tracker("123", issues_list2, "file", client) is True
     mock_lbl.assert_called_once_with(
         "123",
         "match_me",
@@ -322,7 +319,7 @@ def test_label_on_issues_from_issue_tracker(mocker: MockerFixture) -> None:
         "file",
         "",
         "",
-        ["api"],
+        client,
     )
 
     # short search term
@@ -334,7 +331,7 @@ def test_label_on_issues_from_issue_tracker(mocker: MockerFixture) -> None:
         }
     ]
     mock_lbl.reset_mock()
-    assert openqa_label_known_issues.label_on_issues_from_issue_tracker("123", issues_list3, "file", ["api"]) is False
+    assert openqa_label_known_issues.label_on_issues_from_issue_tracker("123", issues_list3, "file", client) is False
     mock_lbl.assert_not_called()
 
     # no quotes
@@ -346,7 +343,7 @@ def test_label_on_issues_from_issue_tracker(mocker: MockerFixture) -> None:
         }
     ]
     mock_lbl.reset_mock()
-    assert openqa_label_known_issues.label_on_issues_from_issue_tracker("123", issues_list4, "file", ["api"]) is False
+    assert openqa_label_known_issues.label_on_issues_from_issue_tracker("123", issues_list4, "file", client) is False
     mock_lbl.assert_not_called()
 
 
@@ -367,22 +364,21 @@ def test_get_default_retry_limit(mocker: MockerFixture) -> None:
 def test_count_restarts(mocker: MockerFixture) -> None:
     # No clone_id/cloned_from
     job = {"id": 123}
-    assert openqa_label_known_issues.count_restarts(job, ["api"]) == 0
+    client = openqa_label_known_issues.OpenQAClient("http://localhost")
+    assert openqa_label_known_issues.count_restarts(job, client) == 0
 
     # With nested clone structure (restarts = 2)
     job_with_parent = {"id": 123, "cloned_from": 122}
 
-    # Mock subprocess.run for parent call
-    mock_run = mocker.patch("subprocess.run")
-    # First parent call returns a job that is cloned from 121
-    # Second parent call returns a job that has no cloned_from
+    # Mock openqa_label_known_issues.OpenQAClient.run_cmd instead of subprocess.run
+    mock_run = mocker.patch.object(openqa_label_known_issues.OpenQAClient, "run_cmd")
     res1 = mocker.MagicMock()
     res1.stdout = json.dumps({"job": {"id": 122, "cloned_from": 121}})
     res2 = mocker.MagicMock()
     res2.stdout = json.dumps({"job": {"id": 121}})
     mock_run.side_effect = [res1, res2]
 
-    assert openqa_label_known_issues.count_restarts(job_with_parent, ["api"]) == 2
+    assert openqa_label_known_issues.count_restarts(job_with_parent, client) == 2
     assert mock_run.call_count == 2
 
 
@@ -390,7 +386,7 @@ def test_count_restarts(mocker: MockerFixture) -> None:
     ("restarts_count", "expected_restart"),
     [
         (1, "1"),  # Under the limit, should restart
-        (3, ""),   # Over/equal the limit, should not restart
+        (3, ""),  # Over/equal the limit, should not restart
     ],
 )
 def test_label_on_issues_from_issue_tracker_retry_limit(
@@ -408,9 +404,13 @@ def test_label_on_issues_from_issue_tracker_retry_limit(
     mock_lbl = mocker.patch("openqa_label_known_issues.label_on_issue", return_value=True)
     mocker.patch("openqa_label_known_issues.count_restarts", return_value=restarts_count)
 
-    assert openqa_label_known_issues.label_on_issues_from_issue_tracker(
-        "123", issues_list, "file", ["api"], job={"id": 123}
-    ) is True
+    client = openqa_label_known_issues.OpenQAClient("http://localhost")
+    assert (
+        openqa_label_known_issues.label_on_issues_from_issue_tracker(
+            "123", issues_list, "file", client, job={"id": 123}
+        )
+        is True
+    )
 
     mock_lbl.assert_called_once_with(
         "123",
@@ -419,18 +419,19 @@ def test_label_on_issues_from_issue_tracker_retry_limit(
         "file",
         expected_restart,
         "",
-        ["api"],
+        client,
     )
 
 
 def test_label_on_issues_without_tickets(mocker: MockerFixture) -> None:
+    client = openqa_label_known_issues.OpenQAClient("http://localhost")
     mock_lbl = mocker.patch("openqa_label_known_issues.label_on_issue", return_value=False)
-    assert openqa_label_known_issues.label_on_issues_without_tickets("123", "file", ["api"]) is False
+    assert openqa_label_known_issues.label_on_issues_without_tickets("123", "file", client) is False
     assert mock_lbl.call_count == 9
 
     mock_lbl.reset_mock()
     mock_lbl.side_effect = [False, True]
-    assert openqa_label_known_issues.label_on_issues_without_tickets("123", "file", ["api"]) is True
+    assert openqa_label_known_issues.label_on_issues_without_tickets("123", "file", client) is True
     assert mock_lbl.call_count == 2
 
 
@@ -486,6 +487,7 @@ def test_handle_unreachable(mocker: MockerFixture) -> None:
     mock_resp_get = Mock(status_code=200, text="Gru job failed connection error Inactivity timeout")
     mock_client.get.side_effect = None
     mock_client.get.return_value = mock_resp_get
+    client_obj = openqa_label_known_issues.OpenQAClient("http://host")
     mock_comment = mocker.patch("openqa_label_known_issues.comment_on_job")
     mock_restart = mocker.patch("openqa_label_known_issues.restart_job")
 
@@ -541,64 +543,63 @@ def test_handle_unreviewed(mocker: MockerFixture, tmp_path: pathlib.Path) -> Non
     mocker.patch("openqa_label_known_issues.extract_excerpt", return_value="my excerpt")
     mocker.patch("openqa_label_known_issues.multipart_from_markdown", return_value="multipart-email")
     mock_send = mocker.patch("openqa_label_known_issues.send_email")
+    
+    client_obj = openqa_label_known_issues.OpenQAClient("http://host", dry_run=False)
+    client_obj_dry = openqa_label_known_issues.OpenQAClient("http://host", dry_run=True)
 
     # 1. email_unreviewed is false
     with patch("builtins.print") as mock_print:
         openqa_label_known_issues.handle_unreviewed(
-            "http://testurl", str(f), "my reason", "24", False, "from@ex.com", "notif@ex.com", {}, True, []
+            "http://testurl", str(f), "my reason", "24", False, "from@ex.com", "notif@ex.com", {}, client_obj
         )
         mock_print.assert_any_call(
             "[http://testurl](http://testurl): Unknown test issue, to be reviewed\n-> [autoinst-log.txt](http://testurl/file/autoinst-log.txt)\n",
             file=sys.stderr,
         )
-    mock_send.assert_not_called()
+        mock_send.assert_not_called()
 
-    # 2. email_unreviewed is true, group_id is null
+    # 2. group_id is null
     mock_send.reset_mock()
     openqa_label_known_issues.handle_unreviewed(
-        "http://testurl", str(f), "my reason", "null", True, "from@ex.com", "notif@ex.com", {}, True, []
+        "http://testurl", str(f), "my reason", "null", True, "from@ex.com", "notif@ex.com", {}, client_obj
     )
     mock_send.assert_not_called()
 
-    # 3. email_unreviewed true, group_id valid, clone_id is not null
-    mock_send.reset_mock()
-    job_data = {"job": {"clone_id": "12345"}}
-    openqa_label_known_issues.handle_unreviewed(
-        "http://testurl", str(f), "my reason", "24", True, "from@ex.com", "notif@ex.com", job_data, True, []
-    )
-    mock_send.assert_not_called()
+    # 3. Valid group, but api fetch fails
+    mock_run = mocker.patch.object(client_obj, "run_cmd")
+    mock_run.side_effect = Exception("api error")
+    with patch("builtins.print") as mock_print:
+        openqa_label_known_issues.handle_unreviewed(
+            "http://testurl", str(f), "my reason", "24", True, "from@ex.com", "notif@ex.com", {}, client_obj
+        )
+        mock_print.assert_any_call("Failed to load job group data for 24: api error", file=sys.stderr)
+        mock_send.assert_called_once_with("notif@ex.com", "multipart-email", False)
 
-    # 4. email_unreviewed true, group_id valid, group data fetch success, MAILTO found, clone_id is null
+    # 4. Valid group, fetching group data, MAILTO present
+    mock_res = Mock(stdout='[{"description": "MAILTO: test@test.com", "name": "groupname"}]')
+    mock_run.side_effect = None
+    mock_run.return_value = mock_res
     mock_send.reset_mock()
-    job_data_null = {"job": {"clone_id": "null", "name": "myjob", "result": "failed"}}
-    mock_sub = mocker.patch("subprocess.run")
-    mock_sub.return_value = Mock(stdout='[{"name": "Lala", "description": "MAILTO: dest@ex.com"}]')
+    
+    mock_run_dry = mocker.patch.object(client_obj_dry, "run_cmd", return_value=mock_res)
     openqa_label_known_issues.handle_unreviewed(
-        "http://testurl", str(f), "my reason", "24", True, "from@ex.com", "notif@ex.com", job_data_null, True, []
+        "http://testurl", str(f), "my reason", "24", True, "from@ex.com", "", {}, client_obj_dry
     )
-    mock_send.assert_called_once_with("dest@ex.com", "multipart-email", True)
+    mock_send.assert_called_once_with("test@test.com", "multipart-email", True)
+    mock_run_dry.assert_called_once_with(["job_groups/24"], force_no_dry=True)
 
-    # 5. group data fetch fails, fallback to notification address
-    mock_send.reset_mock()
-    mock_sub.side_effect = Exception("err")
-    openqa_label_known_issues.handle_unreviewed(
-        "http://testurl", str(f), "my reason", "24", True, "from@ex.com", "notif@ex.com", job_data_null, True, []
-    )
-    mock_send.assert_called_once_with("notif@ex.com", "multipart-email", True)
-
-    # 6. group data fetch succeeds but MAILTO not found, fallback to notification address
-    mock_send.reset_mock()
-    mock_sub.side_effect = None
-    mock_sub.return_value = Mock(stdout='[{"name": "Lala", "description": "no mailto info here"}]')
-    openqa_label_known_issues.handle_unreviewed(
-        "http://testurl", str(f), "my reason", "24", True, "from@ex.com", "notif@ex.com", job_data_null, True, []
-    )
-    mock_send.assert_called_once_with("notif@ex.com", "multipart-email", True)
-
-    # 7. group data succeeds, MAILTO not found, no notification address (should not send)
+    # 5. Clone detected (no email should be sent)
     mock_send.reset_mock()
     openqa_label_known_issues.handle_unreviewed(
-        "http://testurl", str(f), "my reason", "24", True, "from@ex.com", "", job_data_null, True, []
+        "http://testurl",
+        str(f),
+        "my reason",
+        "24",
+        True,
+        "from@ex.com",
+        "",
+        {"job": {"clone_id": 12345}},
+        client_obj_dry,
     )
     mock_send.assert_not_called()
 
@@ -635,21 +636,21 @@ def test_investigate_issue(mocker: MockerFixture, tmp_path: pathlib.Path) -> Non
 
     # 1. Invalid job ID
     with patch("builtins.print") as mock_print:
-        openqa_label_known_issues.investigate_issue("http://host/tests/abc", mock_client, [], [], "http://host")
+        openqa_label_known_issues.investigate_issue("http://host/tests/abc", mock_client, openqa_label_known_issues.OpenQAClient("http://host"), [], "http://host")
         mock_print.assert_called_once_with("Invalid job ID extracted from http://host/tests/abc", file=sys.stderr)
 
     # 2. job_data fetch fails
     mock_sub = mocker.patch("subprocess.run")
     mock_sub.side_effect = Exception("err")
     with patch("builtins.print") as mock_print:
-        openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, [], [], "http://host")
+        openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, openqa_label_known_issues.OpenQAClient("http://host"), [], "http://host")
         mock_print.assert_any_call("Failed to load job data for 123: err", file=sys.stderr)
 
     # 3. job state not done / passed (should return early)
     mock_sub.side_effect = None
     mock_sub.return_value = Mock(stdout='{"job": {"state": "running", "result": "none"}}')
     mock_client_get = mocker.patch.object(mock_client, "get")
-    openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, [], [], "http://host")
+    openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, openqa_label_known_issues.OpenQAClient("http://host"), [], "http://host")
     mock_client_get.assert_not_called()
 
     # 4. log fetch returns 200, handles issues tracker matched
@@ -658,7 +659,7 @@ def test_investigate_issue(mocker: MockerFixture, tmp_path: pathlib.Path) -> Non
     mock_client.get.return_value = mock_resp_log
 
     mock_tracker = mocker.patch("openqa_label_known_issues.label_on_issues_from_issue_tracker", return_value=True)
-    openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, [], [], "http://host")
+    openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, openqa_label_known_issues.OpenQAClient("http://host"), [], "http://host")
     mock_tracker.assert_called_once()
 
     # 5. log fetch 404, reason null, unreachable fails
@@ -669,14 +670,14 @@ def test_investigate_issue(mocker: MockerFixture, tmp_path: pathlib.Path) -> Non
     mock_client.get.return_value = mock_resp_log
 
     mock_unreachable = mocker.patch("openqa_label_known_issues.handle_unreachable", return_value=1)
-    openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, [], [], "http://host")
+    openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, openqa_label_known_issues.OpenQAClient("http://host"), [], "http://host")
     mock_unreachable.assert_called_once()
 
     # 6. log fetch 404, reason null, unreachable returns 0 (should print cannot label)
     mock_unreachable.reset_mock()
     mock_unreachable.return_value = 0
     with patch("builtins.print") as mock_print:
-        openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, [], [], "http://host")
+        openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, openqa_label_known_issues.OpenQAClient("http://host"), [], "http://host")
         mock_print.assert_any_call(
             "'http://host/tests/123' does not have autoinst-log.txt or reason, cannot label", file=sys.stderr
         )
@@ -688,7 +689,7 @@ def test_investigate_issue(mocker: MockerFixture, tmp_path: pathlib.Path) -> Non
     mock_sub.return_value = Mock(
         stdout='{"job": {"state": "done", "result": "failed", "reason": null, "group_id": null}}'
     )
-    openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, [], [], "http://host")
+    openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, openqa_label_known_issues.OpenQAClient("http://host"), [], "http://host")
     # unreachable matched and returns early
 
     # 8. REPORT_FILE, KEEP_REPORT_FILE set
@@ -696,13 +697,13 @@ def test_investigate_issue(mocker: MockerFixture, tmp_path: pathlib.Path) -> Non
     mocker.patch.dict("os.environ", {"REPORT_FILE": str(tmp_path / "custom_report"), "KEEP_REPORT_FILE": "1"})
     mock_resp_log.status_code = 200
     mock_resp_log.text = "some text"
-    openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, [], [], "http://host")
+    openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, openqa_label_known_issues.OpenQAClient("http://host"), [], "http://host")
     assert (tmp_path / "custom_report").exists()
 
     # 9. Exception during report file unlink (covers lines 544-545 finally cleanup branch)
     mocker.patch.dict("os.environ", {"REPORT_FILE": "", "KEEP_REPORT_FILE": "0"}, clear=True)
     mocker.patch("pathlib.Path.unlink", side_effect=Exception("unlink err"))
-    openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, [], [], "http://host")
+    openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, openqa_label_known_issues.OpenQAClient("http://host"), [], "http://host")
 
     # 10. label_on_issues_without_tickets returns True (covers line 519 return)
     mocker.patch("pathlib.Path.unlink", side_effect=None)
@@ -712,7 +713,7 @@ def test_investigate_issue(mocker: MockerFixture, tmp_path: pathlib.Path) -> Non
     mock_resp_log.text = "Compilation failed in require at isotovideo line 28."
     mock_client.get.return_value = mock_resp_log
     mocker.patch("openqa_label_known_issues.label_on_issues_without_tickets", return_value=True)
-    openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, [], [], "http://host")
+    openqa_label_known_issues.investigate_issue("http://host/tests/123", mock_client, openqa_label_known_issues.OpenQAClient("http://host"), [], "http://host")
 
 
 def test_main(mocker: MockerFixture) -> None:

--- a/tests/test_openqa_label_known_issues.py
+++ b/tests/test_openqa_label_known_issues.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import importlib.machinery
 import importlib.util
+import json
+import os
 import pathlib
 import subprocess
 import sys
@@ -346,6 +348,79 @@ def test_label_on_issues_from_issue_tracker(mocker: MockerFixture) -> None:
     mock_lbl.reset_mock()
     assert openqa_label_known_issues.label_on_issues_from_issue_tracker("123", issues_list4, "file", ["api"]) is False
     mock_lbl.assert_not_called()
+
+
+def test_get_default_retry_limit(mocker: MockerFixture) -> None:
+    # 1. Fallback default
+    mocker.patch.dict("os.environ", {}, clear=True)
+    assert openqa_label_known_issues.get_default_retry_limit(7) == 7
+
+    # 2. Env override
+    mocker.patch.dict("os.environ", {"auto_review_retry_limit": "4"}, clear=True)
+    assert openqa_label_known_issues.get_default_retry_limit(7) == 4
+
+    # 3. Custom parameter override
+    mocker.patch.dict("os.environ", {}, clear=True)
+    assert openqa_label_known_issues.get_default_retry_limit(5) == 5
+
+
+def test_count_restarts(mocker: MockerFixture) -> None:
+    # No clone_id/cloned_from
+    job = {"id": 123}
+    assert openqa_label_known_issues.count_restarts(job, ["api"]) == 0
+
+    # With nested clone structure (restarts = 2)
+    job_with_parent = {"id": 123, "cloned_from": 122}
+
+    # Mock subprocess.run for parent call
+    mock_run = mocker.patch("subprocess.run")
+    # First parent call returns a job that is cloned from 121
+    # Second parent call returns a job that has no cloned_from
+    res1 = mocker.MagicMock()
+    res1.stdout = json.dumps({"job": {"id": 122, "cloned_from": 121}})
+    res2 = mocker.MagicMock()
+    res2.stdout = json.dumps({"job": {"id": 121}})
+    mock_run.side_effect = [res1, res2]
+
+    assert openqa_label_known_issues.count_restarts(job_with_parent, ["api"]) == 2
+    assert mock_run.call_count == 2
+
+
+@pytest.mark.parametrize(
+    ("restarts_count", "expected_restart"),
+    [
+        (1, "1"),  # Under the limit, should restart
+        (3, ""),   # Over/equal the limit, should not restart
+    ],
+)
+def test_label_on_issues_from_issue_tracker_retry_limit(
+    mocker: MockerFixture, restarts_count: int, expected_restart: str
+) -> None:
+    mocker.patch.dict("os.environ", {"min_search_term": "5"})
+
+    issues_list = [
+        {
+            "id": "1",
+            "subject": 'test auto_review:"match_me":retry:3',
+            "tracker_name": "openqa-force-result",
+        }
+    ]
+    mock_lbl = mocker.patch("openqa_label_known_issues.label_on_issue", return_value=True)
+    mocker.patch("openqa_label_known_issues.count_restarts", return_value=restarts_count)
+
+    assert openqa_label_known_issues.label_on_issues_from_issue_tracker(
+        "123", issues_list, "file", ["api"], job={"id": 123}
+    ) is True
+
+    mock_lbl.assert_called_once_with(
+        "123",
+        "match_me",
+        'poo#1 test auto_review:"match_me":retry:3',
+        "file",
+        expected_restart,
+        "",
+        ["api"],
+    )
 
 
 def test_label_on_issues_without_tickets(mocker: MockerFixture) -> None:


### PR DESCRIPTION
Motivation:
Prevent infinite restart loops of failing openQA jobs that are matched by
the auto-review feature but scheduled in a way where they always fail.

Design Choices:
Parses optional custom retry limits per-ticket (e.g. :retry:3) from the
subject. Traverses parent clones backwards to count previous retries, with
a command-line option `--retry-limit` to customize the default of 7.

Benefits:
Stops runaway job retriggering, saves hardware resources, and improves
general openQA test automation stability.

Related issue: https://progress.opensuse.org/issues/202680

After:
* #612