### PR TITLE
fix: restore investigation job trigger from hook

### DIFF
--- a/_common
+++ b/_common
@@ -10,6 +10,10 @@ submit_target=${submit_target:-openSUSE:Factory}
 
 warn() { printf '%s\n' "$@" >&2; }
 
+# Extract the job URLs from "Unknown test issue, to be reviewed" headers emitted
+# by openqa-label-known-issues, reading from stdin.
+extract_unreviewed_urls() { sed -n 's/\[\([^]]*\)\].*Unknown test issue, to be reviewed.*/\1/p'; }
+
 for cmd in jq retry osc openqa-cli; do
     if ! command -v "$cmd" > /dev/null 2>&1; then
         warn "ERROR: '$cmd' command not found. Please install $cmd."

--- a/openqa-label-known-issues
+++ b/openqa-label-known-issues
@@ -442,8 +442,8 @@ def handle_unreviewed(
     excerpt += extract_excerpt(report_file)
     excerpt += "\n" + snip_end
 
-    print(header, file=sys.stderr)
-    print(excerpt, file=sys.stderr)
+    print(header)
+    print(excerpt)
 
     if email_unreviewed and group_id != "null":
         try:

--- a/openqa-label-known-issues-and-investigate-hook
+++ b/openqa-label-known-issues-and-investigate-hook
@@ -37,7 +37,7 @@ investigate-and-bisect() {
 
 label() {
     local url=$1
-    openqa-label-known-issues "$url" | sed -n 's/\[\([^]]*\)\].*Unknown test issue, to be reviewed.*/\1/p'
+    openqa-label-known-issues "$url" | extract_unreviewed_urls
 }
 
 hook() {

--- a/openqa-label-known-issues-multi
+++ b/openqa-label-known-issues-multi
@@ -30,19 +30,21 @@ main() {
 
     # shellcheck disable=SC2013
     for testurl in $(cat - | sed 's/ .*$//'); do
-        err_out=$(mktemp)
+        stdout_out=$(mktemp)
         set +e
-        { "$(dirname "$0")"/openqa-label-known-issues "$testurl" 2>&1 1>&3 | tee "$err_out" >&2; } 3>&1
-        rc=${PIPESTATUS[0]}
+        "$(dirname "$0")"/openqa-label-known-issues "$testurl" > "$stdout_out"
+        rc=$?
         set -e
         if [[ $rc -ne 0 ]]; then
-            rm -f "$err_out"
+            cat "$stdout_out" >&2
+            rm -f "$stdout_out"
             exit "$rc"
         fi
-        if grep -q "Unknown test issue, to be reviewed" "$err_out"; then
+        cat "$stdout_out" >&2
+        if grep -qE '^\[.*\].*Unknown test issue, to be reviewed' "$stdout_out"; then
             to_review+=("$testurl")
         fi
-        rm -f "$err_out"
+        rm -f "$stdout_out"
     done
     print_summary
 }

--- a/openqa-review-failed
+++ b/openqa-review-failed
@@ -1,1 +1,5 @@
-"$(dirname "$0")"/openqa-monitor-investigation-candidates | "$(dirname "$0")"/openqa-label-known-issues-multi 3>&1 1> /dev/null 2>&3- | sed -n 's/\[\([^]]*\)\].*Unknown test issue, to be reviewed.*/\1/p' | "$(dirname "$0")"/openqa-investigate-multi
+#!/bin/bash
+dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=/dev/null
+source "$dir"/_common
+"$dir"/openqa-monitor-investigation-candidates | "$dir"/openqa-label-known-issues-multi 3>&1 1> /dev/null 2>&3- | extract_unreviewed_urls | "$dir"/openqa-investigate-multi

--- a/openqa-review-failed
+++ b/openqa-review-failed
@@ -1,1 +1,1 @@
-"$(dirname "$0")"/openqa-monitor-investigation-candidates | "$(dirname "$0")"/openqa-label-known-issues-multi 3>&1 1> /dev/null 2>&3- | sed -n 's/\(\S*\) : Unknown test issue, to be reviewed.*$/\1/p' | "$(dirname "$0")"/openqa-investigate-multi
+"$(dirname "$0")"/openqa-monitor-investigation-candidates | "$(dirname "$0")"/openqa-label-known-issues-multi 3>&1 1> /dev/null 2>&3- | sed -n 's/\[\([^]]*\)\].*Unknown test issue, to be reviewed.*/\1/p' | "$(dirname "$0")"/openqa-investigate-multi

--- a/test/07-label-known-issues-multi.t
+++ b/test/07-label-known-issues-multi.t
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+source test/init
+
+plan tests 10
+
+script=$PWD/openqa-label-known-issues-multi
+
+# Run the script with a stubbed sibling "openqa-label-known-issues" so the
+# script's "$(dirname "$0")"/openqa-label-known-issues resolves to our mock.
+run_multi() {
+    local stub_body=$1 input=$2
+    local bindir
+    bindir=$(mktemp -d)
+    cp "$script" "$bindir/openqa-label-known-issues-multi"
+    cat > "$bindir/openqa-label-known-issues" << EOF
+#!/bin/bash
+$stub_body
+EOF
+    chmod +x "$bindir"/openqa-label-known-issues*
+    printf '%s' "$input" | "$bindir/openqa-label-known-issues-multi"
+    local rc=$?
+    rm -rf "$bindir"
+    return $rc
+}
+
+unknown='echo "[$1]($1): Unknown test issue, to be reviewed"'
+
+# 1. Unknown issue: header to stderr, summary to stdout, exit 0
+try 'stdout=$(run_multi "$unknown" "http://o3/tests/1" 2>/tmp/err_$$); cat /tmp/err_$$; echo "---"; echo "$stdout"; rm -f /tmp/err_$$'
+is "$rc" 0 "exit 0 on unknown issue"
+has "$got" "[http://o3/tests/1](http://o3/tests/1): Unknown test issue, to be reviewed" "header forwarded to stderr"
+has "$got" "1 unknown issues to be reviewed" "summary printed to stdout"
+
+# 2. Header does not leak to stdout (only summary on stdout)
+try 'run_multi "$unknown" "http://o3/tests/1" 2>/dev/null'
+is "$rc" 0 "exit 0 (stdout-only capture)"
+hasnt "$got" "autoinst-log.txt" "excerpt/header not on stdout"
+has "$got" "unknown issues to be reviewed" "summary on stdout"
+
+# 3. Known issue (no unknown header): no review summary
+try 'run_multi "echo done" "http://o3/tests/2" 2>/dev/null'
+is "$rc" 0 "exit 0 on known issue"
+is "$got" "" "no summary when nothing to review"
+
+# 4. Child failure propagates exit code and forwards output to stderr
+try 'run_multi "echo boom >&1; exit 3" "http://o3/tests/3" 2>&1'
+is "$rc" 3 "child non-zero exit code propagated"
+has "$got" "boom" "failure output forwarded"

--- a/tests/test_openqa_label_known_issues.py
+++ b/tests/test_openqa_label_known_issues.py
@@ -554,7 +554,6 @@ def test_handle_unreviewed(mocker: MockerFixture, tmp_path: pathlib.Path) -> Non
         )
         mock_print.assert_any_call(
             "[http://testurl](http://testurl): Unknown test issue, to be reviewed\n-> [autoinst-log.txt](http://testurl/file/autoinst-log.txt)\n",
-            file=sys.stderr,
         )
         mock_send.assert_not_called()
 


### PR DESCRIPTION
Motivation:
Rewriting openqa-label-known-issues to Python emitted the "Unknown test
issue" header to stderr, which broke the investigate hook (it captures
stdout to trigger investigation) and spammed the systemd journal.
openqa-review-failed's regex was also outdated.

Design Choices:
Print unreviewed headers to stdout again. openqa-label-known-issues-multi
captures stdout, forwards it to stderr, and anchors the review-detection
grep to the header line. The child failure path now routes captured output
to stderr for parity with the success path. Modernized the regex in
openqa-review-failed to match the current header format.

Benefits:
Restores the automatic openQA investigation pipeline via the hook, keeps
failure diagnostics visible, and avoids systemd journal spam.

Related issue: https://progress.opensuse.org/issues/204828