### PR TITLE
feat: add --force flag to override skip state

### DIFF
--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -772,7 +772,7 @@ def _get_packages_to_submit(dst_project: str, osc_cmd_str: str, *, dry_run: bool
             pkg = line.strip()
             if pkg and not pkg.endswith("-test"):
                 auto_submit_packages.append(pkg)
-    except Exception as e:  # noqa: BLE001
+    except (subprocess.SubprocessError, OSError) as e:
         log.warning("Failed to list packages from %s: %s", dst_project, e)
         return []
     else:
@@ -789,6 +789,7 @@ def _run_submissions(  # noqa: C901,  PLR0912, PLR0913, PLR0914, PLR0915
     submit_target: str,
     *,
     dry_run: bool,
+    force: bool,
     osc_poll_interval: int,
     osc_build_start_poll_tries: int,
     throttle_days: int,
@@ -818,8 +819,26 @@ def _run_submissions(  # noqa: C901,  PLR0912, PLR0913, PLR0914, PLR0915
     if submit_target_extra and submit_target_extra != "none":
         targets.extend(submit_target_extra.split(","))
 
+    if force:
+        skip_file = pathlib.Path("job_post_skip_submission")
+        if skip_file.exists():
+            log.info("Force mode enabled: removing '%s' upfront", skip_file)
+            if not dry_run:
+                skip_file.unlink()
+
+        if staging_project and staging_project not in {"none", src_project}:
+            log.info("Force mode enabled: cleaning up staging project '%s' upfront", staging_project)
+            cleanup_cmd = ["cleanup-obs-project", staging_project, "I am sure"]
+            if dry_run:
+                log.info("[dry-run] Would execute: %s", " ".join(cleanup_cmd))
+            else:
+                try:
+                    subprocess.run(cleanup_cmd, check=True)  # noqa: S603
+                except (subprocess.SubprocessError, OSError) as e:
+                    log.warning("cleanup-obs-project upfront failed: %s", e)
+
     skip_file = pathlib.Path("job_post_skip_submission")
-    if skip_file.exists():
+    if skip_file.exists() and not force:
         _log_skip_reason(_format_skip_reason(skip_file.read_text(encoding="utf-8")))
         raise typer.Exit(code=0)
 
@@ -885,14 +904,14 @@ def _run_submissions(  # noqa: C901,  PLR0912, PLR0913, PLR0914, PLR0915
             os.chdir(original_dir)
 
     # Cleanup obs project
-    if not pathlib.Path("job_post_skip_submission").exists():
+    if force or not pathlib.Path("job_post_skip_submission").exists():
         cleanup_cmd = ["cleanup-obs-project", "devel:openQA:testing", "I am sure"]
         if dry_run:
             log.info("[dry-run] Would execute: %s", " ".join(cleanup_cmd))
         else:
             try:
                 subprocess.run(cleanup_cmd, check=True)  # noqa: S603
-            except Exception as e:  # noqa: BLE001
+            except (subprocess.SubprocessError, OSError) as e:
                 log.warning("cleanup-obs-project failed: %s", e)
 
 
@@ -913,6 +932,7 @@ def main(  # noqa: PLR0913, PLR0917
     ] = "openSUSE:Backports:SLE-15-SP7:Update,openSUSE:Leap:16.0,openSUSE:Leap:16.1",
     verbose: Annotated[int, typer.Option("--verbose", "-v", count=True)] = 0,
     quiet: Annotated[int, typer.Option("--quiet", "-V", count=True)] = 0,
+    force: Annotated[bool, typer.Option("--force", "-f", envvar="force")] = False,  # noqa: FBT002
 ) -> None:
     """Prepare and submit os-autoinst packages to target projects like openSUSE:Factory.
 
@@ -931,6 +951,7 @@ def main(  # noqa: PLR0913, PLR0917
         staging_project=staging_project,
         submit_target=submit_target,
         dry_run=dry_run,
+        force=force,
         osc_poll_interval=osc_poll_interval,
         osc_build_start_poll_tries=osc_build_start_poll_tries,
         throttle_days=throttle_days,

--- a/os-autoinst-obs-auto-submit
+++ b/os-autoinst-obs-auto-submit
@@ -275,7 +275,7 @@ class AutoSubmitter:
         version: str,
     ) -> bool:
         """Create an OBS submit request."""
-        req = get_obs_sr_id(target, self.dst_project, package, self.osc_cmd_str, self.dry_run)
+        req = get_obs_sr_id(target, self.dst_project, package, self.osc_cmd_str, dry_run=self.dry_run)
         cmd = [*shlex.split(self.osc_cmd_str), "sr"]
         if req:
             cmd.extend(["-s", req])

--- a/tests/test_auto_submit.py
+++ b/tests/test_auto_submit.py
@@ -263,3 +263,29 @@ def test_main_logging(mocker: MockerFixture, verbose: int, quiet: int, expected_
     mock_basic_config = mocker.patch("logging.basicConfig")
     auto_submit.main(verbose=verbose, quiet=quiet)
     mock_basic_config.assert_called_with(level=expected_level, format="%(levelname)s: %(message)s", force=True)
+
+
+def test_run_submissions_force(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("subprocess.run")
+    mock_exists = mocker.patch("auto_submit.pathlib.Path.exists", return_value=True)
+    mock_unlink = mocker.patch("auto_submit.pathlib.Path.unlink")
+    mocker.patch("auto_submit._get_packages_to_submit", return_value=["pkg1"])
+    mocker.patch("auto_submit.AutoSubmitter")
+
+    auto_submit._run_submissions(  # noqa: SLF001
+        src_project="devel:openQA",
+        dst_project="devel:openQA:tested",
+        staging_project="devel:openQA:testing",
+        submit_target="openSUSE:Factory",
+        dry_run=False,
+        force=True,
+        osc_poll_interval=2,
+        osc_build_start_poll_tries=90,
+        throttle_days=2,
+        throttle_days_leap_16=7,
+        git_user="user",
+        submit_target_extra="none",
+    )
+
+    mock_unlink.assert_called_once()
+    mock_run.assert_any_call(["cleanup-obs-project", "devel:openQA:testing", "I am sure"], check=True)


### PR DESCRIPTION
Motivation:
Allow users to override skip conditions and force execution by cleaning up
blocked packages and skip files upfront.

Design Choices:
Introduce a --force / -f command line option that removes any existing
job_post_skip_submission file and runs cleanup-obs-project upfront. Add a unit
test to verify force behavior.

Benefits:
Provides an automated way to recover from interrupted or blocked runs without
requiring manual intervention on the staging project.