### PR TITLE
feat: Add submission filter to qem blocker search

### DIFF
--- a/openqa-get-qem-bot-blocking-jobs
+++ b/openqa-get-qem-bot-blocking-jobs
@@ -8,6 +8,8 @@ the absolute source of truth for why qem-bot decides not to approve a submission
 which cannot be determined by simply querying the high-level dashboard.
 """
 
+from __future__ import annotations
+
 import logging
 import re
 import sys
@@ -63,14 +65,21 @@ def get_gitlab_job_raw(
     return response.text
 
 
-def extract_openqa_job_ids(raw_content: str) -> list[str]:
+def extract_openqa_job_ids(raw_content: str, submission_regex: re.Pattern[str] | None = None) -> list[str]:
     """Extract unique openQA job IDs from the GitLab job log."""
     log.debug("Parsing GitLab job log for openQA job IDs")
+
+    def matches_submission(line: str) -> bool:
+        if not submission_regex:
+            return True
+        parts = line.split("for submission ")
+        return len(parts) > 1 and bool(submission_regex.search(parts[1].strip()))
+
     openqa_job_ids = list(
         dict.fromkeys(
             parts[1].split()[0]
             for line in raw_content.splitlines()
-            if "not-ignored job" in line and len(parts := line.split("/t")) > 1
+            if "not-ignored job" in line and len(parts := line.split("/t")) > 1 and matches_submission(line)
         )
     )
     log.info("Extracted openQA job IDs: %s", openqa_job_ids)
@@ -107,6 +116,7 @@ def find_blocking_jobs(
     openqa_url: str,
     filter_regex: str,
     headers: dict[str, str],
+    submission: str | None = None,
 ) -> None:
     """Find and print blocking SLE maintenance jobs from GitLab and openQA."""
     log.info("Starting blocking jobs search")
@@ -118,7 +128,8 @@ def find_blocking_jobs(
         raise typer.Exit(code=1)
 
     raw_content = get_gitlab_job_raw(client, gitlab_url, project_id, filtered_job["id"], headers)
-    openqa_job_ids = extract_openqa_job_ids(raw_content)
+    submission_regex = re.compile(submission) if submission else None
+    openqa_job_ids = extract_openqa_job_ids(raw_content, submission_regex)
     compiled_regex = re.compile(filter_regex)
 
     for job_id in openqa_job_ids:
@@ -134,6 +145,7 @@ def main(
     filter_regex: Annotated[
         str, typer.Option(help="Regex to filter openQA job groups")
     ] = r"(Container|Cloud|SLEM|Minimal.*VM)",
+    submission: Annotated[str | None, typer.Option(help="Regex to filter by submission/request name or ID")] = None,
     gitlab_access_token_file: Annotated[
         str, typer.Option(help="Path to GitLab access token file")
     ] = "~/.gitlab_access_token_suse_de",
@@ -158,6 +170,7 @@ def main(
             openqa_url=openqa_url,
             filter_regex=filter_regex,
             headers=headers,
+            submission=submission,
         )
 
 

--- a/tests/test_openqa_get_qem_bot_blocking_jobs.py
+++ b/tests/test_openqa_get_qem_bot_blocking_jobs.py
@@ -86,6 +86,29 @@ def test_extract_openqa_job_ids(raw_content: str, expected: list[str]) -> None:
     assert blocking_jobs.extract_openqa_job_ids(raw_content) == expected
 
 
+@pytest.mark.parametrize(
+    ("pattern", "expected"),
+    [
+        (r"git:", ["22778588"]),
+        (r"smelt:44345", ["22871672"]),
+        (r"non_existent", []),
+    ],
+    ids=[
+        "match_all_git_submissions",
+        "match_specific_smelt_submission",
+        "no_matching_submission_pattern",
+    ],
+)
+def test_extract_openqa_job_ids_with_submission_regex(pattern: str, expected: list[str]) -> None:
+    raw_content = (
+        "2026-06-17 INFO Found not-ok, not-ignored job https://o.de/t22778588 for submission git:5254\n"
+        "2026-06-17 INFO Found not-ok, not-ignored job https://o.de/t22871672 for submission smelt:44345\n"
+        "2026-06-17 INFO Found not-ok, not-ignored job https://o.de/t22871672 for submission smelt:44495"
+    )
+    regex = re.compile(pattern)
+    assert blocking_jobs.extract_openqa_job_ids(raw_content, regex) == expected
+
+
 def test_get_openqa_job_info(mock_client: MagicMock) -> None:
     mock_client.get.return_value.json.return_value = {"job": {"id": 12345, "group": "Container"}}
 
@@ -144,7 +167,29 @@ def test_find_blocking_jobs_success(mocker: MockerFixture, mock_client: MagicMoc
 
     mock_get_jobs.assert_called_once()
     mock_get_raw.assert_called_once_with(mock_client, "http://gitlab", 6096, 1, {})
-    mock_extract.assert_called_once_with("logs")
+    mock_extract.assert_called_once_with("logs", None)
+    mock_process.assert_called_once()
+
+
+def test_find_blocking_jobs_with_submission(mocker: MockerFixture, mock_client: MagicMock) -> None:
+    mock_get_jobs = mocker.patch(
+        "blocking_jobs.get_gitlab_jobs",
+        return_value=[{"id": 1, "name": "approve submissions"}],
+    )
+    mock_get_raw = mocker.patch("blocking_jobs.get_gitlab_job_raw", return_value="logs")
+    mock_extract = mocker.patch("blocking_jobs.extract_openqa_job_ids", return_value=["12345"])
+    mock_process = mocker.patch("blocking_jobs.process_openqa_job")
+
+    blocking_jobs.find_blocking_jobs(
+        mock_client, 6096, "approve submissions", "http://gitlab", "http://openqa", "Container", {}, "git:5254"
+    )
+
+    mock_get_jobs.assert_called_once()
+    mock_get_raw.assert_called_once_with(mock_client, "http://gitlab", 6096, 1, {})
+    mock_extract.assert_called_once()
+    called_args = mock_extract.call_args[0]
+    assert called_args[0] == "logs"
+    assert called_args[1].pattern == "git:5254"
     mock_process.assert_called_once()
 
 


### PR DESCRIPTION
Motivation:
Allow users to filter blocking openQA jobs based on a specific submission or
request ID.

Design Choices:
Added a --submission regex Option via typer. Used list comprehension and
dict.fromkeys in python to filter raw log lines by the submission name
extracted after 'for submission '.

Benefits:
Provides targeted search results, reducing noise and allowing developers to
efficiently locate blocking jobs for their specific submission or request.

After:
* #609