### PR TITLE
fix(query-label): fix variable interpolation

### DIFF
--- a/openqa-query-for-job-label
+++ b/openqa-query-for-job-label
@@ -40,7 +40,7 @@ main() {
 
     [ "$dry_run" = "1" ] && _dry_run="echo"
     for h in $host; do
-        $_dry_run ssh "$h" "cd /tmp; sudo -u geekotest psql --no-align --tuples-only -F ' | ' -v scheme=\"${scheme}\" -v host=\"${h}\" --command=\"$query\" openqa"
+        $_dry_run ssh "$h" "cd /tmp; sudo -u geekotest psql --no-align --tuples-only -F ' | ' -v scheme=\"${scheme}\" -v host=\"${h}\" -f - openqa" <<< "$query"
     done
     :
 }

--- a/openqa-query-for-job-label
+++ b/openqa-query-for-job-label
@@ -5,7 +5,7 @@ interval="${interval:-"30 day"}"
 failed_since="${failed_since:-"(timezone('UTC', now()) - interval '$interval')"}"
 comment="${1:?"Need comment to search for"}"
 limit="${limit:-10}"
-query="${query:-"select :'scheme' || '://' || :'host' || '/tests/' || jobs.id,t_finished,state,result,test,reason,host from jobs, comments, workers where t_finished >= $failed_since and jobs.assigned_worker_id = workers.id and jobs.id = comments.job_id and comments.text ~ '$comment' order by t_finished desc limit $limit;"}"
+query="${query:-"select :'scheme' || '://' || :'host' || '/t' || jobs.id,t_finished,state,result,test,reason,host from jobs, comments, workers where t_finished >= $failed_since and jobs.assigned_worker_id = workers.id and jobs.id = comments.job_id and comments.text ~ '$comment' order by t_finished desc limit $limit;"}"
 dry_run="${dry_run:-"0"}"
 
 usage() {


### PR DESCRIPTION
Motivation:
Older psql clients do not support variable interpolation when running queries
passed via the --command option, leading to syntax errors on older hosts.

Design Choices:
Pass the query via standard input (-f -) to psql, which supports native
variable interpolation across all client versions.

Benefits:
Restores compatibility with older target databases without sacrificing the use
of native psql variables.