### PR TITLE
ci(mergify): Streamline configuration with other repositories

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,8 @@
 ---
+merge_queue:
+  status_comments: none
+  queue_controls_comment: false
+
 pull_request_rules:
   - name: automatic merge
     conditions:


### PR DESCRIPTION
* Disable `queue_controls_comment` as done recently in os-autoinst and openQA (see e.g. openQA commit 82f256af3e6ea)
* Disable `status_comments` in consistency with os-autoinst and openQA