### PR TITLE
feat: extend s390x zombie reaper with libvirt health check

### DIFF
--- a/s390x-qemu-zombie-reaper.py
+++ b/s390x-qemu-zombie-reaper.py
@@ -39,6 +39,7 @@ HYPERVISORS = {
     "s390zl13.oqa.prg2.suse.org": ["worker32", "worker33"],
 }
 
+RET_SUCCESS = 0
 SSH_ERR_CONNECT = 255
 
 
@@ -116,7 +117,7 @@ def wait_for_host(host: str, config: ReaperConfig) -> bool:
                 check=False,
                 timeout=config.ssh_timeout + 5,
             )
-            if res.returncode == 0:
+            if res.returncode == RET_SUCCESS:
                 print(f"Host {host} is responsive again.")
                 return True
         except (OSError, subprocess.TimeoutExpired) as e:
@@ -180,7 +181,8 @@ def check_libvirt_health(host: str, config: ReaperConfig) -> bool:
     try:
         res = subprocess.run(  # noqa: S603
             shlex.split(check_cmd),
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             text=True,
             check=False,
             timeout=15,
@@ -193,12 +195,12 @@ def check_libvirt_health(host: str, config: ReaperConfig) -> bool:
         if config.verbose:
             print(f"Host {host} is unreachable over SSH (exit code 255). Skipping libvirt health check.")
         return True
-    if res.returncode != 0:
+    if res.returncode != RET_SUCCESS:
         print(f"libvirt health check failed on {host}: virsh list returned {res.returncode}")
-        if res.stderr:
-            print(f"stderr: {res.stderr.strip()}")
+        if res.stdout:
+            print(f"output: {res.stdout.strip()}")
         return False
-    if "error:" in res.stderr or "error:" in res.stdout:
+    if "error:" in res.stdout:
         print(f"libvirt health check failed on {host}: error detected in output")
         return False
     return True
@@ -212,49 +214,41 @@ def handle_host(
     if config.verbose:
         print(f"Checking {host} for zombies...")
 
+    critical_msg = None
+
     # Discover zombie qemu processes
     zombie_pids_str = run_cmd(f"ssh {host} pgrep -r Z qemu-system-s39", check=False, verbose=config.verbose)
     if zombie_pids_str:
-        # Snapshot process identities (PID + start time + state) to detect PID reuse
+        # Snapshot process candidates (PID + start time + state) to detect PID reuse
         pids = ",".join(zombie_pids_str.split())
         id_cmd = f"ssh {host} ps -o pid,lstart,state -p {pids} --no-headers"
-        initial_identities = run_cmd(id_cmd, check=False, verbose=config.verbose)
+        initial_candidates = run_cmd(id_cmd, check=False, verbose=config.verbose)
 
         print(f"Detected potential zombies on {host}, waiting 10s to verify persistence...")
         time.sleep(10)
 
-        # Re-verify identities. Only processes that match exactly are confirmed as persistent zombies.
-        verified_identities = run_cmd(id_cmd, check=False, verbose=config.verbose)
-        stuck_identities = set(initial_identities.splitlines()).intersection(verified_identities.splitlines())
+        # Re-verify candidates. Only processes that match exactly are confirmed as persistent zombies.
+        verified_candidates = run_cmd(id_cmd, check=False, verbose=config.verbose)
+        stuck_candidates = set(initial_candidates.splitlines()).intersection(verified_candidates.splitlines())
 
-        if stuck_identities:
-            # Extract PIDs for logging
-            stuck_pids = [line.split()[0] for line in stuck_identities]
-            print(f"!!! CRITICAL: Found persistent zombie processes on {host}: {', '.join(stuck_pids)}")
-
-            print(f"Identifying jobs using {host}...")
-            jobs = get_running_jobs(host, verbose=config.verbose)
-            if jobs:
-                print(f"Affected jobs to be retriggered: {', '.join(map(str, jobs))}")
-            else:
-                print(f"No active jobs found using {host}.")
-
-            trigger_actions(host, jobs, config)
-            return
-
-        if config.verbose:
+        if stuck_candidates:
+            stuck_pids = [line.split(maxsplit=1)[0] for line in stuck_candidates]
+            critical_msg = f"!!! CRITICAL: Found persistent zombie processes on {host}: {', '.join(stuck_pids)}"
+        elif config.verbose:
             print(f"Zombies on {host} were transient or PIDs were reused.")
 
-    # If no persistent zombies were found, check general libvirt health
-    if not check_libvirt_health(host, config):
-        print(f"!!! CRITICAL: libvirt is unhealthy on {host}")
-        print(f"Identifying jobs using {host}...")
-        jobs = get_running_jobs(host, verbose=config.verbose)
-        if jobs:
-            print(f"Affected jobs to be retriggered: {', '.join(map(str, jobs))}")
-        else:
-            print(f"No active jobs found using {host}.")
+    if not critical_msg and not check_libvirt_health(host, config):
+        critical_msg = f"!!! CRITICAL: libvirt is unhealthy on {host}"
 
+    if critical_msg:
+        print(critical_msg)
+        print(f"Identifying jobs which ran on {host}...")
+        jobs = get_running_jobs(host, verbose=config.verbose)
+        print(
+            f"Affected jobs to be retriggered: {', '.join(map(str, jobs))}"
+            if jobs
+            else f"No active jobs found using {host}."
+        )
         trigger_actions(host, jobs, config)
     elif config.verbose:
         print(f"Host {host} is clean and libvirt is healthy.")

--- a/s390x-qemu-zombie-reaper.py
+++ b/s390x-qemu-zombie-reaper.py
@@ -39,6 +39,8 @@ HYPERVISORS = {
     "s390zl13.oqa.prg2.suse.org": ["worker32", "worker33"],
 }
 
+SSH_ERR_CONNECT = 255
+
 
 @dataclass(frozen=True)
 class ReaperConfig:
@@ -170,6 +172,38 @@ def trigger_actions(
             run_cmd(retrigger_cmd, verbose=config.verbose)
 
 
+def check_libvirt_health(host: str, config: ReaperConfig) -> bool:
+    """Check if libvirt is responsive and healthy on the host."""
+    if config.verbose:
+        print(f"Checking libvirt health on {host}...")
+    check_cmd = f'ssh -o ConnectTimeout={config.ssh_timeout} -o BatchMode=yes {host} "sudo virsh list"'
+    try:
+        res = subprocess.run(  # noqa: S603
+            shlex.split(check_cmd),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        print(f"libvirt health check failed on {host}: {e}")
+        return False
+
+    if res.returncode == SSH_ERR_CONNECT:
+        if config.verbose:
+            print(f"Host {host} is unreachable over SSH (exit code 255). Skipping libvirt health check.")
+        return True
+    if res.returncode != 0:
+        print(f"libvirt health check failed on {host}: virsh list returned {res.returncode}")
+        if res.stderr:
+            print(f"stderr: {res.stderr.strip()}")
+        return False
+    if "error:" in res.stderr or "error:" in res.stdout:
+        print(f"libvirt health check failed on {host}: error detected in output")
+        return False
+    return True
+
+
 def handle_host(
     host: str,
     config: ReaperConfig,
@@ -180,40 +214,50 @@ def handle_host(
 
     # Discover zombie qemu processes
     zombie_pids_str = run_cmd(f"ssh {host} pgrep -r Z qemu-system-s39", check=False, verbose=config.verbose)
-    if not zombie_pids_str:
-        if config.verbose:
-            print(f"Host {host} is clean.")
-        return
+    if zombie_pids_str:
+        # Snapshot process identities (PID + start time + state) to detect PID reuse
+        pids = ",".join(zombie_pids_str.split())
+        id_cmd = f"ssh {host} ps -o pid,lstart,state -p {pids} --no-headers"
+        initial_identities = run_cmd(id_cmd, check=False, verbose=config.verbose)
 
-    # Snapshot process identities (PID + start time + state) to detect PID reuse
-    pids = ",".join(zombie_pids_str.split())
-    id_cmd = f"ssh {host} ps -o pid,lstart,state -p {pids} --no-headers"
-    initial_identities = run_cmd(id_cmd, check=False, verbose=config.verbose)
+        print(f"Detected potential zombies on {host}, waiting 10s to verify persistence...")
+        time.sleep(10)
 
-    print(f"Detected potential zombies on {host}, waiting 10s to verify persistence...")
-    time.sleep(10)
+        # Re-verify identities. Only processes that match exactly are confirmed as persistent zombies.
+        verified_identities = run_cmd(id_cmd, check=False, verbose=config.verbose)
+        stuck_identities = set(initial_identities.splitlines()).intersection(verified_identities.splitlines())
 
-    # Re-verify identities. Only processes that match exactly are confirmed as persistent zombies.
-    verified_identities = run_cmd(id_cmd, check=False, verbose=config.verbose)
-    stuck_identities = set(initial_identities.splitlines()).intersection(verified_identities.splitlines())
+        if stuck_identities:
+            # Extract PIDs for logging
+            stuck_pids = [line.split()[0] for line in stuck_identities]
+            print(f"!!! CRITICAL: Found persistent zombie processes on {host}: {', '.join(stuck_pids)}")
 
-    if not stuck_identities:
+            print(f"Identifying jobs using {host}...")
+            jobs = get_running_jobs(host, verbose=config.verbose)
+            if jobs:
+                print(f"Affected jobs to be retriggered: {', '.join(map(str, jobs))}")
+            else:
+                print(f"No active jobs found using {host}.")
+
+            trigger_actions(host, jobs, config)
+            return
+
         if config.verbose:
             print(f"Zombies on {host} were transient or PIDs were reused.")
-        return
 
-    # Extract PIDs for logging
-    stuck_pids = [line.split()[0] for line in stuck_identities]
-    print(f"!!! CRITICAL: Found persistent zombie processes on {host}: {', '.join(stuck_pids)}")
+    # If no persistent zombies were found, check general libvirt health
+    if not check_libvirt_health(host, config):
+        print(f"!!! CRITICAL: libvirt is unhealthy on {host}")
+        print(f"Identifying jobs using {host}...")
+        jobs = get_running_jobs(host, verbose=config.verbose)
+        if jobs:
+            print(f"Affected jobs to be retriggered: {', '.join(map(str, jobs))}")
+        else:
+            print(f"No active jobs found using {host}.")
 
-    print(f"Identifying jobs using {host}...")
-    jobs = get_running_jobs(host, verbose=config.verbose)
-    if jobs:
-        print(f"Affected jobs to be retriggered: {', '.join(map(str, jobs))}")
-    else:
-        print(f"No active jobs found using {host}.")
-
-    trigger_actions(host, jobs, config)
+        trigger_actions(host, jobs, config)
+    elif config.verbose:
+        print(f"Host {host} is clean and libvirt is healthy.")
 
 
 @app.command()

--- a/tests/test_s390x_qemu_zombie_reaper.py
+++ b/tests/test_s390x_qemu_zombie_reaper.py
@@ -1,5 +1,5 @@
 # Copyright SUSE LLC
-# ruff: noqa: FBT001
+# ruff: noqa: FBT001, S404
 """Unit tests for s390x-qemu-zombie-reaper.py."""
 
 from __future__ import annotations
@@ -7,6 +7,7 @@ from __future__ import annotations
 import importlib.machinery
 import importlib.util
 import pathlib
+import subprocess
 import sys
 from typing import TYPE_CHECKING
 
@@ -105,11 +106,13 @@ def test_trigger_actions(
 def test_handle_host_clean(mocker: MockerFixture) -> None:
     mock_run_cmd = mocker.patch("reaper.run_cmd")
     mock_run_cmd.return_value = ""
+    mock_health = mocker.patch("reaper.check_libvirt_health", return_value=True)
     config = reaper.ReaperConfig(dry_run=False, verbose=False)
     reaper.handle_host("s390zl12.oqa.prg2.suse.org", config)
     mock_run_cmd.assert_called_once_with(
         "ssh s390zl12.oqa.prg2.suse.org pgrep -r Z qemu-system-s39", check=False, verbose=False
     )
+    mock_health.assert_called_once_with("s390zl12.oqa.prg2.suse.org", config)
 
 
 def test_handle_host_zombie_persistent(mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
@@ -177,3 +180,62 @@ def test_trigger_actions_custom_limits(
     assert "Waiting 1 minutes for host stability before restarting jobs..." in captured
     mock_wait.assert_called_once_with("s390zl12.oqa.prg2.suse.org", config)
     mock_sleep.assert_called_once_with(60)
+
+
+def test_check_libvirt_health_success(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("subprocess.run")
+    mock_run.return_value = mocker.MagicMock(
+        returncode=0, stdout="Id Name State\n----------------\n1 openQA-SUT-1 running", stderr=""
+    )
+    config = reaper.ReaperConfig(dry_run=False, verbose=False)
+    assert reaper.check_libvirt_health("s390zl12.oqa.prg2.suse.org", config) is True
+
+
+def test_check_libvirt_health_unreachable_ssh(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("subprocess.run")
+    mock_run.return_value = mocker.MagicMock(
+        returncode=reaper.SSH_ERR_CONNECT,
+        stdout="",
+        stderr="ssh: connect to host s390zl12.oqa.prg2.suse.org port 22: Connection refused",
+    )
+    config = reaper.ReaperConfig(dry_run=False, verbose=False)
+    assert reaper.check_libvirt_health("s390zl12.oqa.prg2.suse.org", config) is True
+
+
+def test_check_libvirt_health_failed_command(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("subprocess.run")
+    mock_run.return_value = mocker.MagicMock(
+        returncode=1, stdout="", stderr="error: failed to connect to the hypervisor"
+    )
+    config = reaper.ReaperConfig(dry_run=False, verbose=False)
+    assert reaper.check_libvirt_health("s390zl12.oqa.prg2.suse.org", config) is False
+
+
+def test_check_libvirt_health_error_in_output(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("subprocess.run")
+    mock_run.return_value = mocker.MagicMock(
+        returncode=0, stdout="error: Disconnected from qemu:///system due to end of file", stderr=""
+    )
+    config = reaper.ReaperConfig(dry_run=False, verbose=False)
+    assert reaper.check_libvirt_health("s390zl12.oqa.prg2.suse.org", config) is False
+
+
+def test_check_libvirt_health_timeout(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("subprocess.run")
+    mock_run.side_effect = subprocess.TimeoutExpired("ssh ...", 15)
+    config = reaper.ReaperConfig(dry_run=False, verbose=False)
+    assert reaper.check_libvirt_health("s390zl12.oqa.prg2.suse.org", config) is False
+
+
+def test_handle_host_unhealthy_libvirt(mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_run_cmd = mocker.patch("reaper.run_cmd")
+    mock_run_cmd.side_effect = ["", '{"workers": []}', ""]  # pgrep, openqa-cli workers, and reboot
+    mock_health = mocker.patch("reaper.check_libvirt_health", return_value=False)
+    mocker.patch("reaper.wait_for_host", return_value=True)
+    mocker.patch("time.sleep")
+    config = reaper.ReaperConfig(dry_run=False, verbose=False)
+    reaper.handle_host("s390zl12.oqa.prg2.suse.org", config)
+    captured = capsys.readouterr().out
+    assert "!!! CRITICAL: libvirt is unhealthy on s390zl12.oqa.prg2.suse.org" in captured
+    assert "Triggering kernel crash dump (kdump) on s390zl12.oqa.prg2.suse.org..." in captured
+    mock_health.assert_called_once_with("s390zl12.oqa.prg2.suse.org", config)

--- a/tests/test_s390x_qemu_zombie_reaper.py
+++ b/tests/test_s390x_qemu_zombie_reaper.py
@@ -182,49 +182,27 @@ def test_trigger_actions_custom_limits(
     mock_sleep.assert_called_once_with(60)
 
 
-def test_check_libvirt_health_success(mocker: MockerFixture) -> None:
+@pytest.mark.parametrize(
+    ("returncode", "stdout", "stderr", "side_effect", "expected"),
+    [
+        (0, "Id Name State\n----------------\n1 openQA-SUT-1 running", "", None, True),
+        (reaper.SSH_ERR_CONNECT, "", "ssh: connect to host ...", None, True),
+        (1, "", "error: failed to connect to the hypervisor", None, False),
+        (0, "error: Disconnected from qemu:///system due to end of file", "", None, False),
+        (0, "", "", subprocess.TimeoutExpired("ssh ...", 15), False),
+    ],
+    ids=["success", "unreachable_ssh", "failed_command", "error_in_output", "timeout"],
+)
+def test_check_libvirt_health(
+    mocker: MockerFixture, returncode: int, stdout: str, stderr: str, side_effect: Exception | None, expected: bool
+) -> None:
     mock_run = mocker.patch("subprocess.run")
-    mock_run.return_value = mocker.MagicMock(
-        returncode=0, stdout="Id Name State\n----------------\n1 openQA-SUT-1 running", stderr=""
-    )
+    if side_effect:
+        mock_run.side_effect = side_effect
+    else:
+        mock_run.return_value = mocker.MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
     config = reaper.ReaperConfig(dry_run=False, verbose=False)
-    assert reaper.check_libvirt_health("s390zl12.oqa.prg2.suse.org", config) is True
-
-
-def test_check_libvirt_health_unreachable_ssh(mocker: MockerFixture) -> None:
-    mock_run = mocker.patch("subprocess.run")
-    mock_run.return_value = mocker.MagicMock(
-        returncode=reaper.SSH_ERR_CONNECT,
-        stdout="",
-        stderr="ssh: connect to host s390zl12.oqa.prg2.suse.org port 22: Connection refused",
-    )
-    config = reaper.ReaperConfig(dry_run=False, verbose=False)
-    assert reaper.check_libvirt_health("s390zl12.oqa.prg2.suse.org", config) is True
-
-
-def test_check_libvirt_health_failed_command(mocker: MockerFixture) -> None:
-    mock_run = mocker.patch("subprocess.run")
-    mock_run.return_value = mocker.MagicMock(
-        returncode=1, stdout="", stderr="error: failed to connect to the hypervisor"
-    )
-    config = reaper.ReaperConfig(dry_run=False, verbose=False)
-    assert reaper.check_libvirt_health("s390zl12.oqa.prg2.suse.org", config) is False
-
-
-def test_check_libvirt_health_error_in_output(mocker: MockerFixture) -> None:
-    mock_run = mocker.patch("subprocess.run")
-    mock_run.return_value = mocker.MagicMock(
-        returncode=0, stdout="error: Disconnected from qemu:///system due to end of file", stderr=""
-    )
-    config = reaper.ReaperConfig(dry_run=False, verbose=False)
-    assert reaper.check_libvirt_health("s390zl12.oqa.prg2.suse.org", config) is False
-
-
-def test_check_libvirt_health_timeout(mocker: MockerFixture) -> None:
-    mock_run = mocker.patch("subprocess.run")
-    mock_run.side_effect = subprocess.TimeoutExpired("ssh ...", 15)
-    config = reaper.ReaperConfig(dry_run=False, verbose=False)
-    assert reaper.check_libvirt_health("s390zl12.oqa.prg2.suse.org", config) is False
+    assert reaper.check_libvirt_health("s390zl12.oqa.prg2.suse.org", config) is expected
 
 
 def test_handle_host_unhealthy_libvirt(mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
Motivation:
Ensure that s390x hypervisors are rebooted when libvirt loses connection to
the qemu:///system daemon (or is otherwise unresponsive), preventing silent
reoccurring openQA job failures on the same hypervisor.

Design Choices:
Added a `check_libvirt_health` helper executing a timed-out `virsh list`
command on the host, gracefully skipping reboots if SSH connection fails.
Extended `handle_host` to trigger reboots and retrigger jobs if libvirt is
unhealthy.

Benefits:
Automates recovery of hypervisors affected by libvirtd and QEMU connection
disconnect issues, matching the existing robust zombie-process healing flow.

Related issue: https://progress.opensuse.org/issues/204384