### PR TITLE
Fix Agama live boot and prevent GPU call traces on GPU nodes

### DIFF
--- a/ipxe/menu.ipxe
+++ b/ipxe/menu.ipxe
@@ -60,7 +60,7 @@ goto editandboot
 :tumbleweed_KVM_agama
 set kernel http://openqa.opensuse.org/assets/repo/fixed/Tumbleweed-agama-installer-x86_64-CURRENT/boot/x86_64/loader/linux
 set initrd http://openqa.opensuse.org/assets/repo/fixed/Tumbleweed-agama-installer-x86_64-CURRENT/boot/x86_64/loader/initrd
-set cmdline plymouth.enable=0 console=tty console=ttyS1,115200 reboot_timeout=0 kernel.softlockup_panic=1 vga=791 video=1024x768 vt.color=0x07 quiet inst.install_url=http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-x86_64-CURRENT live.password=nots3cr3t inst.auto=http://openqa.opensuse.org/assets/other/tw_virt_host.jsonnet inst.finish=stop
+set cmdline plymouth.enable=0 console=tty console=ttyS1,115200 reboot_timeout=0 kernel.softlockup_panic=1 vga=791 video=1024x768 vt.color=0x07 quiet inst.install_url=http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-x86_64-CURRENT root=live:http://openqa.opensuse.org/assets/repo/fixed/Tumbleweed-agama-installer-x86_64-CURRENT/LiveOS/squashfs.img modprobe.blacklist=nouveau rd.driver.blacklist=nouveau nomodeset live.password=nots3cr3t inst.auto=http://openqa.opensuse.org/assets/other/tw_virt_host.jsonnet inst.finish=stop
 goto editandboot
 
 :tumbleweed_KVM_autoyast


### PR DESCRIPTION
- dracut requires the root=live:... kernel parameter to tell initrd where to download and mount the squashfs root image

- nouveau results in call trace on machine with a GPU device


verification run: https://openqa.opensuse.org/tests/6144298   //passed Agama installation