### PR TITLE
feat: wait for hypervisor SSH before retriggering jobs

### DIFF
--- a/s390x-qemu-zombie-reaper.py
+++ b/s390x-qemu-zombie-reaper.py
@@ -14,6 +14,7 @@ import json
 import shlex
 import subprocess
 import time
+from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Annotated
 
@@ -37,6 +38,19 @@ HYPERVISORS = {
     "s390zl12.oqa.prg2.suse.org": ["worker31", "worker32"],
     "s390zl13.oqa.prg2.suse.org": ["worker32", "worker33"],
 }
+
+
+@dataclass(frozen=True)
+class ReaperConfig:
+    """Configuration for the zombie reaper execution."""
+
+    dry_run: bool = False
+    verbose: bool = False
+    reboot_method: RebootMethod = RebootMethod.SYSRQ
+    max_wait_minutes: int = 30
+    stability_delay_minutes: int = 3
+    ssh_timeout: int = 10
+    ssh_check_interval: int = 15
 
 
 def run_cmd(cmd: str, *, check: bool = True, verbose: bool = False) -> str:
@@ -81,16 +95,44 @@ def get_running_jobs(hypervisor_host: str, *, verbose: bool = False) -> list[int
     return list(set(jobs_to_restart))
 
 
+def wait_for_host(host: str, config: ReaperConfig) -> bool:
+    """Wait until the host is responsive over SSH."""
+    print(f"Waiting for {host} to become responsive over SSH...")
+    start_time = time.time()
+    max_wait_seconds = config.max_wait_minutes * 60
+
+    while time.time() - start_time < max_wait_seconds:
+        # Use short timeout to avoid hanging indefinitely
+        check_cmd = f"ssh -o ConnectTimeout={config.ssh_timeout} -o BatchMode=yes {host} true"
+        if config.verbose:
+            print(f"Checking host availability: {check_cmd}")
+        try:
+            res = subprocess.run(  # noqa: S603
+                shlex.split(check_cmd),
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=config.ssh_timeout + 5,
+            )
+            if res.returncode == 0:
+                print(f"Host {host} is responsive again.")
+                return True
+        except (OSError, subprocess.TimeoutExpired) as e:
+            if config.verbose:
+                print(f"SSH check failed: {e}")
+        time.sleep(config.ssh_check_interval)
+
+    print(f"Timeout waiting for {host} to become responsive after {config.max_wait_minutes} minutes.")
+    return False
+
+
 def trigger_actions(
     host: str,
     jobs: list[int],
-    *,
-    dry_run: bool,
-    verbose: bool,
-    reboot_method: RebootMethod = RebootMethod.SYSRQ,
+    config: ReaperConfig,
 ) -> None:
     """Trigger kdump (which reboots the machine) or standard reboot, and job re-triggering."""
-    if reboot_method == RebootMethod.SYSRQ:
+    if config.reboot_method == RebootMethod.SYSRQ:
         # Echoing 'c' to sysrq-trigger panics the kernel, dumping core and rebooting
         reboot_cmd = f"ssh {host} \"sudo bash -c 'echo c > /proc/sysrq-trigger'\""
         action_msg = f"Triggering kernel crash dump (kdump) on {host}..."
@@ -98,47 +140,65 @@ def trigger_actions(
         reboot_cmd = f'ssh {host} "sudo reboot"'
         action_msg = f"Triggering reboot on {host}..."
 
-    if dry_run:
+    print(action_msg)
+    if config.dry_run:
         print(f"[DRY-RUN] Would execute: {reboot_cmd}")
-        for job_id in jobs:
-            retrigger_cmd = f"openqa-cli api --osd -X POST jobs/{job_id}/restart"
-            print(f"[DRY-RUN] Would execute: {retrigger_cmd}")
     else:
-        print(action_msg)
-        run_cmd(reboot_cmd, verbose=verbose)
+        run_cmd(reboot_cmd, check=False, verbose=config.verbose)
 
-        for job_id in jobs:
-            retrigger_cmd = f"openqa-cli api --osd -X POST jobs/{job_id}/restart"
+    if not jobs:
+        return
+
+    if config.dry_run:
+        print(f"[DRY-RUN] Would wait for {host} to be responsive over SSH.")
+        print(f"[DRY-RUN] Would wait an additional {config.stability_delay_minutes} minutes.")
+    else:
+        if not wait_for_host(host, config):
+            print(f"Host {host} did not come back online. Skipping job retriggering.")
+            return
+
+        if config.stability_delay_minutes > 0:
+            print(f"Waiting {config.stability_delay_minutes} minutes for host stability before restarting jobs...")
+            time.sleep(config.stability_delay_minutes * 60)
+
+    for job_id in jobs:
+        retrigger_cmd = f"openqa-cli api --osd -X POST jobs/{job_id}/restart"
+        if config.dry_run:
+            print(f"[DRY-RUN] Would execute: {retrigger_cmd}")
+        else:
             print(f"Retriggering job {job_id}...")
-            run_cmd(retrigger_cmd, verbose=verbose)
+            run_cmd(retrigger_cmd, verbose=config.verbose)
 
 
-def handle_host(host: str, *, dry_run: bool, verbose: bool, reboot_method: RebootMethod = RebootMethod.SYSRQ) -> None:
+def handle_host(
+    host: str,
+    config: ReaperConfig,
+) -> None:
     """Check a single host for zombies and take action if found."""
-    if verbose:
+    if config.verbose:
         print(f"Checking {host} for zombies...")
 
     # Discover zombie qemu processes
-    zombie_pids_str = run_cmd(f"ssh {host} pgrep -r Z qemu-system-s39", check=False, verbose=verbose)
+    zombie_pids_str = run_cmd(f"ssh {host} pgrep -r Z qemu-system-s39", check=False, verbose=config.verbose)
     if not zombie_pids_str:
-        if verbose:
+        if config.verbose:
             print(f"Host {host} is clean.")
         return
 
     # Snapshot process identities (PID + start time + state) to detect PID reuse
     pids = ",".join(zombie_pids_str.split())
     id_cmd = f"ssh {host} ps -o pid,lstart,state -p {pids} --no-headers"
-    initial_identities = run_cmd(id_cmd, check=False, verbose=verbose)
+    initial_identities = run_cmd(id_cmd, check=False, verbose=config.verbose)
 
     print(f"Detected potential zombies on {host}, waiting 10s to verify persistence...")
     time.sleep(10)
 
     # Re-verify identities. Only processes that match exactly are confirmed as persistent zombies.
-    verified_identities = run_cmd(id_cmd, check=False, verbose=verbose)
+    verified_identities = run_cmd(id_cmd, check=False, verbose=config.verbose)
     stuck_identities = set(initial_identities.splitlines()).intersection(verified_identities.splitlines())
 
     if not stuck_identities:
-        if verbose:
+        if config.verbose:
             print(f"Zombies on {host} were transient or PIDs were reused.")
         return
 
@@ -147,13 +207,13 @@ def handle_host(host: str, *, dry_run: bool, verbose: bool, reboot_method: Reboo
     print(f"!!! CRITICAL: Found persistent zombie processes on {host}: {', '.join(stuck_pids)}")
 
     print(f"Identifying jobs using {host}...")
-    jobs = get_running_jobs(host, verbose=verbose)
+    jobs = get_running_jobs(host, verbose=config.verbose)
     if jobs:
         print(f"Affected jobs to be retriggered: {', '.join(map(str, jobs))}")
     else:
         print(f"No active jobs found using {host}.")
 
-    trigger_actions(host, jobs, dry_run=dry_run, verbose=verbose, reboot_method=reboot_method)
+    trigger_actions(host, jobs, config)
 
 
 @app.command()
@@ -164,10 +224,25 @@ def reap(
         RebootMethod,
         typer.Option("--reboot-method", help="Reboot method to use ('sysrq' to induce crash or 'reboot' to reboot)"),
     ] = RebootMethod.SYSRQ,
+    max_wait_minutes: Annotated[
+        int,
+        typer.Option("--max-wait-minutes", help="Maximum time in minutes to wait for host to become responsive"),
+    ] = 30,
+    stability_delay_minutes: Annotated[
+        int,
+        typer.Option("--stability-delay-minutes", help="Time in minutes to wait for host stability after reboot"),
+    ] = 3,
 ) -> None:
     """Check hypervisors for zombies and reboot/retrigger jobs if found."""
+    config = ReaperConfig(
+        dry_run=dry_run,
+        verbose=verbose,
+        reboot_method=reboot_method,
+        max_wait_minutes=max_wait_minutes,
+        stability_delay_minutes=stability_delay_minutes,
+    )
     for host in HYPERVISORS:
-        handle_host(host, dry_run=dry_run, verbose=verbose, reboot_method=reboot_method)
+        handle_host(host, config)
 
 
 if __name__ == "__main__":

--- a/tests/test_s390x_qemu_zombie_reaper.py
+++ b/tests/test_s390x_qemu_zombie_reaper.py
@@ -90,19 +90,23 @@ def test_trigger_actions(
     expected_cmd: str | None,
 ) -> None:
     mock_run_cmd = mocker.patch("reaper.run_cmd")
+    mocker.patch("reaper.wait_for_host", return_value=True)
+    mocker.patch("time.sleep")
     method = reaper.RebootMethod(reboot_method)
-    reaper.trigger_actions("s390zl12.oqa.prg2.suse.org", jobs, dry_run=dry_run, verbose=False, reboot_method=method)
+    config = reaper.ReaperConfig(dry_run=dry_run, verbose=False, reboot_method=method)
+    reaper.trigger_actions("s390zl12.oqa.prg2.suse.org", jobs, config)
     captured = capsys.readouterr().out
     for expected in expected_calls:
         assert expected in captured
     if not dry_run and expected_cmd:
-        mock_run_cmd.assert_any_call(expected_cmd, verbose=False)
+        mock_run_cmd.assert_any_call(expected_cmd, check=False, verbose=False)
 
 
 def test_handle_host_clean(mocker: MockerFixture) -> None:
     mock_run_cmd = mocker.patch("reaper.run_cmd")
     mock_run_cmd.return_value = ""
-    reaper.handle_host("s390zl12.oqa.prg2.suse.org", dry_run=False, verbose=False)
+    config = reaper.ReaperConfig(dry_run=False, verbose=False)
+    reaper.handle_host("s390zl12.oqa.prg2.suse.org", config)
     mock_run_cmd.assert_called_once_with(
         "ssh s390zl12.oqa.prg2.suse.org pgrep -r Z qemu-system-s39", check=False, verbose=False
     )
@@ -112,7 +116,8 @@ def test_handle_host_zombie_persistent(mocker: MockerFixture, capsys: pytest.Cap
     mock_run_cmd = mocker.patch("reaper.run_cmd")
     mock_sleep = mocker.patch("time.sleep")
     mock_run_cmd.side_effect = ["12345", "12345 Fri Jul 17 2026 Z", "12345 Fri Jul 17 2026 Z", '{"workers": []}', ""]
-    reaper.handle_host("s390zl12.oqa.prg2.suse.org", dry_run=False, verbose=False)
+    config = reaper.ReaperConfig(dry_run=False, verbose=False)
+    reaper.handle_host("s390zl12.oqa.prg2.suse.org", config)
     captured = capsys.readouterr().out
     assert "!!! CRITICAL: Found persistent zombie processes on s390zl12.oqa.prg2.suse.org: 12345" in captured
     mock_sleep.assert_called_once_with(10)
@@ -122,12 +127,53 @@ def test_handle_host_zombie_persistent_reboot(mocker: MockerFixture, capsys: pyt
     mock_run_cmd = mocker.patch("reaper.run_cmd")
     mock_sleep = mocker.patch("time.sleep")
     mock_run_cmd.side_effect = ["12345", "12345 Fri Jul 17 2026 Z", "12345 Fri Jul 17 2026 Z", '{"workers": []}', ""]
-    reaper.handle_host(
-        "s390zl12.oqa.prg2.suse.org",
-        dry_run=False,
-        verbose=False,
-        reboot_method=reaper.RebootMethod.REBOOT,
-    )
+    config = reaper.ReaperConfig(dry_run=False, verbose=False, reboot_method=reaper.RebootMethod.REBOOT)
+    reaper.handle_host("s390zl12.oqa.prg2.suse.org", config)
     captured = capsys.readouterr().out
     assert "Triggering reboot on s390zl12.oqa.prg2.suse.org..." in captured
     mock_sleep.assert_called_once_with(10)
+
+
+def test_wait_for_host_success(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("subprocess.run")
+    mock_run.return_value = mocker.MagicMock(returncode=0)
+    mock_sleep = mocker.patch("time.sleep")
+    assert reaper.wait_for_host("s390zl12.oqa.prg2.suse.org", reaper.ReaperConfig()) is True
+    mock_sleep.assert_not_called()
+
+
+def test_wait_for_host_timeout(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("subprocess.run")
+    mock_run.return_value = mocker.MagicMock(returncode=255)
+    mock_sleep = mocker.patch("time.sleep")
+    mock_time = mocker.patch("time.time")
+    # First time.time() returns start_time (0). Subsequent calls simulate elapsed time.
+    # To timeout with max_wait_minutes=1, we need elapsed > 60.
+    mock_time.side_effect = [0, 10, 30, 65]
+    assert reaper.wait_for_host("s390zl12.oqa.prg2.suse.org", reaper.ReaperConfig(max_wait_minutes=1)) is False
+    assert mock_sleep.call_count == 2
+
+
+def test_trigger_actions_custom_limits(
+    mocker: MockerFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mocker.patch("reaper.run_cmd")
+    mock_wait = mocker.patch("reaper.wait_for_host", return_value=True)
+    mock_sleep = mocker.patch("time.sleep")
+
+    config = reaper.ReaperConfig(
+        dry_run=False,
+        verbose=False,
+        max_wait_minutes=5,
+        stability_delay_minutes=1,
+    )
+    reaper.trigger_actions(
+        "s390zl12.oqa.prg2.suse.org",
+        [123],
+        config,
+    )
+    captured = capsys.readouterr().out
+    assert "Waiting 1 minutes for host stability before restarting jobs..." in captured
+    mock_wait.assert_called_once_with("s390zl12.oqa.prg2.suse.org", config)
+    mock_sleep.assert_called_once_with(60)


### PR DESCRIPTION
Motivation:
Retriggered jobs were instantly failing because they were picked up
before the rebooting hypervisor's SSH server was back online.

Design Choices:
Added a wait_for_host polling loop inside s390x-qemu-zombie-reaper.py
to ensure the host is responsive before openqa-cli restart commands
are issued.

Benefits:
Prevents new jobs from crashing immediately against unreachable hosts
and outlines the future architectural fix for the s390x backend.

Related issue: https://progress.opensuse.org/issues/201144