### PR TITLE
fix: call _get_packages_to_submit with kwarg

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -911,6 +911,8 @@ def main(  # noqa: PLR0913, PLR0917
     submit_target_extra: Annotated[
         str, typer.Option(envvar="submit_target_extra")
     ] = "openSUSE:Backports:SLE-15-SP7:Update,openSUSE:Leap:16.0,openSUSE:Leap:16.1",
+    verbose: Annotated[int, typer.Option("--verbose", "-v", count=True)] = 0,
+    quiet: Annotated[int, typer.Option("--quiet", "-V", count=True)] = 0,
 ) -> None:
     """Prepare and submit os-autoinst packages to target projects like openSUSE:Factory.
 
@@ -918,7 +920,11 @@ def main(  # noqa: PLR0913, PLR0917
     for openQA-related packages on OBS (Open Build Service) and Gitea.
     Can be configured additionally using environment variables.
     """
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    verbosity = verbose - quiet
+    levels = [logging.CRITICAL, logging.ERROR, logging.WARNING, logging.INFO, logging.DEBUG]
+    # base level INFO is at levels.index(logging.INFO). Increment/decrement moves the index.
+    idx = max(0, min(len(levels) - 1, levels.index(logging.INFO) + verbosity))
+    logging.basicConfig(level=levels[idx], format="%(levelname)s: %(message)s", force=True)
     _run_submissions(
         src_project=src_project,
         dst_project=dst_project,

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -827,7 +827,7 @@ def _run_submissions(  # noqa: C901,  PLR0912, PLR0913, PLR0914, PLR0915
     original_dir = pathlib.Path.cwd().resolve()
 
     # Determine packages to submit
-    auto_submit_packages = _get_packages_to_submit(dst_project, osc_cmd_str, dry_run)
+    auto_submit_packages = _get_packages_to_submit(dst_project, osc_cmd_str, dry_run=dry_run)
 
     # Submit packages using TMPDIR
     must_cleanup_staging = False

--- a/tests/test_auto_submit.py
+++ b/tests/test_auto_submit.py
@@ -230,3 +230,18 @@ def test_log_skip_reason(reason: str, expected: str, caplog: pytest.LogCaptureFi
     with caplog.at_level("INFO"):
         auto_submit._log_skip_reason(reason)  # noqa: SLF001
     assert caplog.records[0].getMessage() == expected
+
+
+def test_get_packages_to_submit_env(mocker: MockerFixture) -> None:
+    mocker.patch.dict("os.environ", {"PACKAGES": "pkg1 pkg2"})
+    res = auto_submit._get_packages_to_submit("dst", "osc", dry_run=False)  # noqa: SLF001
+    assert res == ["pkg1", "pkg2"]
+
+
+def test_get_packages_to_submit_osc(mocker: MockerFixture) -> None:
+    mocker.patch.dict("os.environ", {}, clear=True)
+    mock_run = mocker.patch("auto_submit.run_osc_cmd")
+    mock_run.return_value = subprocess.CompletedProcess(["osc"], 0, stdout="pkg1\npkg2-test\npkg3\n")
+    res = auto_submit._get_packages_to_submit("dst", "osc", dry_run=True)  # noqa: SLF001
+    assert res == ["pkg1", "pkg3"]
+    mock_run.assert_called_once_with(["osc", "ls", "dst"], dry_run=True, mutating=False)

--- a/tests/test_auto_submit.py
+++ b/tests/test_auto_submit.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import datetime
 import importlib.machinery
 import importlib.util
+import logging
 import pathlib
 import subprocess
 import sys
@@ -245,3 +246,20 @@ def test_get_packages_to_submit_osc(mocker: MockerFixture) -> None:
     res = auto_submit._get_packages_to_submit("dst", "osc", dry_run=True)  # noqa: SLF001
     assert res == ["pkg1", "pkg3"]
     mock_run.assert_called_once_with(["osc", "ls", "dst"], dry_run=True, mutating=False)
+
+
+@pytest.mark.parametrize(
+    ("verbose", "quiet", "expected_level"),
+    [
+        (0, 0, logging.INFO),
+        (1, 0, logging.DEBUG),
+        (0, 1, logging.WARNING),
+        (0, 2, logging.ERROR),
+        (0, 3, logging.CRITICAL),
+    ],
+)
+def test_main_logging(mocker: MockerFixture, verbose: int, quiet: int, expected_level: int) -> None:
+    mocker.patch("auto_submit._run_submissions")
+    mock_basic_config = mocker.patch("logging.basicConfig")
+    auto_submit.main(verbose=verbose, quiet=quiet)
+    mock_basic_config.assert_called_with(level=expected_level, format="%(levelname)s: %(message)s", force=True)


### PR DESCRIPTION
Motivation:
The function _get_packages_to_submit requires dry_run as a keyword-only
parameter, but it was being called with dry_run passed as a positional
argument, raising a TypeError.

Design Choices:
Explicitly pass dry_run as a keyword argument (dry_run=dry_run) in the
call inside _run_submissions, and add corresponding unit tests in
tests/test_auto_submit.py.

Benefits:
Fixes the TypeError during auto-submissions and ensures the parameter passing
logic is well-tested.

Related issue: https://progress.opensuse.org/issues/201843