### PR TITLE
style: Simplify shell scripts by removing superfluous quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,11 @@ test-online: ## Run tests that require online connection
 checkstyle: test-shellcheck test-yaml checkstyle-python check-code-health test-gitlint ## Run all style checks
 
 shfmt: ## Format shell scripts
-	shfmt -w ${SH_FILES}
+	shfmt -w --simplify ${SH_FILES}
 
 test-shellcheck: ## Run shell script checks
 	@which shfmt >/dev/null 2>&1 || echo "Command 'shfmt' not found, can not execute shell script formating checks"
-	shfmt -d ${SH_FILES}
+	shfmt -d --simplify ${SH_FILES}
 	@which shellcheck >/dev/null 2>&1 || echo "Command 'shellcheck' not found, can not execute shell script checks"
 	if [ -n "${SH_SHELLCHECK_FILES}" ]; then shellcheck -x ${SH_SHELLCHECK_FILES}; fi
 

--- a/_common
+++ b/_common
@@ -28,7 +28,7 @@ error-handler() {
     # shellcheck disable=SC2207
     local c=($(caller))
     warn "${c[1]}: ERROR: line $line"
-    [[ -n "$errorlog" ]] && rm -f "$errorlog"
+    [[ -n $errorlog ]] && rm -f "$errorlog"
 }
 
 # From openqa-cli JSON output filter and return the id/ids of jobs,
@@ -49,12 +49,12 @@ runcli() {
     output=$("${args[@]}" 2> "$errorlog")
     rc=$?
     set -e
-    if [[ -s "$errorlog" ]]; then
+    if [[ -s $errorlog ]]; then
         read -r errstr < "$errorlog"
         warn "$1 ($(caller)): (${args[*]}) stderr: >>>$errstr<<<"
     fi
     rm "$errorlog"
-    [[ "$rc" == 0 ]] && echo "$output" && return
+    [[ $rc == 0 ]] && echo "$output" && return
     warn "$1 ($(caller)): (${args[*]}) rc: $rc >>>$output<<<"
     return $rc
 }
