### PR TITLE
fix: Render multi-line skip reasons as an indented block

### DIFF
--- a/_common
+++ b/_common
@@ -360,8 +360,13 @@ get-dependencies-ajax() {
 }
 
 list_packages() {
-    local obs_project=$1
-    $osc ls "$obs_project" | grep -v '\-test$'
+    local obs_project=$1 output
+    # Capture osc output separately so a failed 'osc ls' (e.g. HTTP 5xx, where
+    # osc prints "Request:/Headers:" error details to stdout) is not mistaken
+    # for a package list. Only emit real package names on success.
+    output=$($osc ls "$obs_project") || return $?
+    [[ -n $output ]] || return 0
+    printf '%s\n' "$output" | grep -v '\-test$'
 }
 
 delete_packages_from_obs_project() {

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -730,6 +730,25 @@ class AutoSubmitter:
             os.chdir(original_dir)
 
 
+def _format_skip_reason(content: str) -> str:
+    """Render job_post_skip_submission content as a concise human-readable reason.
+
+    The file is written by other pipeline steps in different formats: a plain
+    text note, a "not yet ready" message, or JSON with failed openQA job IDs.
+    """
+    content = content.strip()
+    if not content:
+        return "unknown"
+    try:
+        data = json.loads(content)
+    except (json.JSONDecodeError, ValueError):
+        return content
+    failed_jobs = data.get("failed_jobs") if isinstance(data, dict) else None
+    if failed_jobs:
+        return f"failed openQA jobs: {', '.join(str(j) for j in failed_jobs)}"
+    return content
+
+
 def _get_packages_to_submit(dst_project: str, osc_cmd_str: str, *, dry_run: bool) -> list[str]:
     """Determine packages to submit."""
     key_packages = "packages"
@@ -791,9 +810,9 @@ def _run_submissions(  # noqa: C901,  PLR0912, PLR0913, PLR0914, PLR0915
     if submit_target_extra and submit_target_extra != "none":
         targets.extend(submit_target_extra.split(","))
 
-    if pathlib.Path("job_post_skip_submission").exists():
-        log.info("Skipping submission, reason: ")
-        log.info("%s", pathlib.Path("job_post_skip_submission").read_text(encoding="utf-8"))
+    skip_file = pathlib.Path("job_post_skip_submission")
+    if skip_file.exists():
+        log.info("Skipping submission, reason: %s", _format_skip_reason(skip_file.read_text(encoding="utf-8")))
         raise typer.Exit(code=0)
 
     tmpdir_base = os.environ.get("TMPDIR")

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -749,6 +749,15 @@ def _format_skip_reason(content: str) -> str:
     return content
 
 
+def _log_skip_reason(reason: str) -> None:
+    """Log a skip reason, rendering multi-line reasons as an indented block."""
+    if "\n" in reason:
+        indented = "\n".join(f"  {line}" for line in reason.splitlines())
+        log.info("Skipping submission, reason:\n%s", indented)
+    else:
+        log.info("Skipping submission, reason: %s", reason)
+
+
 def _get_packages_to_submit(dst_project: str, osc_cmd_str: str, *, dry_run: bool) -> list[str]:
     """Determine packages to submit."""
     key_packages = "packages"
@@ -812,7 +821,7 @@ def _run_submissions(  # noqa: C901,  PLR0912, PLR0913, PLR0914, PLR0915
 
     skip_file = pathlib.Path("job_post_skip_submission")
     if skip_file.exists():
-        log.info("Skipping submission, reason: %s", _format_skip_reason(skip_file.read_text(encoding="utf-8")))
+        _log_skip_reason(_format_skip_reason(skip_file.read_text(encoding="utf-8")))
         raise typer.Exit(code=0)
 
     tmpdir_base = os.environ.get("TMPDIR")

--- a/test/04-common.t
+++ b/test/04-common.t
@@ -2,7 +2,7 @@
 
 source test/init
 
-plan tests 21
+plan tests 27
 
 source ./_common
 
@@ -64,7 +64,6 @@ somecommand() {
 
 try runcli somecommand
 like "$got" "somecommand.*>>>STDERR<<<.*STDOUT" "somecommand stdout and stderr"
-
 try "bash -c 'command() { if [[ \"\$1\" == \"-v\" && \"\$2\" == \"jq\" ]]; then return 1; fi; if [[ \"\$1\" == \"-v\" && ( \"\$2\" == \"retry\" || \"\$2\" == \"osc\" || \"\$2\" == \"openqa-cli\" ) ]]; then return 0; fi; builtin command \"\$@\"; }; export -f command; source ./_common'"
 is "$rc" 1 "exits with 1 when jq is missing"
 like "$got" "ERROR: 'jq' command not found" "prints correct error message when jq is missing"
@@ -80,3 +79,32 @@ like "$got" "ERROR: 'osc' command not found" "prints correct error message when 
 try "bash -c 'command() { if [[ \"\$1\" == \"-v\" && \"\$2\" == \"openqa-cli\" ]]; then return 1; fi; if [[ \"\$1\" == \"-v\" && ( \"\$2\" == \"jq\" || \"\$2\" == \"retry\" || \"\$2\" == \"osc\" ) ]]; then return 0; fi; builtin command \"\$@\"; }; export -f command; source ./_common'"
 is "$rc" 1 "exits with 1 when openqa-cli is missing"
 like "$got" "ERROR: 'openqa-cli' command not found" "prints correct error message when openqa-cli is missing"
+
+# list_packages: 'osc' is invoked via the $osc variable, so mock it there
+# list_packages: returns real package names, filtering out '*-test' entries
+mock_osc_success() {
+    shift
+    printf '%s\n' openQA os-autoinst openQA-test
+}
+osc=mock_osc_success
+try list_packages devel:openQA
+is "$rc" 0 "list_packages success"
+is "$got" $'openQA\nos-autoinst' "list_packages returns packages without -test entries"
+
+# list_packages: empty project yields no output and success
+mock_osc_empty() { return 0; }
+osc=mock_osc_empty
+try list_packages devel:openQA:testing
+is "$rc" 0 "list_packages empty project success"
+is "$got" "" "list_packages empty project has no output"
+
+# list_packages: failed 'osc ls' (e.g. HTTP 5xx printing to stdout) must not
+# be mistaken for a package list; propagate failure and emit nothing
+mock_osc_fail() {
+    printf '%s\n' "Request: https://api.opensuse.org/source/devel:openQA:testing?deleted=0" "Headers:"
+    return 1
+}
+osc=mock_osc_fail
+try list_packages devel:openQA:testing
+is "$rc" 1 "list_packages propagates osc failure"
+is "$got" "" "list_packages emits no output on osc failure"

--- a/tests/test_auto_submit.py
+++ b/tests/test_auto_submit.py
@@ -181,3 +181,19 @@ def test_last_revision_none(mocker: MockerFixture) -> None:
     mock_run.return_value = subprocess.CompletedProcess(["osc"], 0, stdout="")
     res = auto_submit.last_revision("proj", "pkg", "Factory", "osc")
     assert res == ""
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ("", "unknown"),
+        ("   \n  ", "unknown"),
+        ("Package pkg is not yet ready for release\nscheduled", "Package pkg is not yet ready for release\nscheduled"),
+        ('{"failed_jobs": [123, 456]}', "failed openQA jobs: 123, 456"),
+        ('{"failed_jobs": []}', '{"failed_jobs": []}'),
+        ('{"other": 1}', '{"other": 1}'),
+        ("not json { at all", "not json { at all"),
+    ],
+)
+def test_format_skip_reason(content: str, expected: str) -> None:
+    assert auto_submit._format_skip_reason(content) == expected  # noqa: SLF001

--- a/tests/test_auto_submit.py
+++ b/tests/test_auto_submit.py
@@ -197,3 +197,16 @@ def test_last_revision_none(mocker: MockerFixture) -> None:
 )
 def test_format_skip_reason(content: str, expected: str) -> None:
     assert auto_submit._format_skip_reason(content) == expected  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    ("reason", "expected"),
+    [
+        ("single line", "Skipping submission, reason: single line"),
+        ("note\npkg1\npkg2", "Skipping submission, reason:\n  note\n  pkg1\n  pkg2"),
+    ],
+)
+def test_log_skip_reason(reason: str, expected: str, caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level("INFO"):
+        auto_submit._log_skip_reason(reason)  # noqa: SLF001
+    assert caplog.records[0].getMessage() == expected


### PR DESCRIPTION
Motivation: A multi-line job_post_skip_submission (e.g. a note followed by a
package list) looked misaligned when appended after "reason: " on one line.

Design Choices: Add _log_skip_reason which keeps single-line reasons inline
and prints multi-line reasons on following lines, each indented by two
spaces.

Benefits: Multi-line skip reasons read as a clear block instead of wrapping
awkwardly after the "reason:" label.

Related issue: https://progress.opensuse.org/issues/201843