### PR TITLE
feat: support reboot option in zombie reaper

### DIFF
--- a/s390x-qemu-zombie-reaper.py
+++ b/s390x-qemu-zombie-reaper.py
@@ -14,6 +14,7 @@ import json
 import shlex
 import subprocess
 import time
+from enum import Enum
 from typing import TYPE_CHECKING, Annotated
 
 import typer
@@ -22,6 +23,14 @@ if TYPE_CHECKING:
     from typing import Any
 
 app = typer.Typer(help="Automated openQA Zombie Reaper for s390x")
+
+
+class RebootMethod(str, Enum):
+    """Method used to reboot the hypervisor."""
+
+    SYSRQ = "sysrq"
+    REBOOT = "reboot"
+
 
 # Mapping of hypervisors to the workers that use them
 HYPERVISORS = {
@@ -72,17 +81,30 @@ def get_running_jobs(hypervisor_host: str, *, verbose: bool = False) -> list[int
     return list(set(jobs_to_restart))
 
 
-def trigger_actions(host: str, jobs: list[int], *, dry_run: bool, verbose: bool) -> None:
-    """Trigger kdump (which reboots the machine) and job re-triggering."""
-    # Echoing 'c' to sysrq-trigger panics the kernel, dumping core and rebooting
-    reboot_cmd = f"ssh {host} \"sudo bash -c 'echo c > /proc/sysrq-trigger'\""
+def trigger_actions(
+    host: str,
+    jobs: list[int],
+    *,
+    dry_run: bool,
+    verbose: bool,
+    reboot_method: RebootMethod = RebootMethod.SYSRQ,
+) -> None:
+    """Trigger kdump (which reboots the machine) or standard reboot, and job re-triggering."""
+    if reboot_method == RebootMethod.SYSRQ:
+        # Echoing 'c' to sysrq-trigger panics the kernel, dumping core and rebooting
+        reboot_cmd = f"ssh {host} \"sudo bash -c 'echo c > /proc/sysrq-trigger'\""
+        action_msg = f"Triggering kernel crash dump (kdump) on {host}..."
+    else:
+        reboot_cmd = f'ssh {host} "sudo reboot"'
+        action_msg = f"Triggering reboot on {host}..."
+
     if dry_run:
         print(f"[DRY-RUN] Would execute: {reboot_cmd}")
         for job_id in jobs:
             retrigger_cmd = f"openqa-cli api --osd -X POST jobs/{job_id}/restart"
             print(f"[DRY-RUN] Would execute: {retrigger_cmd}")
     else:
-        print(f"Triggering kernel crash dump (kdump) on {host}...")
+        print(action_msg)
         run_cmd(reboot_cmd, verbose=verbose)
 
         for job_id in jobs:
@@ -91,7 +113,7 @@ def trigger_actions(host: str, jobs: list[int], *, dry_run: bool, verbose: bool)
             run_cmd(retrigger_cmd, verbose=verbose)
 
 
-def handle_host(host: str, *, dry_run: bool, verbose: bool) -> None:
+def handle_host(host: str, *, dry_run: bool, verbose: bool, reboot_method: RebootMethod = RebootMethod.SYSRQ) -> None:
     """Check a single host for zombies and take action if found."""
     if verbose:
         print(f"Checking {host} for zombies...")
@@ -131,17 +153,21 @@ def handle_host(host: str, *, dry_run: bool, verbose: bool) -> None:
     else:
         print(f"No active jobs found using {host}.")
 
-    trigger_actions(host, jobs, dry_run=dry_run, verbose=verbose)
+    trigger_actions(host, jobs, dry_run=dry_run, verbose=verbose, reboot_method=reboot_method)
 
 
 @app.command()
 def reap(
     dry_run: Annotated[bool, typer.Option("--dry-run", help="Show what would be done without executing")] = False,  # noqa: FBT002
     verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Enable verbose output")] = False,  # noqa: FBT002
+    reboot_method: Annotated[
+        RebootMethod,
+        typer.Option("--reboot-method", help="Reboot method to use ('sysrq' to induce crash or 'reboot' to reboot)"),
+    ] = RebootMethod.SYSRQ,
 ) -> None:
     """Check hypervisors for zombies and reboot/retrigger jobs if found."""
     for host in HYPERVISORS:
-        handle_host(host, dry_run=dry_run, verbose=verbose)
+        handle_host(host, dry_run=dry_run, verbose=verbose, reboot_method=reboot_method)
 
 
 if __name__ == "__main__":

--- a/tests/test_s390x_qemu_zombie_reaper.py
+++ b/tests/test_s390x_qemu_zombie_reaper.py
@@ -39,11 +39,12 @@ def test_get_running_jobs(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.parametrize(
-    ("dry_run", "jobs", "expected_calls"),
+    ("dry_run", "jobs", "reboot_method", "expected_calls", "expected_cmd"),
     [
         (
             True,
             [123],
+            "sysrq",
             [
                 (
                     "[DRY-RUN] Would execute: ssh s390zl12.oqa.prg2.suse.org "
@@ -51,26 +52,51 @@ def test_get_running_jobs(mocker: MockerFixture) -> None:
                 ),
                 "[DRY-RUN] Would execute: openqa-cli api --osd -X POST jobs/123/restart",
             ],
+            None,
+        ),
+        (
+            True,
+            [123],
+            "reboot",
+            [
+                ('[DRY-RUN] Would execute: ssh s390zl12.oqa.prg2.suse.org "sudo reboot"'),
+                "[DRY-RUN] Would execute: openqa-cli api --osd -X POST jobs/123/restart",
+            ],
+            None,
         ),
         (
             False,
             [123],
+            "sysrq",
             ["Triggering kernel crash dump (kdump) on s390zl12.oqa.prg2.suse.org...", "Retriggering job 123..."],
+            "ssh s390zl12.oqa.prg2.suse.org \"sudo bash -c 'echo c > /proc/sysrq-trigger'\"",
+        ),
+        (
+            False,
+            [123],
+            "reboot",
+            ["Triggering reboot on s390zl12.oqa.prg2.suse.org...", "Retriggering job 123..."],
+            'ssh s390zl12.oqa.prg2.suse.org "sudo reboot"',
         ),
     ],
 )
 def test_trigger_actions(
-    mocker: MockerFixture, capsys: pytest.CaptureFixture[str], dry_run: bool, jobs: list[int], expected_calls: list[str]
+    mocker: MockerFixture,
+    capsys: pytest.CaptureFixture[str],
+    dry_run: bool,
+    jobs: list[int],
+    reboot_method: str,
+    expected_calls: list[str],
+    expected_cmd: str | None,
 ) -> None:
     mock_run_cmd = mocker.patch("reaper.run_cmd")
-    reaper.trigger_actions("s390zl12.oqa.prg2.suse.org", jobs, dry_run=dry_run, verbose=False)
+    method = reaper.RebootMethod(reboot_method)
+    reaper.trigger_actions("s390zl12.oqa.prg2.suse.org", jobs, dry_run=dry_run, verbose=False, reboot_method=method)
     captured = capsys.readouterr().out
     for expected in expected_calls:
         assert expected in captured
-    if not dry_run:
-        mock_run_cmd.assert_any_call(
-            "ssh s390zl12.oqa.prg2.suse.org \"sudo bash -c 'echo c > /proc/sysrq-trigger'\"", verbose=False
-        )
+    if not dry_run and expected_cmd:
+        mock_run_cmd.assert_any_call(expected_cmd, verbose=False)
 
 
 def test_handle_host_clean(mocker: MockerFixture) -> None:
@@ -89,4 +115,19 @@ def test_handle_host_zombie_persistent(mocker: MockerFixture, capsys: pytest.Cap
     reaper.handle_host("s390zl12.oqa.prg2.suse.org", dry_run=False, verbose=False)
     captured = capsys.readouterr().out
     assert "!!! CRITICAL: Found persistent zombie processes on s390zl12.oqa.prg2.suse.org: 12345" in captured
+    mock_sleep.assert_called_once_with(10)
+
+
+def test_handle_host_zombie_persistent_reboot(mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_run_cmd = mocker.patch("reaper.run_cmd")
+    mock_sleep = mocker.patch("time.sleep")
+    mock_run_cmd.side_effect = ["12345", "12345 Fri Jul 17 2026 Z", "12345 Fri Jul 17 2026 Z", '{"workers": []}', ""]
+    reaper.handle_host(
+        "s390zl12.oqa.prg2.suse.org",
+        dry_run=False,
+        verbose=False,
+        reboot_method=reaper.RebootMethod.REBOOT,
+    )
+    captured = capsys.readouterr().out
+    assert "Triggering reboot on s390zl12.oqa.prg2.suse.org..." in captured
     mock_sleep.assert_called_once_with(10)


### PR DESCRIPTION
Motivation:
Provide a way to perform a standard reboot instead of forcing a sysrq crash.

Design Choices:
Added a new Typer Enum option --reboot-method with values 'sysrq' and 'reboot'.
Propagated this option throughout handle_host and trigger_actions.

Benefits:
Gives operators flexibility to reboot hypervisors cleanly when kernel dumps
are not desired.