### PR TITLE
refactor: Remove unused function `sync_changesrevision()`

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -207,21 +207,6 @@ update_package() {
     return $rc
 }
 
-sync_changesrevision() {
-    log-info "sync_changesrevision $*"
-    local dir=$1
-    local package=$2
-    local target_rev=$3
-    path="$dir/$package"
-    $prefix xmlstarlet ed -L -u "//param[@name='changesrevision']" -v "$target_rev" "$path"/_servicedata
-    if ! diff -u "$path"/.osc/_servicedata "$path"/_servicedata; then
-        debug_osc up "$path"
-        debug_osc cat "$submit_target" "$package" "$package".changes > "$path/$package".changes
-        debug_osc ci -m "sync changesrevision with $submit_target" "$path"
-        debug_osc up --server-side-source-service-files "$path"
-    fi
-}
-
 get_spec_changes_in_requirements() {
     local package=$1
     local project=$2


### PR DESCRIPTION
The syncing has been moved to `trigger-openqa_in_openqa` so the function can be removed from `os-autoinst-obs-auto-submit`.