### PR TITLE
refactor(query-label): use native psql variables

### DIFF
--- a/openqa-query-for-job-label
+++ b/openqa-query-for-job-label
@@ -5,6 +5,7 @@ interval="${interval:-"30 day"}"
 failed_since="${failed_since:-"(timezone('UTC', now()) - interval '$interval')"}"
 comment="${1:?"Need comment to search for"}"
 limit="${limit:-10}"
+query="${query:-"select :'scheme' || '://' || :'host' || '/tests/' || jobs.id,t_finished,state,result,test,reason,host from jobs, comments, workers where t_finished >= $failed_since and jobs.assigned_worker_id = workers.id and jobs.id = comments.job_id and comments.text ~ '$comment' order by t_finished desc limit $limit;"}"
 dry_run="${dry_run:-"0"}"
 
 usage() {
@@ -39,8 +40,7 @@ main() {
 
     [ "$dry_run" = "1" ] && _dry_run="echo"
     for h in $host; do
-        q="${query:-"select '${scheme}://${h}/tests/' || jobs.id,t_finished,state,result,test,reason,host from jobs, comments, workers where t_finished >= $failed_since and jobs.assigned_worker_id = workers.id and jobs.id = comments.job_id and comments.text ~ '$comment' order by t_finished desc limit $limit;"}"
-        $_dry_run ssh "$h" "cd /tmp; sudo -u geekotest psql --no-align --tuples-only -F ' | ' --command=\"$q\" openqa"
+        $_dry_run ssh "$h" "cd /tmp; sudo -u geekotest psql --no-align --tuples-only -F ' | ' -v scheme=\"${scheme}\" -v host=\"${h}\" --command=\"$query\" openqa"
     done
     :
 }


### PR DESCRIPTION
Motivation:
Redefining the SQL query string in each host-iteration loop to interpolate
host details is wasteful and inefficient.

Design Choices:
Moved the query definition to the script level using psql variables
:'scheme' and :'host', and passed them natively to psql via the -v option.

Benefits:
Avoids loop-dependent SQL redefinition, leverages secure PostgreSQL native
variable binding, and keeps the code clean and maintainable.

Related issue: https://github.com/os-autoinst/os-autoinst-scripts/pull/631