### PR TITLE
fix: Fetch parent before switching branch in obs-auto-submit

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -323,19 +323,18 @@ class AutoSubmitter:
     def _prepare_local_clone(self, package: str, branch: str) -> None:
         """Prepare local clone with files from original directory."""
         git_cmd = shlex.split(self.git_cmd_str)
-        switch_cmd = [*git_cmd, "switch", branch]
+        # "parent" remote is added by git-obs; fetch before switch because the
+        # fork may lack the branch (switch-first fails "invalid reference").
         fetch_cmd = [*git_cmd, "fetch", "parent"]
-        reset_cmd = [*git_cmd, "reset", "--hard", f"parent/{branch}"]
+        switch_cmd = [*git_cmd, "switch", "-C", branch, f"parent/{branch}"]
 
         if self.dry_run:
-            log.info("[dry-run] Would execute: %s", " ".join(switch_cmd))
             log.info("[dry-run] Would execute: %s", " ".join(fetch_cmd))
-            log.info("[dry-run] Would execute: %s", " ".join(reset_cmd))
+            log.info("[dry-run] Would execute: %s", " ".join(switch_cmd))
             log.info("[dry-run] Would replace files in clone with files from ../../%s/*", package)
         else:
-            subprocess.run(switch_cmd, check=True)  # noqa: S603
             subprocess.run(fetch_cmd, check=True)  # noqa: S603
-            subprocess.run(reset_cmd, check=True)  # noqa: S603
+            subprocess.run(switch_cmd, check=True)  # noqa: S603
 
             for item in pathlib.Path().iterdir():
                 if item.name == ".git":

--- a/tests/test_auto_submit.py
+++ b/tests/test_auto_submit.py
@@ -127,6 +127,26 @@ def test_has_pending_submission(
     assert res is expected
 
 
+def test_prepare_local_clone_fetches_before_switch(mocker: MockerFixture) -> None:
+    """Fetch parent before creating the branch so a fork lacking it still works."""
+    mock_run = mocker.patch("auto_submit.subprocess.run")
+    mocker.patch("auto_submit.pathlib.Path.iterdir", return_value=[])
+    submitter = auto_submit.AutoSubmitter(dst_project="dst", git_cmd_str="git", dry_run=False)
+    submitter._prepare_local_clone("openQA", "leap-16.0")  # noqa: SLF001
+    git_calls = [call.args[0] for call in mock_run.call_args_list]
+    assert git_calls[0] == ["git", "fetch", "parent"]
+    assert git_calls[1] == ["git", "switch", "-C", "leap-16.0", "parent/leap-16.0"]
+
+
+def test_prepare_local_clone_dry_run_logs_fetch_first(caplog: pytest.LogCaptureFixture) -> None:
+    submitter = auto_submit.AutoSubmitter(dst_project="dst", git_cmd_str="git", dry_run=True)
+    with caplog.at_level("INFO"):
+        submitter._prepare_local_clone("openQA", "leap-16.0")  # noqa: SLF001
+    messages = [r.getMessage() for r in caplog.records]
+    assert messages[0] == "[dry-run] Would execute: git fetch parent"
+    assert messages[1] == "[dry-run] Would execute: git switch -C leap-16.0 parent/leap-16.0"
+
+
 def test_make_obs_submit_request_success(mocker: MockerFixture) -> None:
     mocker.patch("auto_submit.get_obs_sr_id", return_value="23")
     mock_run = mocker.patch("auto_submit.run_osc_cmd")


### PR DESCRIPTION
Motivation: Git submissions to Leap targets failed with "fatal: invalid
reference: leap-16.0" because the freshly cloned fork lacks the leap
branch, which exists only on the parent remote fetched afterwards.

Design Choices: Fetch the parent remote first, then force-create the
local branch from parent/<branch> via "git switch -C", which also
resets the working tree and makes the prior separate reset redundant.

Benefits: Submissions succeed regardless of whether the fork carries
the target branch, restoring the Leap 16.0/16.1 auto-submit flow.

Related issue: https://progress.opensuse.org/issues/201843

After:
* #632