### PR TITLE
fix: Do not source python script in openqa-label-known-issues-multi

### DIFF
--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -369,8 +369,8 @@ def handle_unreviewed(
     excerpt += extract_excerpt(report_file)
     excerpt += "\n" + snip_end
 
-    print(header)
-    print(excerpt)
+    print(header, file=sys.stderr)
+    print(excerpt, file=sys.stderr)
 
     if email_unreviewed and group_id != "null":
         cmd_group = (

--- a/openqa-label-known-issues-hook
+++ b/openqa-label-known-issues-hook
@@ -11,8 +11,7 @@ usage() {
 Usage: $0 [OPTIONS]
 
 "hook script" intended to be called by openQA instances taking a job ID as
-parameter and forwarding a complete job URL to
-"openqa-label-known-issues-multi" on stdin.
+parameter and calling "openqa-label-known-issues" directly.
 
 Options:
  -h, --help         display this help
@@ -35,7 +34,7 @@ done
 
 main() {
     host_url="$scheme://$host"
-    echo "$host_url/tests/$id" | "$(dirname "$0")"/openqa-label-known-issues-multi
+    "$(dirname "$0")"/openqa-label-known-issues "$host_url/tests/$id"
 }
 
 caller 0 > /dev/null || main "$@"

--- a/openqa-label-known-issues-multi
+++ b/openqa-label-known-issues-multi
@@ -2,8 +2,6 @@
 
 set -o pipefail -o errtrace
 
-source "$(dirname "$0")"/openqa-label-known-issues
-
 to_review=()
 
 print_summary() {
@@ -32,7 +30,19 @@ main() {
 
     # shellcheck disable=SC2013
     for testurl in $(cat - | sed 's/ .*$//'); do
-        label_issue "$testurl"
+        err_out=$(mktemp)
+        set +e
+        { "$(dirname "$0")"/openqa-label-known-issues "$testurl" 2>&1 1>&3 | tee "$err_out" >&2; } 3>&1
+        rc=${PIPESTATUS[0]}
+        set -e
+        if [[ $rc -ne 0 ]]; then
+            rm -f "$err_out"
+            exit "$rc"
+        fi
+        if grep -q "Unknown test issue, to be reviewed" "$err_out"; then
+            to_review+=("$testurl")
+        fi
+        rm -f "$err_out"
     done
     print_summary
 }

--- a/tests/test_openqa_label_known_issues.py
+++ b/tests/test_openqa_label_known_issues.py
@@ -473,7 +473,8 @@ def test_handle_unreviewed(mocker: MockerFixture, tmp_path: pathlib.Path) -> Non
             "http://testurl", str(f), "my reason", "24", False, "from@ex.com", "notif@ex.com", {}, True, []
         )
         mock_print.assert_any_call(
-            "[http://testurl](http://testurl): Unknown test issue, to be reviewed\n-> [autoinst-log.txt](http://testurl/file/autoinst-log.txt)\n"
+            "[http://testurl](http://testurl): Unknown test issue, to be reviewed\n-> [autoinst-log.txt](http://testurl/file/autoinst-log.txt)\n",
+            file=sys.stderr,
         )
     mock_send.assert_not_called()
 


### PR DESCRIPTION
Motivation:
The rewrite of `openqa-label-known-issues` to Python broke the `-multi`
script which attempted to source it like a bash script, causing "command not
found" errors. Additionally, standard output was being used instead of
standard error for messages that `openqa-review-failed` relies on.

Design Choices:
Updated `openqa-label-known-issues-multi` to execute the python script as a
subprocess and safely preserve standard output and standard error using
pipeline redirection and a temporary file. Adjusted the Python script to
output the "Unknown test issue" header to `sys.stderr` to match the legacy
Bash behavior expected by `openqa-review-failed`.

Benefits:
Fixes the "command not found" alert on minion jobs and restores full
functionality to the investigation multi-job handling pipeline.

Related issue: https://progress.opensuse.org/issues/204420