### PR TITLE
refactor: Use openqa-label-known-issues script for single url

### DIFF
--- a/openqa-label-known-issues-hook
+++ b/openqa-label-known-issues-hook
@@ -35,7 +35,7 @@ done
 
 main() {
     host_url="$scheme://$host"
-    echo "$host_url/tests/$id" | "$(dirname "$0")"/openqa-label-known-issues-multi
+    "$(dirname "$0")"/openqa-label-known-issues "$host_url/tests/$id"
 }
 
 caller 0 > /dev/null || main "$@"


### PR DESCRIPTION
openqa-label-known-issues-hook is used in minion jobs, but it only calls /openqa-label-known-issues-multi for one job, so it makes sense to use the script intended for just one job.