### PR TITLE
feat(monitor): Indicate failed jobs via artifact/file

### DIFF
--- a/monitor-openqa_job
+++ b/monitor-openqa_job
@@ -222,9 +222,9 @@ app = typer.Typer(add_completion=False)
 Monitor an openQA job by polling the status of a job over the API.
 
 Continuously polls the openQA API for the status of the specified jobs until
-all jobs finish. After the jobs have finished this program exits with an exit
-code corresponding to the jobs' result. For example all jobs pass it would
-exit this program with exit code 0 for success; otherwise with 1.
+all jobs finish. If any jobs have failed, it writes the file
+"job_post_skip_submission" with the IDs of the failed jobs. After the jobs have
+finished this program exits with a 0 return code.
 """
 )
 def main(
@@ -296,7 +296,12 @@ def main(
         openqa_groupid_val=openqa_groupid_val,
         host_val=host_val,
     )
-    raise typer.Exit(code=1)
+
+    # let os-autoinst-obs-auto-submit skip the submission
+    pathlib.Path("job_post_skip_submission").write_text(json.dumps({"failed_jobs": failed_jobs}), encoding="utf8")
+
+    # consider the monitoring itself succesful; notifications about the failing jobs are provided via job done hooks
+    raise typer.Exit(code=0)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/monitor-openqa_job
+++ b/monitor-openqa_job
@@ -163,7 +163,7 @@ def comment_on_failed_jobs(
     host_val: str,
 ) -> None:
     if not comment_on_obs or not obs_package_name:
-        raise typer.Exit(code=1)
+        return
 
     log.info("Posting comment with failed jobs to OBS")
     delete_old_comments(osc_cmd_str, obs_component, obs_package_name)
@@ -175,7 +175,6 @@ def comment_on_failed_jobs(
     comment_text += f"groupid={openqa_groupid_val}"
 
     post_comment(osc_cmd_str, obs_component, obs_package_name, comment_text)
-    raise typer.Exit(code=1)
 
 
 def monitor_single_job(
@@ -297,6 +296,7 @@ def main(
         openqa_groupid_val=openqa_groupid_val,
         host_val=host_val,
     )
+    raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_monitor_openqa_job.py
+++ b/tests/test_monitor_openqa_job.py
@@ -153,14 +153,14 @@ def test_monitor_single_job(
 
 
 @pytest.mark.parametrize(
-    ("job_res", "pkg_name", "comment_obs", "env_patch", "expected_exit"),
+    ("job_res", "pkg_name", "comment_obs", "env_patch", "expected_exit", "expected_skip_reason"),
     [
-        ((1, "passed", ""), "", "", {}, 0),
-        ((1, "failed", "15"), "", "", {}, 1),
-        ((1, "failed", "15"), "pkg", "1", {}, 1),
-        ((1, "passed", ""), "", "", {"OPENQA_CLI_RETRIES": "invalid"}, 0),
-        ((1, "passed", ""), "", "", {"PREFIX": "pre", "OSC": ""}, 0),
-        ((1, "passed", ""), "", "", {"OSC": "custom"}, 0),
+        ((1, "passed", ""), "", "", {}, 0, None),
+        ((1, "failed", "15"), "", "", {}, 0, '{"failed_jobs": [1]}'),
+        ((1, "failed", "15"), "pkg", "1", {}, 0, '{"failed_jobs": [1]}'),
+        ((1, "passed", ""), "", "", {"OPENQA_CLI_RETRIES": "invalid"}, 0, None),
+        ((1, "passed", ""), "", "", {"PREFIX": "pre", "OSC": ""}, 0, None),
+        ((1, "passed", ""), "", "", {"OSC": "custom"}, 0, None),
     ],
 )
 def test_main_flow(
@@ -170,6 +170,7 @@ def test_main_flow(
     comment_obs: str,
     env_patch: dict[str, str],
     expected_exit: int,
+    expected_skip_reason: str,
 ) -> None:
     mocker.patch("monitor_job.load_job_ids", return_value=[1])
     mocker.patch("monitor_job.monitor_single_job", return_value=job_res)
@@ -182,7 +183,10 @@ def test_main_flow(
 
     with pytest.raises(typer.Exit) as exc:
         monitor_job.main(obs_package_name=pkg_name, comment_on_obs=comment_obs)
+
     assert exc.value.exit_code == expected_exit
+    if expected_skip_reason is not None:
+        assert pathlib.Path("job_post_skip_submission").read_text(encoding="utf8") == expected_skip_reason
 
 
 @pytest.mark.parametrize(

--- a/tests/test_monitor_openqa_job.py
+++ b/tests/test_monitor_openqa_job.py
@@ -186,18 +186,13 @@ def test_main_flow(
 
 
 @pytest.mark.parametrize(
-    ("pkg", "comment_obs", "expected_exit"),
-    [
-        ("pkg", "", 1),
-        ("pkg", "1", 1),
-    ],
+    ("pkg", "comment_obs"),
+    [("pkg", ""), ("pkg", "1")],
 )
-def test_comment_on_failed_jobs(mocker: MockerFixture, pkg: str, comment_obs: str, expected_exit: int) -> None:
+def test_comment_on_failed_jobs(mocker: MockerFixture, pkg: str, comment_obs: str) -> None:
     mock_del = mocker.patch("monitor_job.delete_old_comments")
     mock_post = mocker.patch("monitor_job.post_comment")
-    with pytest.raises(typer.Exit) as exc:
-        monitor_job.comment_on_failed_jobs("osc", "package", pkg, comment_obs, [1], {"1": 1}, "24", "http://host")
-    assert exc.value.exit_code == expected_exit
+    monitor_job.comment_on_failed_jobs("osc", "package", pkg, comment_obs, [1], {"1": 1}, "24", "http://host")
     if comment_obs:
         mock_del.assert_called_once()
         mock_post.assert_called_once()


### PR DESCRIPTION
* Avoid duplication of `raise typer.Exit(code=1)`
* Avoid deciding the exit code in `comment_on_failed_jobs` which is not
  intuitive as the function name sounds like the function is only supposed
  to add comments (and only call e.g. `raise typer.Exit(code=1)` if *that*
  fails)
* Avoid that the monitoring pipeline fails (causing alerts) in case the
  openQA jobs being monitored fail (as we receive notifications for those
  anyway)
* Write the file `job_post_skip_submission` which is then picked up by
  Jenkins as artifact and made available in the submission pipeline that
  will then skip the submission

Related ticket: https://progress.opensuse.org/issues/202467