### PR TITLE
feat(openqa-query-for-job-label): render fully clickable job URLs

### DIFF
--- a/openqa-query-for-job-label
+++ b/openqa-query-for-job-label
@@ -5,7 +5,6 @@ interval="${interval:-"30 day"}"
 failed_since="${failed_since:-"(timezone('UTC', now()) - interval '$interval')"}"
 comment="${1:?"Need comment to search for"}"
 limit="${limit:-10}"
-query="${query:-"select jobs.id,t_finished,state,result,test,reason,host from jobs, comments, workers where t_finished >= $failed_since and jobs.assigned_worker_id = workers.id and jobs.id = comments.job_id and comments.text ~ '$comment' order by t_finished desc limit $limit;"}"
 dry_run="${dry_run:-"0"}"
 
 usage() {
@@ -40,7 +39,8 @@ main() {
 
     [ "$dry_run" = "1" ] && _dry_run="echo"
     for h in $host; do
-        $_dry_run ssh "$h" "cd /tmp; sudo -u geekotest psql --no-align --tuples-only --command=\"$query\" openqa"
+        q="${query:-"select '${scheme}://${h}/tests/' || jobs.id,t_finished,state,result,test,reason,host from jobs, comments, workers where t_finished >= $failed_since and jobs.assigned_worker_id = workers.id and jobs.id = comments.job_id and comments.text ~ '$comment' order by t_finished desc limit $limit;"}"
+        $_dry_run ssh "$h" "cd /tmp; sudo -u geekotest psql --no-align --tuples-only -F ' | ' --command=\"$q\" openqa"
     done
     :
 }


### PR DESCRIPTION
Motivation:
The `openqa-query-for-job-label` script previously output raw job IDs,
and attempts to prepend the host for a clickable URL failed because the
`$h` host variable was prematurely evaluated before the host-iteration
loop. Additionally, the default unspaced `|` separator caused terminal
emulators to include subsequent output fields as part of the URL when
clicked.

Design Choices:
Moved the default SQL query string definition into the loop iterating
over the hosts so that `$h` and `$scheme` are accurately evaluated for
each target. Prepended `'${scheme}://${h}/tests/'` directly to the job
IDs in the SQL string. Finally, added the `-F ' | '` option to the
`psql` command to cleanly isolate the URL with spaced boundaries.

Benefits:
The output is now formatted as fully clickable URLs. The spaced field
separators prevent terminal emulators from inadvertently including trailing
metadata into the URL.