### PR TITLE
fix(openqa-query-for-job-label): Make test ids clickable links

### DIFF
--- a/openqa-query-for-job-label
+++ b/openqa-query-for-job-label
@@ -5,7 +5,9 @@ interval="${interval:-"30 day"}"
 failed_since="${failed_since:-"(timezone('UTC', now()) - interval '$interval')"}"
 comment="${1:?"Need comment to search for"}"
 limit="${limit:-10}"
-query="${query:-"select :'scheme' || '://' || :'host' || '/tests/' || jobs.id,t_finished,state,result,test,reason,host from jobs, comments, workers where t_finished >= $failed_since and jobs.assigned_worker_id = workers.id and jobs.id = comments.job_id and comments.text ~ '$comment' order by t_finished desc limit $limit;"}"
+query="${query:-"select jobs.id,t_finished,state,result,test,reason,host from jobs, comments, workers where t_finished >= $failed_since and jobs.assigned_worker_id = workers.id and jobs.id = comments.job_id and comments.text ~ '$comment' order by t_finished desc limit $limit;"}"
+[ -t 1 ] && pd=0 || pd=1 # default to plain output when not writing to TTY
+plain_output="${plain_output:-"$pd"}"
 dry_run="${dry_run:-"0"}"
 
 usage() {
@@ -40,7 +42,15 @@ main() {
 
     [ "$dry_run" = "1" ] && _dry_run="echo"
     for h in $host; do
-        $_dry_run ssh "$h" "cd /tmp; sudo -u geekotest psql --no-align --tuples-only -F ' | ' -v scheme=\"${scheme}\" -v host=\"${h}\" --command=\"$query\" openqa"
+        $_dry_run ssh "$h" "cd /tmp; sudo -u geekotest psql --no-align --tuples-only --command=\"$query\" openqa" | while read -r line; do
+            test_id=$(echo "$line" | cut -d '|' -f1)
+            rest=$(echo "$line" | cut -d '|' -f2-)
+            if [ "$plain_output" = "0" ]; then
+                printf '\e]8;;%s://%s/t%s\e\\%s\e]8;;\e\|%s\n' "$scheme" "$host" "$test_id" "$test_id" "$rest"
+            else
+                printf "%s://%s/t%s |%s\n" "$scheme" "$host" "$test_id" "$rest"
+            fi
+        done
     done
     :
 }


### PR DESCRIPTION
Don't use more screen space but make the test id a clickable link.
This will work in modern terminals like alacritty and kitty.
In older terminals it will look like before.
Also when writing to a pipe or redirect, the plain output will be written.

<img width="980" height="218" alt="link" src="https://github.com/user-attachments/assets/9d61fc38-f8a4-4739-9133-078c64d4fa2d" />