@@ -69,7 +69,7 @@ runjq() {
     output=$(echo "$input" | jq "$@" 2>&1)
     rc=$?
     set -e
-    [[ "$rc" == 0 ]] && echo "$output" && return
+    [[ $rc == 0 ]] && echo "$output" && return
     output=$(echo "$output" | head -"$jq_output_limit")
     warn "jq ($(caller)): $output (rc: $rc Input: >>>$input<<<)"
     return $rc
@@ -78,7 +78,7 @@ runjq() {
 exp_retry() {
     local stop_exponent=$1
     local exponent=$2
-    if [[ "$exponent" == "$stop_exponent" ]]; then
+    if [[ $exponent == "$stop_exponent" ]]; then
         warn "$stop_exponent (re)tries exceeded"
         return 1
     fi
@@ -93,7 +93,7 @@ shorten_string() {
     local max_str_len=${max_str_len:-"120"}
     local max_str_len_half=$((max_str_len / 2))
     if [[ ${#sstring} -gt $max_str_len ]]; then
-        sstring=${sstring:0:$max_str_len_half}…${sstring: -$max_str_len_half}
+        sstring=${sstring:0:max_str_len_half}…${sstring: -$max_str_len_half}
     fi
     echo "$sstring"
 }
@@ -111,14 +111,14 @@ runcurl() {
         response=$(curl -w "\n%{http_code}\n" "$@" 2>&1)
         rc=$?
         set -e
-        if [[ "$rc" != 0 ]]; then
+        if [[ $rc != 0 ]]; then
             response=$(shorten_string "$response")
             warn "curl ($(caller)): Error fetching ($*): $response"
             # shellcheck disable=SC2015
             exp_retry "$exp_retries" "$retry_exponent" && continue || break
         fi
         status_code=$(echo "$response" | tail -1)
-        if [[ "$status_code" != 200 ]]; then
+        if [[ $status_code != 200 ]]; then
             warn "curl ($(caller)): Error fetching url ($*): Got Status $status_code"
             # shellcheck disable=SC2015
             exp_retry "$exp_retries" "$retry_exponent" && continue || break
@@ -162,12 +162,12 @@ search_log() {
     local grep_opts="${grep_opts:-"-qPzo"}"
     # shellcheck disable=SC2086
     grep_output=$(timeout "$grep_timeout" grep $grep_opts "$search_term" "$out" 2>&1) || rc=$?
-    if [[ "$rc" == 1 ]]; then
+    if [[ $rc == 1 ]]; then
         return 1
-    elif [[ "$rc" == 124 ]]; then
+    elif [[ $rc == 124 ]]; then
         warn "grep was killed, possibly timed out: cmd=>grep $grep_opts '$search_term' '$out'< output='$grep_output'"
         return $rc
-    elif [[ "$rc" != 0 ]]; then
+    elif [[ $rc != 0 ]]; then
         # unexpected error, e.g. "exceeded PCRE's backtracking limit"
         warn "grep failed: cmd=>grep $grep_opts '$search_term' '$out'< output='$grep_output'"
         return $rc
@@ -199,14 +199,14 @@ handle_unreviewed() {
     echo "$header"
     echo "$excerpt"
 
-    if "$email_unreviewed" && [[ "$group_id" != 'null' ]]; then
+    if "$email_unreviewed" && [[ $group_id != 'null' ]]; then
         group_data=$(openqa-cli "${client_args[@]}" "job_groups/$group_id")
         group_description=$(echo "$group_data" | runjq -r '.[0].description') || true
         group_mailto=$(echo "$group_description" | perl -n -wE'm/.*MAILTO: (\S+).*/ and say $1' | head -1)
         group_mailto=${group_mailto:-$notification_address}
         # Avoid sending notifications for jobs that were restarted
         clone_id="$(echo "$job_data" | runjq -r '.job.clone_id')"
-        if [[ -n "$group_mailto" && "$clone_id" == 'null' ]]; then
+        if [[ -n $group_mailto && $clone_id == 'null' ]]; then
             group_name=$(echo "$group_data" | runjq -r '.[0].name')
             job_name=$(echo "$job_data" | runjq -r '.job.name')
             job_result=$(echo "$job_data" | runjq -r '.job.result')
@@ -289,12 +289,12 @@ find_latest_published_tumbleweed_image() {
     local latest_builds build image=null assetname
     local tw_group_id=$1 arch=$2 machine=$3 type=$4
     read -r -d '' -a latest_builds <<< "$(latest_published_tw_builds "$tw_group_id")"
-    if [[ "${#latest_builds[@]}" -eq 0 ]]; then
+    if [[ ${#latest_builds[@]} -eq 0 ]]; then
         warn "Unable to find latest published Tumbleweed builds."
         exit 1
     fi
     for build in "${latest_builds[@]}"; do
-        if [[ "$type" = iso ]]; then
+        if [[ $type == iso ]]; then
             assetname="Tumbleweed-NET-$arch-Snapshot$build-Media.iso$"
         else
             assetname="Tumbleweed-$arch-$build-minimalx\\\\@$machine.qcow"
@@ -303,12 +303,12 @@ find_latest_published_tumbleweed_image() {
 
         [[ $image == "" ]] && image=null # the result can be empty for other reasons
         # This published build has an image available
-        [[ "$image" != null ]] && break
+        [[ $image != null ]] && break
         # Published but no image available, we'll try and continue
         warn "Unable to determine $type image for Tumbleweed build '$build' (for architecture '$arch' and machine '$machine')."
     done
     # No published image available
-    if [[ "$image" = null ]]; then
+    if [[ $image == null ]]; then
         exit 2
     fi
     echo "$image"
@@ -407,7 +407,7 @@ colorize() {
     local msg=$3
     local fn=1
     [[ $fh == 'err' ]] && fn=2
-    if [[ -t "$fn" && $color == "auto" || $color == "always" ]]; then
+    if [[ -t $fn && $color == "auto" || $color == "always" ]]; then
         msg="${!msgcolor}$msg${_NO_COLOR}"
     fi
     if [[ $fh == 'err' ]]; then

--- a/openqa-advanced-retrigger-jobs
+++ b/openqa-advanced-retrigger-jobs
@@ -73,7 +73,7 @@ main() {
 
     for job_id in $job_ids; do
         query_params+=("jobs=$job_id")
-        [[ ${#query_params[@]} -ge "$max_jobs_per_request" ]] && restart-jobs
+        [[ ${#query_params[@]} -ge $max_jobs_per_request ]] && restart-jobs
     done
     restart-jobs
 }

--- a/openqa-investigate
+++ b/openqa-investigate
@@ -32,7 +32,7 @@ clone() {
     name_suffix=${3+":$3"}
     refspec=${4+$4}
     local clone_job_data
-    if [[ "$origin" == "$id" ]]; then
+    if [[ $origin == "$id" ]]; then
         clone_job_data=$job_data
     else
         clone_job_data=$(client-get-job "$id")
@@ -79,7 +79,7 @@ clone() {
     clone_settings+=($(echo "$clone_job_data" | runjq -r '.job.settings | keys[] | select (startswith("PUBLISH_")) | . + "=none"')) || return $?
     clone_settings+=("OPENQA_INVESTIGATE_ORIGIN=$host_url/t$origin")
     out=$($clone_call "$host_url/tests/$id" "${clone_settings[@]}") || return $?
-    if [[ $dry_run = 1 ]]; then
+    if [[ $dry_run == 1 ]]; then
         echo "$out"
         out="{ \"$origin\": 42}"
     fi
@@ -106,7 +106,7 @@ trigger_jobs() {
     job_url="$host_url/tests/$id"
     investigation=$(runcurl "${curl_args[@]}" -sS "$job_url"/investigation_ajax) || return $?
     last_good_exists=$(echo "$investigation" | runjq -r '.last_good') || return $?
-    if [[ "$last_good_exists" = "null" || "$last_good_exists" = "not found" ]]; then
+    if [[ $last_good_exists == "null" || $last_good_exists == "not found" ]]; then
         echo "No last good recorded, skipping regression investigation jobs" && return 0
     fi
     last_good=$(echo "$investigation" | runjq -r '.last_good.text') || return $?
@@ -177,7 +177,7 @@ query_dependency_data_or_postpone() {
 sync_via_investigation_comment() {
     local id=$1 first_cluster_job_id=$2
 
-    [[ $dry_run = 1 ]] && return 255
+    [[ $dry_run == 1 ]] && return 255
     comment_id=$(client-post-job-comment "$first_cluster_job_id" "Starting investigation for job $id" | runjq -r '.id') || return $?
     first_comment_id=$(client-get-job-comments "$first_cluster_job_id" | runjq -r '[.[] | select(.text | contains("investigation"))] | min_by(.id) | .id') || return $?
 
@@ -217,7 +217,7 @@ fetch-investigation-results() {
     local origin_job_id=$1
     local state job investigate_type other_id result investigate_comment output comment_lines
 
-    [[ $dry_run = 1 ]] && return 0
+    [[ $dry_run == 1 ]] && return 0
     investigate_comment=$(client-get-job-comments "$origin_job_id" | runjq -r '[.[] | select(.text | contains("Automatic investigation jobs for job") and contains(":investigate:retry*:"))] | min_by(.id)') || return $?
     [[ $investigate_comment == 'null' ]] && return
     output=$(echo "$investigate_comment" | runjq -r '.text') || return $?
@@ -275,11 +275,11 @@ identify-issue-type() {
             fi
         fi
     done
-    if ([[ -z "$pass_lgtb" ]] || "$pass_lgtb") && ([[ -z "$pass_lgt" ]] || ! "$pass_lgt") && [[ -n "$pass_lgb" ]] && "$pass_lgb"; then
+    if ([[ -z $pass_lgtb ]] || "$pass_lgtb") && ([[ -z $pass_lgt ]] || ! "$pass_lgt") && [[ -n $pass_lgb ]] && "$pass_lgb"; then
         product_issue=true
-    elif ([[ -z "$pass_lgtb" ]] || "$pass_lgtb") && [[ -n "$pass_lgt" ]] && "$pass_lgt" && ([[ -z "$pass_lgb" ]] || ! "$pass_lgb"); then
+    elif ([[ -z $pass_lgtb ]] || "$pass_lgtb") && [[ -n $pass_lgt ]] && "$pass_lgt" && ([[ -z $pass_lgb ]] || ! "$pass_lgb"); then
         test_issue=true
-    elif ([[ -n "$pass_lgtb" ]] && ! "$pass_lgtb") && ([[ -n "$pass_lgt" ]] && ! "$pass_lgt") && ([[ -n "$pass_lgb" ]] && ! "$pass_lgb"); then
+    elif ([[ -n $pass_lgtb ]] && ! "$pass_lgtb") && ([[ -n $pass_lgt ]] && ! "$pass_lgt") && ([[ -n $pass_lgb ]] && ! "$pass_lgb"); then
         infra_issue=true
     fi
 }
@@ -287,7 +287,7 @@ identify-issue-type() {
 post-investigate() {
     local id=$1 retry_name=$2
     local rc=0 status
-    [[ ! "$retry_name" =~ investigate:retry$ ]] && echo "Job is ':investigate:' already, skipping investigation" && return 0
+    [[ ! $retry_name =~ investigate:retry$ ]] && echo "Job is ':investigate:' already, skipping investigation" && return 0
     # We are in the investigate:retry job now. From here we will check the
     # results of the other investigation jobs, if necessary
     retry_result="$(echo "$job_data" | runjq -r '.job.result')" || return $?
@@ -335,9 +335,9 @@ post-investigate() {
     # meanwhile the original job might have been deleted already, handle
     # gracefully
     out=$(client-post-job-comment "$origin_job_id" "$comment" 2>&1) || rc=$?
-    if [[ "$rc" -ne 0 ]]; then
+    if [[ $rc -ne 0 ]]; then
         status=$(echo "$out" | runjq .error_status 2> /dev/null || echo "unknown")
-        if [[ "$status" != "404" ]]; then
+        if [[ $status != "404" ]]; then
             echoerr "Unexpected error encountered when posting comments on job $origin_job_id after investigation job $id failed: '$out'"
             return 2
         fi
@@ -359,12 +359,12 @@ investigate() {
     # shellcheck disable=SC2181
     [[ $? != 0 ]] && echoerr "unable to query job data for $id: $job_data" && return 1
     old_name="$(echo "$job_data" | runjq -r '.job.test')" || return $?
-    if [[ "$old_name" =~ ":investigate:" ]]; then
+    if [[ $old_name =~ ":investigate:" ]]; then
         post-investigate "$id" "$old_name" || return $?
         return 0
     fi
     clone="$(echo "$job_data" | runjq -r '.job.clone_id')" || return $?
-    if ! "$force" && [[ "$clone" != "null" ]]; then
+    if ! "$force" && [[ $clone != "null" ]]; then
         echoerr "Job $id already has a clone, skipping investigation. Use the env variable 'force=true' to trigger investigation jobs"
         return 0
     fi
@@ -376,11 +376,11 @@ investigate() {
     # determine the job in the cluster with the lowest ID to use that for commenting/synchronization
     first_cluster_job_id=$(echo "$dependency_data" | runjq -r "[$id, [.cluster[] | select(contains([$id]))]] | flatten | min") || return $?
 
-    [[ "$old_name" =~ $exclude_name_regex ]] && echo "Job name '$old_name' matches \$exclude_name_regex '$exclude_name_regex', skipping investigation" && return 0
+    [[ $old_name =~ $exclude_name_regex ]] && echo "Job name '$old_name' matches \$exclude_name_regex '$exclude_name_regex', skipping investigation" && return 0
     group="$(echo "$job_data" | runjq -r '.job.parent_group + " / " + .job.group')" || return $?
-    [[ "$group" = " / " ]] && [[ "$exclude_no_group" = "true" ]] && echo "Job w/o job group, \$exclude_no_group is set, skipping investigation" && return 0
-    [[ "$group" =~ $exclude_group_regex ]] && echo "Job group '$group' matches \$exclude_group_regex '$exclude_group_regex', skipping investigation" && return 0
-    user_unset="$(echo "$job_data" | runjq -r '.job.settings.NO_INVESTIGATION')" && [[ ! "$user_unset" =~ "null" ]] && [[ $user_unset -eq 1 ]] && echo "NO_INVESTIGATION=1 detected, skipping" && return 0
+    [[ $group == " / " ]] && [[ $exclude_no_group == "true" ]] && echo 'Job w/o job group, $exclude_no_group is set, skipping investigation' && return 0
+    [[ $group =~ $exclude_group_regex ]] && echo "Job group '$group' matches \$exclude_group_regex '$exclude_group_regex', skipping investigation" && return 0
+    user_unset="$(echo "$job_data" | runjq -r '.job.settings.NO_INVESTIGATION')" && [[ ! $user_unset =~ "null" ]] && [[ $user_unset -eq 1 ]] && echo "NO_INVESTIGATION=1 detected, skipping" && return 0
 
     # Optionally we can find "first failed", could extend openQA investigation
     # method instead for we are just working based on supplied job which can
@@ -415,7 +415,7 @@ main() {
     client_prefix=''
     [ "$dry_run" = "1" ] && client_prefix="echo"
     set +u
-    if [[ -z "${client_call[*]}" ]]; then
+    if [[ -z ${client_call[*]} ]]; then
         client_call=(openqa-cli "${client_args[@]}")
         client_prefix="${client_prefix:-runcli}"
         client_call=("$client_prefix" "${client_call[@]}")

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -153,7 +153,7 @@ investigate_issue() {
     state="$(echo "$job_data" | runjq -r '.job.state')"
     result="$(echo "$job_data" | runjq -r '.job.result')"
     # Skip all unfinished or passed jobs for now
-    if [[ "$state" != 'done' || "$result" == passed ]]; then
+    if [[ $state != 'done' || $result == passed ]]; then
         return
     fi
     reason=$(echo "$job_data" | runjq -r '.job.reason')
@@ -163,13 +163,13 @@ investigate_issue() {
     # against even in case when autoinst-log.txt is missing the details, e.g.
     # see https://progress.opensuse.org/issues/69178
     echo "$reason" >> "$out"
-    if [[ "$curl_output" != "200" ]] && [[ "$curl_output" != "301" ]]; then
+    if [[ $curl_output != "200" ]] && [[ $curl_output != "301" ]]; then
         # if we can not even access the page it is something more critical
         handle_unreachable "$testurl" "$out" || return 0
 
         [[ $curl_output != 404 ]] && return
         # not unreachable, no log, no reason, not too old
-        if [[ -z $reason ]] || [[ $reason = null ]]; then
+        if [[ -z $reason ]] || [[ $reason == null ]]; then
             echoerr "'$testurl' does not have autoinst-log.txt or reason, cannot label"
             return
         fi
@@ -208,10 +208,10 @@ label_issue() {
     done
 
     local testurl="${1:?"Need 'testurl'"}"
-    [[ "$dry_run" = "1" ]] && client_prefix="echo"
-    if [[ -z "$client_call" ]]; then
+    [[ $dry_run == "1" ]] && client_prefix="echo"
+    if [[ -z $client_call ]]; then
         client_call=(openqa-cli "${client_args[@]}")
-        if [[ -n "$client_prefix" ]]; then
+        if [[ -n $client_prefix ]]; then
             client_call=("$client_prefix" "${client_call[@]}")
         fi
     fi

--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -16,7 +16,7 @@ host_url="$scheme://$host"
 investigate-and-bisect() {
     local rc=0 test
     read -r test || rc=$?
-    [[ -n "$test" ]] || return 0
+    [[ -n $test ]] || return 0
     rc=0
 
     # Call the new LLM investigation script first, which acts as a gatekeeper
@@ -27,10 +27,10 @@ investigate-and-bisect() {
         investigate_target="$test"
     fi
 
-    [[ -z "$investigate_target" ]] && return 0
+    [[ -z $investigate_target ]] && return 0
 
     openqa-investigate "$investigate_target" || rc=$?
-    [[ "$rc" -eq 142 ]] && return "$rc"
+    [[ $rc -eq 142 ]] && return "$rc"
     openqa-trigger-bisect-jobs -v --url "$investigate_target" || rc=$?
     return "$rc"
 }
@@ -63,7 +63,7 @@ hook() {
     name="$(echo "$job_data" | runjq -r '.job.test')" || return $?
     state="$(echo "$job_data" | runjq -r '.job.state')" || return $?
     result="$(echo "$job_data" | runjq -r '.job.result')" || return $?
-    [[ "$state" != "done" ]] && return
+    [[ $state != "done" ]] && return
     if [[ $result != passed && ! $name =~ ":investigate:" ]]; then
         testsuite="$(echo "$job_data" | runjq -r '.job.settings.TEST')"
         # Remove optional "container_host_" prefix

--- a/openqa-search-maintenance-core-jobs
+++ b/openqa-search-maintenance-core-jobs
@@ -74,7 +74,7 @@ search_maintenance_single_incidents() {
 
     for version in $versions $versions_teradata; do
         local groupid=${dict_group[$version]}
-        [[ -z "$groupid" ]] && continue
+        [[ -z $groupid ]] && continue
 
         local count_url="${url_openqa}/api/v1/jobs/overview?distri=sle&version=${version%%-TERADATA}&build=${build}&groupid=${groupid}"
         local count
@@ -117,7 +117,7 @@ search_maintenance_aggregated() {
     versions=$(curl -sk -X GET "${url_dashboard_qam}/api/incident_settings/$ID" | jq -r '.[].settings.VERSION' | sort | uniq)
 
     for version in $versions; do
-        [[ -z "${dict_group[$version]}" ]] && continue
+        [[ -z ${dict_group[$version]} ]] && continue
 
         for day in $(seq 0 "$days"); do
             local build
@@ -128,7 +128,7 @@ search_maintenance_aggregated() {
             local id
             id=$(curl -sk -X GET "$URL" | jq -r '.[0].id | select( . != null)')
 
-            [[ -z "$id" ]] && continue
+            [[ -z $id ]] && continue
 
             local json
             json=$(curl -sk -X GET "${url_openqa}/api/v1/jobs/${id}")
@@ -194,7 +194,7 @@ while getopts :a:d: name; do
     esac
 done
 
-if [[ -z "$review_request_id" ]]; then
+if [[ -z $review_request_id ]]; then
     usage
     exit 1
 fi

--- a/test/02-investigate.t
+++ b/test/02-investigate.t
@@ -289,7 +289,7 @@ try clone 10021 10030 last_good_tests_and_build:123 refspec
 has "$got" 'unidentified worker class in vars.json' "info shown in the name is WORKER_CLASS is empty"
 
 curl() {
-    if [[ "$@" =~ investigation_ajax ]]; then
+    if [[ $@ =~ investigation_ajax ]]; then
         echo -n '{ }'$'\n'200
     else
         echo -n 200

--- a/test/03-openqa-label-known-issues-and-investigate-hook.t
+++ b/test/03-openqa-label-known-issues-and-investigate-hook.t
@@ -42,13 +42,13 @@ openqa-trigger-bisect-jobs() {
 }
 openqa-api-get() {
     local path=$1
-    if [[ "$path" == "jobs/123" ]]; then
+    if [[ $path == "jobs/123" ]]; then
         echo '{"job":{"state":"done", "result":"failed", "test":"foo"}}'
-    elif [[ "$path" == "jobs/124" ]]; then
+    elif [[ $path == "jobs/124" ]]; then
         echo '{"job":{"state":"done", "result":"passed", "test":"foo"}}'
-    elif [[ "$path" == "jobs/125" ]]; then
+    elif [[ $path == "jobs/125" ]]; then
         echo '{"job":{"state":"done", "result":"failed", "test":"foo:investigate:retry:x"}}'
-    elif [[ "$path" == "jobs/126" ]]; then
+    elif [[ $path == "jobs/126" ]]; then
         echo '{"job":{"state":"done", "result":"failed", "test":"foo:investigate:abc:x"}}'
     fi
 }

--- a/test/07-openqa-label-known-issues.t
+++ b/test/07-openqa-label-known-issues.t
@@ -29,7 +29,7 @@ openqa-cli() {
     cat "$dir/data/$id.json"
 }
 curl() {
-    if [[ "$7" =~ /(404|414|101|102)/file/autoinst-log.txt ]]; then
+    if [[ $7 =~ /(404|414|101|102)/file/autoinst-log.txt ]]; then
         echo -n "404"
     else
         echo -n "200"

--- a/trigger-openqa_in_openqa
+++ b/trigger-openqa_in_openqa
@@ -149,7 +149,7 @@ trigger() {
     # prevent host access problem when running within o3 infrastructure
     # where o3 is not reachable over https
     declare -a ARGS
-    [[ $target_host = "openqa.opensuse.org" ]] && ARGS+=("OPENQA_HOST=http://openqa.opensuse.org")
+    [[ $target_host == "openqa.opensuse.org" ]] && ARGS+=("OPENQA_HOST=http://openqa.opensuse.org")
     # shellcheck disable=SC2206
     [[ $full_run_args ]] && ARGS+=($full_run_args)
 

--- a/trigger-pflash-test
+++ b/trigger-pflash-test
@@ -16,10 +16,10 @@ OPENQA_API_KEY=${OPENQA_API_KEY:-}
 OPENQA_API_SECRET=${OPENQA_API_SECRET:-}
 CLI_ARGS=()
 TRIGGERED_BY=${TRIGGERED_BY:$0}
-if [[ -n "$GITHUB_SERVER_URL" ]]; then
+if [[ -n $GITHUB_SERVER_URL ]]; then
     TRIGGERED_BY="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/$GITHUB_REF_NAME/$0"
 fi
-if [[ -n "$TRIGGERED_BY" ]]; then
+if [[ -n $TRIGGERED_BY ]]; then
     CLI_ARGS+=("TRIGGERED_BY=$TRIGGERED_BY")
 fi
 
@@ -40,7 +40,7 @@ main() {
     done
 
     local image
-    [[ "$dry_run" = 1 ]] && client_prefix="echo"
+    [[ $dry_run == 1 ]] && client_prefix="echo"
     image=$(find_latest_published_tumbleweed_image "$tw_group_id" "$arch" "$machine" iso)
 
     ${client_prefix} "${openqa_cli}" \


### PR DESCRIPTION
Add --simplify to shfmt call.

This will remove superfluous quotes inside `[[ ... ]]` for example.