### PR TITLE
ipxe: Update tumbleweed_KVM_agama entry to match new pattern

### DIFF
--- a/ipxe/menu.ipxe
+++ b/ipxe/menu.ipxe
@@ -58,8 +58,8 @@ set initrd http://download.opensuse.org/distribution/leap/15.6/repo/oss/boot/x86
 goto editandboot
 
 :tumbleweed_KVM_agama
-set kernel http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-x86_64-CURRENT/boot/x86_64/loader/linux
-set initrd http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-x86_64-CURRENT/boot/x86_64/loader/initrd
+set kernel http://openqa.opensuse.org/assets/repo/Tumbleweed-agama-installer-x86_64-CURRENT/boot/x86_64/loader/linux
+set initrd http://openqa.opensuse.org/assets/repo/Tumbleweed-agama-installer-x86_64-CURRENT/boot/x86_64/loader/initrd
 set cmdline plymouth.enable=0 console=tty console=ttyS1,115200 reboot_timeout=0 kernel.softlockup_panic=1 vga=791 video=1024x768 vt.color=0x07 quiet inst.install_url=http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-x86_64-CURRENT live.password=nots3cr3t inst.auto=http://openqa.opensuse.org/assets/other/tw_virt_host.jsonnet inst.finish=stop
 goto editandboot
 


### PR DESCRIPTION
This is the same as https://github.com/os-autoinst/os-autoinst-scripts/pull/635

With https://github.com/os-autoinst/openqa-trigger-from-obs/pull/380 there's now a different path for the assets of the agama installer in Tumbleweed

~Needs https://github.com/os-autoinst/openqa-trigger-from-obs/pull/380 to be merged first~

Just new submission to circumvent [bug with obs](https://github.com/os-autoinst/os-autoinst-scripts/pull/635#issuecomment-5004306976)
